### PR TITLE
Collect only ocp and k8s related metadata

### DIFF
--- a/resources/backpack_role.yaml
+++ b/resources/backpack_role.yaml
@@ -34,19 +34,10 @@ metadata:
   name: backpack-view
   namespace: my-ripsaw
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: backpack-view
-  namespace: my-ripsaw
-  annotations:
-    kubernetes.io/service-account.name: backpack-view
-type: kubernetes.io/service-account-token
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: backpack-view
+  name: binding-backpack_role
   namespace: my-ripsaw
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -37,11 +37,27 @@ spec:
       - name: backpack
         image: {{ metadata.image }}
         command: ["/bin/sh", "-c"]
+        args:
+          - >
+            python3
+            stockpile-wrapper.py
+            -s={{ elasticsearch.server }}
+            -p={{ elasticsearch.port }}
+            -u={{ uuid }}
+            -n=${my_node_name}
+            -N=${my_pod_name}
+            --redisip={{ bo.resources[0].status.podIP }}
+            --redisport=6379
 {% if metadata.force is sameas true %}
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force && touch /tmp/indexed; sleep infinity"]
-{% else %}
-        args: ["python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n $my_node_name -N $my_pod_name --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 && touch /tmp/indexed; sleep infinity"]
+            --force
 {% endif %}
+{% if metadata.stockpile_tags|length > 0 %}
+            --tags={{ metadata.stockpile_tags|join(",") }}
+{% endif %}
+{% if metadata.stockpile_skip_tags|length > 0 %}
+            --skip-tags={{ metadata.stockpile_skip_tags|join(",") }}
+{% endif %}
+            && touch /tmp/indexed; sleep infinity
         imagePullPolicy: Always
         securityContext:
           privileged: {{ metadata.privileged }}

--- a/test.sh
+++ b/test.sh
@@ -77,6 +77,7 @@ sed -i "s/benchmarks/benchmarks-$UUID/g" tests/common.sh
 sed -i "s/kind: Benchmark/kind: Benchmark-$UUID/g" tests/test_crs/*.yaml
 sed -i "s/kind: Benchmark/kind: Benchmark-$UUID/g" playbook.yml
 sed -i "s/kind: Benchmark/kind: Benchmark-$UUID/g" watches.yaml
+sed -i "s/backpack_role/backpack_role-$UUID/g" resources/backpack_role.yaml
 grep -Rl "kind: Benchmark" roles/ | xargs sed -i "s/kind: Benchmark/kind: Benchmark-$UUID/g"
 
 # Update the operator image

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -128,7 +128,6 @@ function apply_operator {
     sed 's#quay.io/benchmark-operator/benchmark-operator:master#'$BENCHMARK_OPERATOR_IMAGE'#' | \
     kubectl apply -f -
   kubectl wait --for=condition=available "deployment/benchmark-operator" -n my-ripsaw --timeout=300s
-  backpack_requirements
 }
 
 function delete_operator {

--- a/tests/test_backpack.sh
+++ b/tests/test_backpack.sh
@@ -10,6 +10,7 @@ function finish {
   fi
 
   echo "Cleaning up backpack"
+  kubectl delete -f resources/backpack_role.yaml
   wait_clean
 }
 
@@ -19,6 +20,7 @@ trap finish EXIT
 function functional_test_backpack {
   wait_clean
   apply_operator
+  backpack_requirements
   kubectl apply -f $1
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}


### PR DESCRIPTION
Prevent backpack from trying to collect metadata not related with OCP or k8s.
Also moving the call to backpack_requirements to test_backpack to fix CI issues.