### PR TITLE
Have the benchmark operator prefer to run on a workload node

### DIFF
--- a/resources/operator.yaml
+++ b/resources/operator.yaml
@@ -13,6 +13,20 @@ spec:
       labels:
         name: benchmark-operator
     spec:
+      tolerations:
+      - key: role
+        value: workload
+        effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/workload
+                operator: In
+                values:
+                - ""
       serviceAccountName: benchmark-operator
       containers:
         - name: ansible


### PR DESCRIPTION
Currently the benchmark operator will land on any available worker node. This is fine in many cases however to avoid having it being impacted by ongoing tests we should try to pin it to the workload node if possible.