### PR TITLE
Enabling Scaling the Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ a performance baseline of Kubernetes cluster on your provider.
 | [hammerdb](docs/hammerdb.md)   | Database Performance   | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
 | [Service Mesh](docs/servicemesh.md) | Microservices     | Working            |  Used, default : 3second   | Not Supported         | Not Supported   |
 | [Vegeta](docs/vegeta.md)       | HTTP Performance       | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
+| [Scale Openshift](docs/scale_openshift.md) | Scale Openshift Cluster       | Working            |  Used, default : 3second  | Not Supported         | Not Supported  |
 
 
 ### Reconciliation
@@ -103,6 +104,6 @@ spec:
 [Capturing Prometheus Data](docs/prometheus.md)
 
 ## Community
-Key Members(slack_usernames): aakarsh, dry923, rsevilla or rook
+Key Members(slack_usernames): ravi, mohit, dry923, rsevilla or rook
 * [**#sig-scalability on Kubernetes Slack**](https://kubernetes.slack.com)
 * [**#forum-perfscale on CoreOS Slack**](https://coreos.slack.com)

--- a/docs/scale_openshift.md
+++ b/docs/scale_openshift.md
@@ -1,0 +1,99 @@
+# Scale Openshift
+
+## What does it do?
+
+The Scale Openshift functionality allows a user to scale their environment to a provided size 
+and obtain the time it takes for the scaling procedure. This data will also be indexed if 
+Elasticsearch information is provided.
+
+## Variables
+
+The scale workload takes the following required variables:
+
+'scale' the target number of workers to scale too
+'serviceaccount' the service account to run as. Note the "default" account generally does not have enough privileges
+
+Optional variables:
+
+'poll_interval' how long, in seconds, to wait between polls to see if the scaling is complete. default: 5
+'post_sleep' how long, in seconds, to wait after the scaling is complete before marking the pod as complete. default: 0
+'label' a dictionary consisting of 'key' and 'value'. If provided it will require to launch the node with
+        matching key and value
+'tolerations' a dictionary consisting of a 'key', 'value' and 'effect'. If provided it will add a toleration
+        for the matching key/value/effect
+
+Your resource file may look like this when using all avaible options:
+
+```yaml
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: scale
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: foo
+    port: 9090
+    index_name: ripsaw-scale
+  workload:
+    name: scale_openshift
+    args:
+      scale: 25
+      serviceaccount: scaler
+      poll_interval: 2
+      post_sleep: 300
+      label:
+        key: node-role.kubernetes.io/workload
+        value: ""
+      tolerations:
+        key: role
+        value: workload
+        effect: NoSchedule
+```
+
+*NOTE:* If the cluster is already at the desired scale the timings will still be captured and uploaded to
+Elasticsearch (if provided). The overall time will simply be the time it took the scale process to confirm
+that the cluster is at the correct scale.
+
+## Service Account and Permissions
+
+The default service account generally does not have the required visibility/permissions to allow the Scale job
+to modify the cluster machine sets. An example service account setup has been provided in resources/scale_role.yaml
+as well as described below:
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scale_role
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - machines
+  - machinesets
+  - nodes
+  - infrastructures
+  verbs:
+  - '*'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scaler
+  namespace: my-ripsaw
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scaler
+  namespace: my-ripsaw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scale_role
+subjects:
+- kind: ServiceAccount
+  name: scaler
+  namespace: my-ripsaw
+```

--- a/resources/scale_role.yaml
+++ b/resources/scale_role.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scale_role
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - machines
+  - machinesets
+  - nodes
+  - infrastructures
+  verbs:
+  - '*'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: scaler
+  namespace: my-ripsaw
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: scaler
+  namespace: my-ripsaw
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scale_role
+subjects:
+- kind: ServiceAccount
+  name: scaler
+  namespace: my-ripsaw

--- a/roles/scale_openshift/tasks/main.yml
+++ b/roles/scale_openshift/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: Get benchmark state
+  k8s_facts:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+  register: benchmark_state
+
+- operator_sdk.util.k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      state: "Starting Scale Pod"
+      complete: false
+  when: benchmark_state.resources[0].status.state is not defined
+
+- name: Get benchmark state 
+  k8s_facts:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+  register: benchmark_state
+
+- block:
+  
+  - name: Create scale pod
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'scale.yml') }}"
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Scaling Cluster"
+
+  when: benchmark_state.resources[0].status.state == "Starting Scale Pod"
+
+- block:
+
+  - name: Waiting for scaling pod to complete
+    k8s_facts:
+      kind: pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - app = scale-{{ trunc_uuid }}
+    register: scale_pod
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Complete
+        complete: true
+    when: scale_pod|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')
+
+  when: benchmark_state.resources[0].status.state == "Scaling Cluster"

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -1,0 +1,72 @@
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: 'scale-{{ trunc_uuid }}'
+  namespace: '{{ operator_namespace }}'
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app: scale-{{ trunc_uuid }}
+    spec:
+{% if workload_args.tolerations is defined %}
+      tolerations:
+      - key: {{ workload_args.tolerations.key }}
+        value: {{ workload_args.tolerations.value }}
+        effect: {{ workload_args.tolerations.effect }}
+{% endif %}
+{% if workload_args.label is defined %}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ workload_args.label.key }}
+                operator: In
+                values:
+                - {{ workload_args.label.value }}
+{% endif %}
+      containers:
+      - name: scale
+        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/scale_openshift:latest') }}
+        imagePullPolicy: Always
+        env:
+          - name: uuid
+            value: "{{ uuid }}"
+          - name: test_user
+            value: "{{ test_user | default("ripsaw") }}"
+          - name: clustername
+            value: "{{ clustername }}"
+{% if elasticsearch is defined %}
+          - name: es
+            value: "{{ elasticsearch.server }}"
+          - name: es_port
+            value: "{{ elasticsearch.port }}"
+          - name: es_index
+            value: "{{ elasticsearch.index_name | default("openshift-cluster-timings") }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.cert_verify | default("true") }}"
+          - name: parallel
+            value: "{{ elasticsearch.parallel | default("false") }}"
+{% endif %}
+{% if prometheus is defined %}
+          - name: prom_es
+            value: "{{ prometheus.server }}"
+          - name: prom_port
+            value: "{{ prometheus.port }}"
+          - name: prom_parallel
+            value: "{{ prometheus.parallel | default("false") }}"
+          - name: prom_token
+            value: "{{ prometheus.prom_token | default() }}"
+          - name: prom_url
+            value: "{{ prometheus.prom_url | default() }}"
+{% endif %}
+        command: ["/bin/sh", "-c"]
+        args:
+          - "run_snafu --tool scale --scale {{workload_args.scale}} -u {{uuid}} --user {{test_user|default("ripsaw")}} --incluster true --poll_interval {{workload_args.poll_interval|default(5)}};
+            sleep {{post_sleep|default(0)}}"
+      serviceAccountName: {{workload_args.serviceaccount|default("default")}}
+      restartPolicy: Never
+{% include "metadata.yml.j2" %}

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -25,6 +25,7 @@ function populate_test_list {
     if [[ $(echo ${item} | grep 'roles/hammerdb') ]]; then echo "test_hammerdb.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'roles/smallfile') ]]; then echo "test_smallfile.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'roles/vegeta') ]]; then echo "test_vegeta.sh" >> tests/iterate_tests; fi
+    if [[ $(echo ${item} | grep 'roles/scale_openshift') ]]; then echo "test_scale_openshift.sh" >> tests/iterate_tests; fi
 
     # Check for changes in cr files
     if [[ $(echo ${item} | grep 'valid_backpack*') ]]; then echo "test_backpack.sh" >> tests/iterate_tests; fi
@@ -39,6 +40,7 @@ function populate_test_list {
     if [[ $(echo ${item} | grep 'valid_uperf*') ]]; then echo "test_uperf.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'valid_ycsb*') ]]; then echo "test_ycsb.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'valid_vegeta*') ]]; then echo "test_vegeta.sh" >> tests/iterate_tests; fi
+    if [[ $(echo ${item} | grep 'valid_scale*') ]]; then echo "test_scale_openshift.sh" >> tests/iterate_tests; fi
 
     # Check for changes in test scripts
     test_check=`echo $item | awk -F / '{print $2}'`

--- a/tests/test_crs/valid_scale_down.yaml
+++ b/tests/test_crs/valid_scale_down.yaml
@@ -1,0 +1,17 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: scale
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: ES_SERVER
+    port: ES_PORT
+    index_name: openshift-cluster-timings
+  workload:
+    name: scale_openshift
+    args:
+      scale: 0
+      serviceaccount: scaler
+      poll_interval: 2
+

--- a/tests/test_crs/valid_scale_up.yaml
+++ b/tests/test_crs/valid_scale_up.yaml
@@ -1,0 +1,17 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: scale
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: ES_SERVER
+    port: ES_PORT
+    index_name: openshift-cluster-timings
+  workload:
+    name: scale_openshift
+    args:
+      scale: 1
+      serviceaccount: scaler
+      poll_interval: 2
+

--- a/tests/test_list
+++ b/tests/test_list
@@ -10,3 +10,4 @@ test_uperf.sh
 test_byowl.sh
 test_hammerdb.sh
 test_vegeta.sh
+test_scale_openshift.sh

--- a/tests/test_scale_openshift.sh
+++ b/tests/test_scale_openshift.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -xeEo pipefail
+
+source tests/common.sh
+
+function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
+  echo "Cleaning up Scale Test"
+  kubectl delete -f resources/scale_role.yaml --ignore-not-found
+  wait_clean
+}
+
+trap error ERR
+trap finish EXIT
+
+function functional_test_scale_openshift {
+  wait_clean
+  apply_operator
+  test_name=$1
+  cr=$2
+  
+  # Apply scale role and service account
+  kubectl apply -f resources/scale_role.yaml
+  
+  echo "Performing: ${test_name}"
+  kubectl apply -f ${cr}
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
+
+  scale_pod=$(get_pod "app=scale-$uuid" 300)
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized -l app=scale-$uuid pods --timeout=300s" "300s" $scale_pod
+  wait_for "kubectl wait -n my-ripsaw --for=condition=complete -l app=scale-$uuid jobs --timeout=500s" "500s" $scale_pod
+
+  index="openshift-cluster-timings"
+  if check_es "${long_uuid}" "${index}"
+  then
+    echo "${test_name} test: Success"
+  else
+    echo "Failed to find data for ${test_name} in ES"
+    kubectl logs "$scale_pod" -n my-ripsaw
+    exit 1
+  fi
+  kubectl delete -f ${cr}
+}
+
+figlet $(basename $0)
+functional_test_scale_openshift "Scale Up" tests/test_crs/valid_scale_up.yaml
+functional_test_scale_openshift "Scale Down" tests/test_crs/valid_scale_down.yaml


### PR DESCRIPTION
This will enable the ability of ripsaw to scale a cluster utilizing the snafu scale_openshift wrapper. I added the scaling to be run prior to the normal testing to make sure it doesn't impact the other ci tests as they normally run in parallel. 

Note: this requires https://github.com/cloud-bulldozer/benchmark-wrapper/pull/205