### PR TITLE
Fix iperf3 hostnetwork and add test to it

### DIFF
--- a/roles/iperf3/templates/client.yml.j2
+++ b/roles/iperf3/templates/client.yml.j2
@@ -11,7 +11,7 @@ spec:
       labels:
         app: iperf3-bench-client-{{ trunc_uuid }}
     spec:
-{% if workload_args.hostnetwork is defined and workload_args.hostnetwork %}
+{% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator
       serviceAccount: benchmark-operator

--- a/roles/iperf3/templates/client_store.yml.j2
+++ b/roles/iperf3/templates/client_store.yml.j2
@@ -11,7 +11,7 @@ spec:
       labels:
         app: iperf3-bench-client-{{ trunc_uuid }}
     spec:
-{% if workload_args.hostnetwork is defined and workload_args.hostnetwork %}
+{% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator
       serviceAccount: benchmark-operator

--- a/roles/iperf3/templates/server.yml.j2
+++ b/roles/iperf3/templates/server.yml.j2
@@ -6,14 +6,15 @@ metadata:
   namespace: "{{ operator_namespace }}"
 spec:
   ttlSecondsAfterFinished: 600
-  backoffLimit: 0
   template:
     metadata:
       labels:
         app: iperf3-bench-server-{{ trunc_uuid }}
     spec:
-{% if workload_args.hostnetwork is defined and iperf3.hostnetwork %}
+{% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
+      serviceAccountName: benchmark-operator
+      serviceAccount: benchmark-operator
 {% endif %}
       containers:
       - name: benchmark

--- a/tests/test_crs/valid_iperf3.yaml
+++ b/tests/test_crs/valid_iperf3.yaml
@@ -13,6 +13,7 @@ spec:
     name: iperf3
     args:
       pairs: 1
+      hostnetwork: false
       port: 5201
       transmit_type: time
       transmit_value: 60

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -20,7 +20,8 @@ trap finish EXIT
 function functional_test_iperf {
   wait_clean
   apply_operator
-  kubectl apply -f tests/test_crs/valid_iperf3.yaml
+  echo "Performing iperf3: ${1}"
+  sed -e "s/hostnetwork:.*/${1}/g" tests/test_crs/valid_iperf3.yaml | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 
@@ -32,8 +33,9 @@ function functional_test_iperf {
   sleep 5
   # ensuring that iperf actually ran and we can access metrics
   kubectl logs "$iperf_client_pod" --namespace my-ripsaw | grep "iperf Done."
-  echo "iperf test: Success"
+  echo "iperf ${1}: Success"
 }
 
 figlet $(basename $0)
-functional_test_iperf
+functional_test_iperf "hostnetwork: false"
+functional_test_iperf "hostnetwork: true"


### PR DESCRIPTION
iperf blows up if we use hostnetwork as mentioned at https://github.com/cloud-bulldozer/benchmark-operator/issues/413. This PR fixes it and also adds a test case for iperf3 w/ hostnetwork: true

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>