### PR TITLE
Allow passing workload.args.prom_es_user and prom_es_pass

### DIFF
--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -43,6 +43,8 @@ All kube-burner's workloads support the following parameters:
 
 - **workload**: Type of kube-burner workload. As mentioned before, allowed values are cluster-density, kubelet-density and kubelet-density-heavy
 - **default_index**: Elasticsearch index name. Defaults to __ripsaw-kube-burner__
+- **prom_es_user**: Prometheus Elasticsearch user if required
+- **prom_es_pass**: Prometheus Elasticsearch pass if required
 - **job_iterations**: How many iterations to execute of the specified kube-burner workload
 - **qps**: Limit object creation queries per second. Defaults to __5__
 - **burst**: Maximum burst for throttle. Defaults to __10__

--- a/roles/kube-burner/templates/cluster-density.yml.j2
+++ b/roles/kube-burner/templates/cluster-density.yml.j2
@@ -5,6 +5,10 @@ global:
   indexerConfig:
     enabled: true
     esServers: [{{ prometheus.server }}]
+{% if workload_args.prom_es_user is defined and workload_args.prom_es_pass is defined %}
+    username: {{ workload_args.prom_es_user }}
+    password: {{ workload_args.prom_es_pass }}
+{% endif %}
     insecureSkipVerify: true
     defaultIndex: {{ workload_args.default_index|default("ripsaw-kube-burner") }}
     type: elastic

--- a/roles/kube-burner/templates/kubelet-density-heavy.yml.j2
+++ b/roles/kube-burner/templates/kubelet-density-heavy.yml.j2
@@ -5,6 +5,10 @@ global:
   indexerConfig:
     enabled: true
     esServers: [{{ prometheus.server }}]
+{% if workload_args.prom_es_user is defined and workload_args.prom_es_pass is defined %}
+    username: {{ workload_args.prom_es_user }}
+    password: {{ workload_args.prom_es_pass }}
+{% endif %}
     insecureSkipVerify: true
     defaultIndex: {{ workload_args.default_index|default("ripsaw-kube-burner") }}
     type: elastic

--- a/roles/kube-burner/templates/kubelet-density.yml.j2
+++ b/roles/kube-burner/templates/kubelet-density.yml.j2
@@ -5,6 +5,10 @@ global:
   indexerConfig:
     enabled: true
     esServers: [{{ prometheus.server }}]
+{% if workload_args.prom_es_user is defined and workload_args.prom_es_pass is defined %}
+    username: {{ workload_args.prom_es_user }}
+    password: {{ workload_args.prom_es_pass }}
+{% endif %}
     insecureSkipVerify: true
     defaultIndex: {{ workload_args.default_index|default("ripsaw-kube-burner") }}
     type: elastic


### PR DESCRIPTION
If login is required for the ES server when pushing prometheus data. It can be supplied in the workload.args section of the yaml as prom_es_user and prom_es_pass.