### PR TITLE
Lighter builds for cluster-density

### DIFF
--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -56,10 +56,10 @@ All kube-burner's workloads support the following parameters:
 
 ```yaml
 node_selector:
-  value: node-role.kubernetes.io/master
-  key: ""
+  key: node-role.kubernetes.io/master
+  value: ""
 ```
-Where value defaults to __node-role.kubernetes.io/worker__ and key defaults to empty string ""
+Where key defaults to __node-role.kubernetes.io/worker__ and value defaults to empty string ""
 
 - **cleanup**: Delete old namespaces for the selected workload before starting a new benchmark. Defaults to __true__
 - **wait_for**: List containing the objects Kind to wait for at the end of each iteration or job. This parameter only **applies the cluster-density workload**. If not defined wait for all objects. i.e: wait_for: ["Deployment"]
@@ -92,6 +92,7 @@ kube-burner is able to collect Prometheus metrics using the time range of the be
 - [metrics-aggregated.yaml](../roles/kube-burner/files/metrics-aggregated.yaml): This metric profile is indicated for benchmarks in large clusters. Since the metrics from the worker nodes and the infra nodes are aggregated and only metrics from master nodes are collected individually. Also the parameter **step** can be used to reduce the number of metrics (at the expense of granularity) that will be indexed.
 
 By default the [metrics.yaml](metrics.yaml) profile is used. You can change this profile with the variable **metrics_profile**.
+> Metrics collection and indexing is enabled when setting prometheus.prom_url.
 
 ## Pin to server and tolerations
 

--- a/roles/kube-burner/files/build.yml
+++ b/roles/kube-burner/files/build.yml
@@ -4,22 +4,21 @@ apiVersion: build.openshift.io/v1
 metadata:
   name: {{.JobName}}-{{.Replica}}-{{.UUID}}
 spec:
-  output:
-    to:
-      kind: ImageStreamTag
-      name: {{.JobName}}-{{.Replica}}-{{.UUID}}:latest
+  nodeSelector:
+    {{.nodeSelectorKey}}: {{.nodeSelectorValue}}
   serviceAccount: builder
   source:
     dockerfile: |-
-      FROM quay.io/openshift-scale/mastervertical-build
-      USER example
-    git:
-      uri: {{.gitUri}}
-    secrets:
-    type: Git
+      FROM registry.fedoraproject.org/fedora-minimal:latest
+      RUN touch $(date +%s)
+    type: Dockerfile
   strategy:
-    sourceStrategy:
+    dockerStrategy:
       from:
         kind: DockerImage
-        name: {{.image}}
+        name: registry.fedoraproject.org/fedora-minimal:latest
     type: Source
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{.prefix}}-{{.Replica}}-{{.UUID}}:latest

--- a/roles/kube-burner/files/buildconfig.yml
+++ b/roles/kube-burner/files/buildconfig.yml
@@ -4,6 +4,8 @@ apiVersion: build.openshift.io/v1
 metadata:
   name: {{.JobName}}-{{.Replica}}-{{.UUID}}
 spec:
+  nodeSelector:
+    {{.nodeSelectorKey}}: {{.nodeSelectorValue}}
   triggers:
   - type: GitHub
     github:
@@ -13,9 +15,6 @@ spec:
     type: Git
     git:
       uri: {{.gitUri}}
-    dockerfile: |-
-      FROM quay.io/openshift-scale/mastervertical-build
-      USER 1001
   strategy:
     type: Source
     sourceStrategy:

--- a/roles/kube-burner/templates/cluster-density.yml.j2
+++ b/roles/kube-burner/templates/cluster-density.yml.j2
@@ -48,6 +48,8 @@ jobs:
           from: cluster-density-src
           to: cluster-density-dst
           gitUri: https://github.com/openshift-scale/hello-openshift.git  
+          nodeSelectorKey: {{ workload_args.node_selector.key|default("node-role.kubernetes.io/worker") }}
+          nodeSelectorValue: "{{ workload_args.node_selector.value|default("") }}"
 
       - objectTemplate: imagestream.yml
         replicas: 6
@@ -57,8 +59,9 @@ jobs:
       - objectTemplate: build.yml
         replicas: 6
         inputVars:
-          gitUri: https://github.com/openshift-scale/hello-openshift.git
-          image: quay.io/openshift-scale/mastervertical-build:latest
+          prefix: cluster-density
+          nodeSelectorKey: {{ workload_args.node_selector.key|default("node-role.kubernetes.io/worker") }}
+          nodeSelectorValue: "{{ workload_args.node_selector.value|default("") }}"
 
       - objectTemplate: deployment.yml
         replicas: 1


### PR DESCRIPTION
Make builds from the cluster-density workload lighter by changing the build strategy to dockerStrategy and using the image registry.fedoraproject.org/fedora-minimal for that.

buildconfigs still use the original sourceStrategy, so with this change we'll test both sourceStrategy and dockerStrategy for OCP builds.

Builds based on dockerStrategy last ~ 30 seconds and the original ones > 1 minute.
```
[root@ip-172-31-78-162 ~]# oc get build
NAME                                                       TYPE     FROM          STATUS     STARTED              DURATION
cluster-density-1-7a01f8c5-88ef-5e82-b5d7-3a08f9b501a0     Docker   Dockerfile    Complete   About a minute ago   31s
cluster-density-5-7a01f8c5-88ef-5e82-b5d7-3a08f9b501a0     Docker   Dockerfile    Complete   About a minute ago   31s
cluster-density-2-7a01f8c5-88ef-5e82-b5d7-3a08f9b501a0     Docker   Dockerfile    Complete   About a minute ago   31s
cluster-density-3-7a01f8c5-88ef-5e82-b5d7-3a08f9b501a0     Docker   Dockerfile    Complete   About a minute ago   31s
cluster-density-4-7a01f8c5-88ef-5e82-b5d7-3a08f9b501a0     Docker   Dockerfile    Complete   About a minute ago   31s
cluster-density-6-7a01f8c5-88ef-5e82-b5d7-3a08f9b501a0     Docker   Dockerfile    Complete   About a minute ago   31s
cluster-density-2-7a01f8c5-88ef-5e82-b5d7-3a08f9b501a0-1   Source   Git@86b7475   Complete   About a minute ago   1m35s
cluster-density-3-7a01f8c5-88ef-5e82-b5d7-3a08f9b501a0-1   Source   Git@86b7475   Complete   About a minute ago   1m35s
cluster-density-1-7a01f8c5-88ef-5e82-b5d7-3a08f9b501a0-1   Source   Git@86b7475   Complete   About a minute ago   1m38s

```


Also add the missing nodeSelector parameter for the builds.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>