### PR TITLE
Fixing wrong default index name for ycsb

### DIFF
--- a/roles/ycsb/templates/ycsb_load.yaml
+++ b/roles/ycsb/templates/ycsb_load.yaml
@@ -35,7 +35,7 @@ spec:
         - name: es_port
           value: "{{ elasticsearch.port }}"
         - name: es_index
-          value: "{{ elasticsearch.index_name | default("ripsaw-fio") }}"
+          value: "{{ elasticsearch.index_name | default("ripsaw-ycsb") }}"
         - name: parallel
           value: "{{ elasticsearch.parallel | default("false") }}"
 {% endif %}

--- a/roles/ycsb/templates/ycsb_run.yaml
+++ b/roles/ycsb/templates/ycsb_run.yaml
@@ -35,7 +35,7 @@ spec:
         - name: es_port
           value: "{{ elasticsearch.port }}"
         - name: es_index
-          value: "{{ elasticsearch.index_name | default("ripsaw-fio") }}"
+          value: "{{ elasticsearch.index_name | default("ripsaw-ycsb") }}"
         - name: parallel
           value: "{{ elasticsearch.parallel | default("false") }}"
 {% endif %}


### PR DESCRIPTION
The index for ycsb was defaulted to fio instead of ycsb