### PR TITLE
Fixing completion check for scale_openshift

### DIFF
--- a/roles/scale_openshift/tasks/main.yml
+++ b/roles/scale_openshift/tasks/main.yml
@@ -61,6 +61,6 @@
       status:
         state: Complete
         complete: true
-    when: scale_pod|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')
+    when: "scale_pod|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length > 0"
 
   when: benchmark_state.resources[0].status.state == "Scaling Cluster"


### PR DESCRIPTION
Previously the scale benchmark was getting set to complete too soon. This resolves the issue