### PR TITLE
Enable Kata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ a performance baseline of Kubernetes cluster on your provider.
 
 ## Workloads status
 
-| Workload                       | Use                    | Status in Operator | Reconciliation usage       | VM support (kubevirt) |
-| ------------------------------ | ---------------------- | ------------------ | -------------------------- | --------------------- |
-| [UPerf](docs/uperf.md)         | Network Performance    | Working            |  Used, default : 3second  | Preview               |
-| [Iperf3](docs/iperf3.md)       | Network Performance    | Working            |  Used, default : 3second  | Not Supported         |
-| [fio](docs/fio_distributed.md) | Storage IO             | Working            |  Used, default : 3second  | Working               |
-| [Sysbench](docs/sysbench.md)   | System Performance     | Working            |  Used, default : 3second  | Not Supported         |
-| [YCSB](docs/ycsb.md)           | Database Performance   | Working            |  Used, default : 3second  | Not Supported         |
-| [Byowl](docs/byowl.md)         | User defined workload  | Working            |  Used, default : 3second  | Not Supported         |
-| [Pgbench](docs/pgbench.md)     | Postgres Performance   | Working            |  Used, default : 3second  | Not Supported         |
-| [Smallfile](docs/smallfile.md) | Storage IO Performance | Working            |  Used, default : 3second  | Not Supported         |
-| [fs-drift](docs/fs-drift.md)   | Storage IO Longevity   | Working            |  Not used                 | Not Supported         |
-| [hammerdb](docs/hammerdb.md)   | Database Performance   | Working            |  Used, default : 3second  | Not Supported         |
-| [Service Mesh](docs/servicemesh.md) | Microservices     | Working            |  Used, default : 3second   | Not Supported         |
-| [Vegeta](docs/vegeta.md)       | HTTP Performance       | Working            |  Used, default : 3second  | Not Supported         |
+| Workload                       | Use                    | Status in Operator | Reconciliation usage       | VM support (kubevirt) | Kata Containers |
+| ------------------------------ | ---------------------- | ------------------ | -------------------------- | --------------------- | --------------- |
+| [UPerf](docs/uperf.md)         | Network Performance    | Working            |  Used, default : 3second  | Working                | Working         |
+| [Iperf3](docs/iperf3.md)       | Network Performance    | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
+| [fio](docs/fio_distributed.md) | Storage IO             | Working            |  Used, default : 3second  | Working                | Working         |
+| [Sysbench](docs/sysbench.md)   | System Performance     | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
+| [YCSB](docs/ycsb.md)           | Database Performance   | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
+| [Byowl](docs/byowl.md)         | User defined workload  | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
+| [Pgbench](docs/pgbench.md)     | Postgres Performance   | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
+| [Smallfile](docs/smallfile.md) | Storage IO Performance | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
+| [fs-drift](docs/fs-drift.md)   | Storage IO Longevity   | Working            |  Not used                 | Not Supported          | Not Supported   |
+| [hammerdb](docs/hammerdb.md)   | Database Performance   | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
+| [Service Mesh](docs/servicemesh.md) | Microservices     | Working            |  Used, default : 3second   | Not Supported         | Not Supported   |
+| [Vegeta](docs/vegeta.md)       | HTTP Performance       | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
 
 
 ### Reconciliation

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -37,6 +37,7 @@ spec:
       # 'vm' needs kubevirt to be available
       # Default: pod
       kind: pod
+      runtime_class: class_name
       jobs:
         - write
         - read
@@ -161,6 +162,8 @@ The workload loops are nested as such from the CR options:
   > Note: Under most circumstances, a `write` job should be provided as the first list item for `jobs`. This will
   > ensure that subsequent jobs in the list can use the files created by the `write` job instead of needing
   > to instantiate the files themselves prior to beginning the benchmark workload.
+- **runtime_class** : If this is set, the benchmark-operator will apply the runtime_class to the podSpec runtimeClassName.
+  > Note: For Kata containers
 - **kind**: Can either be `pod` or `vm` to determine if the fio workload is run in a Pod or in a VM
   > Note: For VM workloads, you need to install Openshift Virtualization first
 - **vm_image**: Whether to use a pre-defined VM image with pre-installed requirements. Necessary for disconnected installs.

--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -32,6 +32,7 @@ spec:
           cpu: 500m
           memory: 500Mi
       serviceip: false
+      runtime_class: class_name
       hostnetwork: false
       pin: false
       kind: pod
@@ -55,6 +56,10 @@ spec:
 `client_resources` and `server_resources` will create uperf client's and server's containers with the given k8s compute resources respectively [k8s resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
 
 `serviceip` will place the uperf server behind a K8s [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
+
+`runtime_class` If this is set, the benchmark-operator will apply the runtime_class to the podSpec runtimeClassName.
+
+*Note:* runtime_class has been tested with Kata containers, no other runtime.
 
 `hostnetwork` will test the performance of the node the pod will run on.
 

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -11,6 +11,9 @@ spec:
       labels:
         app: fiod-client-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: fio-client
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/fio:latest') }}

--- a/roles/fio_distributed/templates/servers.yaml
+++ b/roles/fio_distributed/templates/servers.yaml
@@ -23,6 +23,9 @@ spec:
                   values:
                   - fio-benchmark-{{ trunc_uuid }}
               topologyKey: "kubernetes.io/hostname"
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: fio-server
 {% if hostpath is defined %}

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -17,6 +17,9 @@ spec:
         k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.server}}
 {% endif %}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
 {% endif %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -19,6 +19,9 @@ spec:
         k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.client }}
 {% endif %}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator


### PR DESCRIPTION
In order to enable Kata support we need to add `runtimeClassName` to the
podSpec. The user must supply the `runtime_class` to reflect the
`runtimeClassName` to use.