### PR TITLE
Updating uperf doc for additional details on runtime_class parameter

### DIFF
--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -59,7 +59,7 @@ spec:
 
 `runtime_class` If this is set, the benchmark-operator will apply the runtime_class to the podSpec runtimeClassName.
 
-*Note:* runtime_class has been tested with Kata containers, no other runtime.
+*Note:* runtime_class has been tested with Kata containers, no other runtime. If not using Kata containers the line should not be included in your CR.
 
 `hostnetwork` will test the performance of the node the pod will run on.
 


### PR DESCRIPTION
Re: https://github.com/cloud-bulldozer/benchmark-operator/issues/415

This is to help explain that if Kata containers are not in use the runtime_class options should be removed.