### PR TITLE
Allow for a user provided UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,33 @@ spec:
       image: my.location/foo:latest
 ```
 
+## User Provided UUID
+All benchmarks in the benchmark-operator utilize a UUID for tracking and indexing purposes. This UUID is,
+by default, generated when the workload is first started. However, if desired, a user provided UUID can
+be added to the workload cr.
+
+*NOTE: The provided UUID must be in format XXXXX-XXXXX-XXXXX*
+
+For Example:
+```
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: example-benchmark
+  namespace: my-ripsaw
+spec:
+  uuid: 6060004a-7515-424e-93bb-c49844600dde
+  elasticsearch:
+    server: "my-es.foo.bar"
+    port: 9200
+  metadata_collection: true
+  cleanup: false
+  workload:
+    name: "foo"
+    args:
+      image: my.location/foo:latest
+```
+
 ## Installation
 [Installation](docs/installation.md)
 

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -22,6 +22,8 @@ spec:
           spec:
             type: object
             properties:
+              uuid: 
+                type: string
               elasticsearch:
                 type: object
                 properties:

--- a/roles/uuid/tasks/main.yml
+++ b/roles/uuid/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
-- name: Get files
+- name: Generate UUID
   set_fact: uuid={{ (999999999999999999999 | random | string + (lookup('pipe', 'date +%s%N'))) | to_uuid() | string }}
+  when: uuid is not defined 
 
 - name: set the truncated uuid
   set_fact: trunc_uuid={{ uuid.split("-")[0] }}


### PR DESCRIPTION
A user can now, optionally, provide a custom UUID in the CR file such as:
```
apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
kind: Benchmark
metadata:
  name: example-benchmark
  namespace: my-ripsaw
spec:
  uuid: 6060004a-7515-424e-93bb-c49844600dde     <------custom UUID
  elasticsearch:
    server: "my-es.foo.bar"
    port: 9200
  metadata_collection: true
  cleanup: false
  workload:
    name: "foo"
    args:
      image: my.location/foo:latest
```