### PR TITLE
Fix node name and pod name variables

### DIFF
--- a/templates/metadata.yml.j2
+++ b/templates/metadata.yml.j2
@@ -5,15 +5,18 @@
       initContainers:
       - name: backpack-{{ trunc_uuid }}
         image: {{ metadata.image }}
-        command: ["python3", "stockpile-wrapper.py"]
+        command: ["/bin/sh", "-c"]
         args:
-          - -s={{ elasticsearch.server }}
-          - -p={{ elasticsearch.port }}
-          - -u={{ uuid }}
-          - -n=${my_node_name}
-          - -N=${my_pod_name}
-          - --redisip={{ bo.resources[0].status.podIP }}
-          - --redisport=6379
+          - >
+            python3
+            stockpile-wrapper.py
+            -s={{ elasticsearch.server }}
+            -p={{ elasticsearch.port }}
+            -u={{ uuid }}
+            -n=${my_node_name}
+            -N=${my_pod_name}
+            --redisip={{ bo.resources[0].status.podIP }}
+            --redisport=6379
 {% if metadata.force is sameas true %}
           - --force
 {% endif %}

--- a/test.sh
+++ b/test.sh
@@ -26,7 +26,7 @@ git_diff_files="$(git diff remotes/origin/master --name-only)"
 if [[ $test_choice != '' ]]; then
   echo "Running for requested tests"
   populate_test_list "${test_choice}"
-elif [[ `echo "${git_diff_files}" | grep -cv /` -gt 0 || `echo ${git_diff_files} | grep -E "(build/|deploy/|group_vars/|resources/|/common.sh|/uuid)"` ]]; then
+elif [[ `echo "${git_diff_files}" | grep -cv /` -gt 0 || `echo ${git_diff_files} | grep -E "^(templates|build|deploy|group_vars|resources|tests/common.sh|roles/uuid)"` ]]; then
   echo "Running full test"
   cp tests/test_list tests/iterate_tests
 else


### PR DESCRIPTION
stockpile-wrapper must be executed in a shell to parse environment variables.
It fixes the issue of my_node_name and my_node_name not being replaced in indexed documents.

```
{
  "_index": "meminfo-metadata",
  "_type": "_doc",
  "_id": "hjH613QBdEyVZF0pYiCX",
  "_score": 1,
  "_source": {
    "uuid": "980c93cd-51d2-5852-a9ab-675fa8aacb4f",
    "timestamp": 1601351338,
    "node_name": "${my_node_name}",
    "pod_name": "${my_pod_name}"
```

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>