### PR TITLE
Added handling of fio bsrange parameter

### DIFF
--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -99,7 +99,7 @@ The workload loops are nested as such from the CR options:
 ```
 +-------->numjobs---------+
 |                         |
-| +------>blocksize-----+ |
+| +------>bs|bsrange----+ |
 | |                     | |
 | | +---->job---------+ | |
 | | |                 | | |
@@ -174,6 +174,10 @@ The workload loops are nested as such from the CR options:
   > Note: We set the `direct=1` fio option in the jobfile configmap. In order to avoid errors, the `bs` values
   > provided here should be a multiple of the filesystem blocksize (typically 4KiB). The [note above about units](#understanding-the-cr-options)
   > applies here.
+- **bsrange**:(list) blocksize range values to use for I/O transactions
+  > Note: We set the `direct=1` fio option in the jobfile configmap. In order to avoid errors, the `bsrange` values
+  > provided here should be a multiple of the filesystem blocksize (typically 1KiB - 4KiB). The [note above about units](#understanding-the-cr-options)
+  >  applies here.
 - **numjobs**: (list) Number of clones of the job to run on each server -- Total jobs will be `numjobs * servers`
 - **iodepth**: Number of I/O units to keep in flight against a file; see `fio(1)`
 - **read_runtime**: Amount of time in seconds to run `read` workloads (including `readwrite` workloads)

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -178,6 +178,12 @@ The workload loops are nested as such from the CR options:
   > Note: We set the `direct=1` fio option in the jobfile configmap. In order to avoid errors, the `bsrange` values
   > provided here should be a multiple of the filesystem blocksize (typically 1KiB - 4KiB). The [note above about units](#understanding-the-cr-options)
   >  applies here.
+  ```
+  bsrange:
+    - 1KiB-4KiB
+    - 16KiB-64KiB
+    - 256KiB-4096KiB
+  ```
 - **numjobs**: (list) Number of clones of the job to run on each server -- Total jobs will be `numjobs * servers`
 - **iodepth**: Number of I/O units to keep in flight against a file; see `fio(1)`
 - **read_runtime**: Amount of time in seconds to run `read` workloads (including `readwrite` workloads)

--- a/roles/fio_distributed/templates/configmap.yml.j2
+++ b/roles/fio_distributed/templates/configmap.yml.j2
@@ -25,10 +25,17 @@ data:
     create_on_open=1
     fsync_on_close=1
 {% endif %}
+{% if workload_args.bsrange is defined %}
+{% set loopvar = workload_args.bsrange %}
+{% set loopvar_str = 'bsrange' %}
+{% elif workload_args.bs is defined %}
+{% set loopvar = workload_args.bs %}
+{% set loopvar_str = 'bs' %}
+{% endif %}
 {% for numjobs in workload_args.numjobs %}
-{% for bs in workload_args.bs %}
+{% for i in loopvar %}
 {% for job in workload_args.jobs %}
-  fiojob-{{job}}-{{bs}}-{{numjobs}}: |
+  fiojob-{{job}}-{{i}}-{{numjobs}}: |
     [global]
     directory={{fio_path}}
     filename_format=f.\$jobnum.\$filenum
@@ -43,7 +50,7 @@ data:
     unit_base=8
     ioengine=libaio
     size={{workload_args.filesize}}
-    bs={{bs}}
+    {{loopvar_str}}={{i}}
     iodepth={{workload_args.iodepth}}
     direct=1
     numjobs={{numjobs}}


### PR DESCRIPTION
In order to produce a non-uniform distribution test with fio, this PR attempts to add the use of fio's bsrange parameter. Essentially in this PR we check whether the user is using bs or bsrange, and then loops through the test as previous.

```
if bs in args.bs
   for bs in ags.bs
      do test
elif bsrange in args.bsrange
   for bsrange in ags.bsrange
      do test
```