### PR TITLE
Configurable step size and metrics profile

### DIFF
--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -65,6 +65,8 @@ Where value defaults to __node-role.kubernetes.io/worker__ and key defaults to e
 - **wait_for**: List containing the objects Kind to wait for at the end of each iteration or job. This parameter only **applies the cluster-density workload**. If not defined wait for all objects. i.e: wait_for: ["Deployment"]
 - **job_timeout**: Kube-burner job timeout in seconds. Defaults to __3600__ .Uses the parameter [activeDeadlineSeconds](https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup)
 - **pin_server** and **tolerations**: Detailed in the section [Pin to server and tolerations](#Pin-to-server-and-tolerations)
+- **step**: Prometheus step size, useful for long benchmarks. Defaults to 30s
+- **metrics_profile**: kube-burner metric profile that indicates what prometheus metrics kube-burner will collect. Defaults to `metrics.yaml`. Detailed in the [Metrics section](#Metrics) of this document
 
 kube-burner is able to collect complex prometheus metrics and index them in a ElasticSearch instance. This feature can be configured by the prometheus object of kube-burner's CR.
 
@@ -74,7 +76,6 @@ spec:
     server: https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com:443
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     prom_token: prometheusToken
-    step: 30s
   workload:
 ```
 
@@ -82,11 +83,15 @@ Where:
 - server: Points to a valid ElasticSearch endpoint. Full URL format required. i.e. https://elastic.instance.apps.com:9200
 - prom_url: Points to a valid Prometheus endpoint. Full URL format required. i.e https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
 - prom_token: Refers to a valid prometheus token. It can be obtained with: `oc -n openshift-monitoring sa get-token prometheus-k8s`
-- step: Prometheus step size, useful for long benchmarks. Defaults to 30s
 
 ## Metrics
 
-Metrics collected by kube-burner are predefined in the [metrics.yaml file](../roles/kube-burner/files/metrics.yaml)
+kube-burner is able to collect Prometheus metrics using the time range of the benchmark. There are two metric profiles available at the moment.
+
+- [metrics.yaml](../roles/kube-burner/files/metrics.yaml): This metric profile is indicated for benchmarks executed in small clusters. Since it gets metrics for several system pods from each node. Otherwise, we can reduce the number of indexed metrics (at the expense of granularity) with the parameter **step**.
+- [metrics-aggregated.yaml](../roles/kube-burner/files/metrics-aggregated.yaml): This metric profile is indicated for benchmarks in large clusters. Since the metrics from the worker nodes and the infra nodes are aggregated and only metrics from master nodes are collected individually. Also the parameter **step** can be used to reduce the number of metrics (at the expense of granularity) that will be indexed.
+
+By default the [metrics.yaml](metrics.yaml) profile is used. You can change this profile with the variable **metrics_profile**.
 
 ## Pin to server and tolerations
 

--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -74,6 +74,7 @@ spec:
     server: https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com:443
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     prom_token: prometheusToken
+    step: 30s
   workload:
 ```
 
@@ -81,6 +82,7 @@ Where:
 - server: Points to a valid ElasticSearch endpoint. Full URL format required. i.e. https://elastic.instance.apps.com:9200
 - prom_url: Points to a valid Prometheus endpoint. Full URL format required. i.e https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
 - prom_token: Refers to a valid prometheus token. It can be obtained with: `oc -n openshift-monitoring sa get-token prometheus-k8s`
+- step: Prometheus step size, useful for long benchmarks. Defaults to 30s
 
 ## Metrics
 

--- a/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
@@ -44,7 +44,9 @@ spec:
       cleanup: true
       # Verify object creation
       verify_objects: true
-      # Exit w/o indexint if a verify error happened
+      # Prometheus step size
+      step: 30s
+      # Exit w/o indexing if a verify error happened
       error_on_verify: true
       # kube-burner pod tolerations
       tolerations:

--- a/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
@@ -44,10 +44,12 @@ spec:
       cleanup: true
       # Verify object creation
       verify_objects: true
-      # Prometheus step size
-      step: 30s
       # Exit w/o indexing if a verify error happened
       error_on_verify: true
+      # Prometheus step size
+      step: 30s
+      # kube-burner metrics profile
+      metrics_profile: metrics.yaml
       # kube-burner pod tolerations
       tolerations:
       - key: role

--- a/roles/kube-burner/files/metrics-aggregated.yaml
+++ b/roles/kube-burner/files/metrics-aggregated.yaml
@@ -1,0 +1,160 @@
+metrics:
+  - query: (sum(irate(container_cpu_usage_seconds_total{name!="",namespace=~"openshift-(etcd|oauth-apiserver|sdn|ovn-kubernetes|.*apiserver|authentication|.*controller-manager|.*scheduler)"}[2m]) * 100) by (pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
+    metricName: podCPU-Masters
+
+  - query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"}[2m]) * 100 and on (node) kube_node_role{role="worker"}) by (namespace, container)) > 0
+    metricName: containerCPU-AggregatedWorkers
+
+  - query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring)"}[2m]) * 100 and on (node) kube_node_role{role="infra"}) by (namespace, container)) > 0
+    metricName: containerCPU-AggregatedInfra
+
+  - query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH"}[5m])) by (le, verb)) > 0
+    metricName: API99thLatency
+
+  - query: sum(container_memory_usage_bytes{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler)"}) by (pod, namespace, node) and on (node) kube_node_role{role="master"}
+    metricName: podMemory-Masters
+
+  - query: avg(container_memory_usage_bytes{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"} and on (node) kube_node_role{role="worker"}) by (container, namespace)
+    metricName: containerMemory-AggregatedWorkers
+
+  - query: avg(container_memory_usage_bytes{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring)"} and on (node) kube_node_role{role="infra"}) by (container, namespace)
+    metricName: containerMemory-AggregatedInfra
+
+  - query: avg(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100 and on (node) kube_node_role{role="worker"})
+    metricName: KubeletCPU-AggregatedWorkers
+
+  - query: avg(process_resident_memory_bytes{service="kubelet",job="kubelet"} and on (node) kube_node_role{role="worker"})
+    metricName: KubeletMemory-AggregatedWorkers
+
+  - query: avg(irate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m]) * 100  and on (node) kube_node_role{role="worker"})
+    metricName: CrioCPU-AggregatedWorkers
+
+  - query: avg(process_resident_memory_bytes{service="kubelet",job="crio"} and on (node) kube_node_role{role="worker"})
+    metricName: CrioMemory-AggregatedWorkers
+
+  - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: nodeCPU-Masters
+
+  - query: (avg((sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
+    metricName: nodeCPU-AggregatedWorkers
+
+  - query: (avg((sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
+    metricName: nodeCPU-AggregatedInfra
+
+  - query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)"))
+    metricName: nodeMemoryAvailable-Masters
+
+  - query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
+    metricName: nodeMemoryAvailable-AggregatedWorkers
+
+  - query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
+    metricName: nodeMemoryAvailable-AggregatedInfra
+
+  - query: avg(node_memory_Active_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)"))
+    metricName: nodeMemoryActive-Masters
+
+  - query: avg(node_memory_Active_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
+    metricName: nodeMemoryActive-AggregatedWorkers
+
+  - query: avg(avg(node_memory_Active_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
+    metricName: nodeMemoryActive-AggregatedInfra
+
+  - query: avg(node_memory_Cached_bytes) by (instance) + avg(node_memory_Buffers_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+    metricName: nodeMemoryCached+nodeMemoryBuffers-Masters
+
+  - query: avg(node_memory_Cached_bytes + node_memory_Buffers_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
+    metricName: nodeMemoryCached+nodeMemoryBuffers-AggregatedWorkers
+
+  - query: avg(node_memory_Cached_bytes + node_memory_Buffers_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
+    metricName: nodeMemoryCached+nodeMemoryBuffers-AggregatedInfra
+
+  - query: irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+    metricName: rxNetworkBytes-Masters
+
+  - query: avg(irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
+    metricName: rxNetworkBytes-AggregatedWorkers
+
+  - query: avg(irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
+    metricName: rxNetworkBytes-AggregatedInfra
+
+  - query: irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+    metricName: txNetworkBytes-Masters
+
+  - query: avg(irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
+    metricName: txNetworkBytes-AggregatedWorkers
+
+  - query: avg(irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
+    metricName: txNetworkBytes-AggregatedInfra
+
+  - query: (irate(node_network_receive_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: rxDroppedPackets-Masters
+
+  - query: (avg(irate(node_network_receive_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)) > 0
+    metricName: rxDroppedPackets-AggregatedWorkers
+
+  - query: (avg(irate(node_network_receive_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)) > 0
+    metricName: rxDroppedPackets-AggregatedInfra
+
+  - query: irate(node_network_transmit_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+    metricName: txDroppedPackets-Masters
+
+  - query: (avg(irate(node_network_transmit_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)) > 0
+    metricName: txDroppedPackets-AggregatedWorkers
+
+  - query: (avg(irate(node_network_transmit_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)) > 0
+    metricName: txDroppedPackets-AggregatedInfra
+
+  - query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+    metricName: nodeDiskWrittenBytes-Masters
+
+  - query: avg(rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
+    metricName: nodeDiskWrittenBytes-AggregatedWorkers
+
+  - query: avg(rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
+    metricName: nodeDiskWrittenBytes-AggregatedInfra
+
+  - query: rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+    metricName: nodeDiskReadBytes-Masters
+
+  - query: avg(rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
+    metricName: nodeDiskReadBytes-AggregatedWorkers
+
+  - query: avg(rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
+    metricName: nodeDiskReadBytes-AggregatedInfra
+
+  - query: node_nf_conntrack_entries and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+    metricName: nodeConntrackEntries-Workers
+
+  - query: node_nf_conntrack_entries and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+    metricName: nodeConntrackEntries-Infra
+
+  - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
+    metricName: etcdLeaderChangesRate
+
+  - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
+    metricName: 99thEtcdDiskBackendCommitDurationSeconds
+
+  - query: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))
+    metricName: 99thEtcdDiskWalFsyncDurationSeconds
+
+  - query: count(kube_namespace_created)
+    metricName: namespaceCount
+
+  - query: sum(kube_pod_status_phase{}) by (phase)
+    metricName: podStatusCount
+
+  - query: count(kube_secret_info{})
+    metricName: secretCount
+
+  - query: count(kube_deployment_labels{})
+    metricName: deploymentCount
+
+  - query: count(kube_configmap_info{})
+    metricName: configmapCount
+
+  - query: kube_node_role{role="master"}
+    metricName: nodeRoles
+
+  - query: sum(kube_node_status_condition{status="true"}) by (condition)
+    metricName: nodeStatus
+

--- a/roles/kube-burner/files/metrics.yaml
+++ b/roles/kube-burner/files/metrics.yaml
@@ -56,7 +56,7 @@ metrics:
   - query: etcd_server_has_leader
     metricName: etcdServerHasLeader
 
-  - query: rate(etcd_server_leader_changes_seen_total[2m])
+  - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
     metricName: etcdLeaderChangesRate
 
   - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))

--- a/roles/kube-burner/tasks/main.yml
+++ b/roles/kube-burner/tasks/main.yml
@@ -47,7 +47,7 @@
           namespace: "{{ operator_namespace }}"
         data:
           config.yml: "{{ lookup('template', 'cluster-density.yml.j2')}}"
-          metrics.yaml: "{{ lookup('file', 'metrics.yaml')}}"
+          metrics.yaml: "{{ lookup('file', workload_args.metrics_profile|default('metrics.yaml')) }}"
           build.yml: "{{ lookup('file', 'build.yml')}}"
           buildconfig.yml: "{{ lookup('file', 'buildconfig.yml')}}"
           deployment.yml: "{{ lookup('file', 'deployment.yml')}}"

--- a/roles/kube-burner/templates/kube-burner.yml.j2
+++ b/roles/kube-burner/templates/kube-burner.yml.j2
@@ -27,7 +27,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
 {% if prometheus is defined and prometheus.prom_url is defined %}
-          - kube-burner init -c config.yml -m metrics.yaml -u {{ prometheus.prom_url }} -t {{ prometheus.prom_token }} --uuid={{ uuid }} --log-level={{ workload_args.log_level|default("info") }}
+          - kube-burner init -c config.yml -m metrics.yaml -u {{ prometheus.prom_url }} -t {{ prometheus.prom_token }} --uuid={{ uuid }} --log-level={{ workload_args.log_level|default("info") }} --step={{ workload_args.step|default("30s") }}
 {% else %}
           - kube-burner init -c config.yml --uuid={{ uuid }} --log-level={{ workload_args.log_level|default("info") }}
 {% endif %}

--- a/tests/test_crs/valid_kube-burner.yaml
+++ b/tests/test_crs/valid_kube-burner.yaml
@@ -31,6 +31,7 @@ spec:
       verify_objects: true
       error_on_verify: true
       step: 30s
+      metrics_profile: METRICS_PROFILE
       node_selector:
         key: node-role.kubernetes.io/worker
         value:

--- a/tests/test_crs/valid_kube-burner.yaml
+++ b/tests/test_crs/valid_kube-burner.yaml
@@ -30,6 +30,7 @@ spec:
       log_level: info
       verify_objects: true
       error_on_verify: true
+      step: 30s
       node_selector:
         key: node-role.kubernetes.io/worker
         value:

--- a/tests/test_kubeburner.sh
+++ b/tests/test_kubeburner.sh
@@ -22,6 +22,7 @@ trap finish EXIT
 
 function functional_test_kubeburner {
   workload_name=$1
+  metrics_profile=$2
   token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
   cr=tests/test_crs/valid_kube-burner.yaml
   check_logs=0
@@ -29,7 +30,7 @@ function functional_test_kubeburner {
   apply_operator
   kubectl apply -f resources/kube-burner-role.yml
   echo "Performing kube-burner: ${workload_name}"
-  sed -e "s/WORKLOAD/${workload_name}/g" -e "s/PROMETHEUS_TOKEN/${token}/g" ${cr} | kubectl apply -f -
+  sed -e "s/WORKLOAD/${workload_name}/g" -e "s/PROMETHEUS_TOKEN/${token}/g" -e "s/METRICS_PROFILE/${metrics_profile}/g" ${cr} | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 
@@ -49,6 +50,6 @@ function functional_test_kubeburner {
 }
 
 figlet $(basename $0)
-functional_test_kubeburner cluster-density
-functional_test_kubeburner kubelet-density
-functional_test_kubeburner kubelet-density-heavy
+functional_test_kubeburner cluster-density metrics-aggregated.yaml
+functional_test_kubeburner kubelet-density metrics.yaml
+functional_test_kubeburner kubelet-density-heavy metrics.yaml


### PR DESCRIPTION
Configurable step size for prometheus, useful for long benchmarks since it reduces the number of indexed metrics in exchange of granularity.
Also adding selection of kube-burner metrics profile and added a new metrics profile useful for large clusters (Detailed in doc from this PR). Dashboards for both metric profiles at https://github.com/rsevilla87/kube-burner-workloads/tree/master/dashboards

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>