### PR TITLE
Adding additional CI test for backpack init containers

### DIFF
--- a/tests/test_backpack.sh
+++ b/tests/test_backpack.sh
@@ -10,8 +10,7 @@ function finish {
   fi
 
   echo "Cleaning up backpack"
-  kubectl delete -f tests/test_crs/valid_backpack.yaml
-  delete_operator
+  wait_clean
 }
 
 trap error ERR
@@ -20,11 +19,18 @@ trap finish EXIT
 function functional_test_backpack {
   wait_clean
   apply_operator
-  kubectl apply -f tests/test_crs/valid_backpack.yaml
+  kubectl apply -f $1
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 
-  wait_for_backpack $uuid
+  if [[ $1 == "tests/test_crs/valid_backpack_daemonset.yaml" ]]
+  then
+    wait_for_backpack $uuid
+  else
+    byowl_pod=$(get_pod "app=byowl-$uuid" 300)
+    wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized pods/$byowl_pod --timeout=500s" "500s" $byowl_pod
+    wait_for "kubectl -n my-ripsaw  wait --for=condition=complete -l app=byowl-$uuid jobs --timeout=500s" "500s" $byowl_pod
+  fi
   
   indexes="cpu_vulnerabilities-metadata cpuinfo-metadata dmidecode-metadata k8s_configmaps-metadata k8s_namespaces-metadata k8s_nodes-metadata k8s_pods-metadata lspci-metadata meminfo-metadata sysctl-metadata"
   if check_es "${long_uuid}" "${indexes}"
@@ -37,4 +43,5 @@ function functional_test_backpack {
 }
 
 figlet $(basename $0)
-functional_test_backpack
+functional_test_backpack tests/test_crs/valid_backpack_daemonset.yaml
+functional_test_backpack tests/test_crs/valid_backpack_init.yaml

--- a/tests/test_crs/valid_backpack_daemonset.yaml
+++ b/tests/test_crs/valid_backpack_daemonset.yaml
@@ -1,0 +1,16 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: backpack
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: ES_SERVER
+    port: ES_PORT
+  metadata:
+    collection: true
+    targeted: false
+    privileged: true
+    serviceaccount: backpack-view
+  workload:
+    name: backpack

--- a/tests/test_crs/valid_backpack_init.yaml
+++ b/tests/test_crs/valid_backpack_init.yaml
@@ -9,7 +9,6 @@ spec:
     port: ES_PORT
   metadata:
     collection: true
-    targeted: false
     privileged: true
     serviceaccount: backpack-view
   workload:


### PR DESCRIPTION
We currently do not verify all the indexes gathered by the backpack init containers. This adds an additional test to the backpack CI script to verify them.