### PR TITLE
Option to send fio results to client pod log

### DIFF
--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -207,6 +207,7 @@ The workload loops are nested as such from the CR options:
   > Technical Note: If you are running kube/openshift on VMs make sure the diskimage or volume is preallocated.
 - **prefill**: (Optional) boolean to enable/disable prefill SDS
   - prefill requirement stems from Ceph RBD thin-provisioning - just creating the RBD volume doesn't mean that there is space allocated to read and write out there. For example, reads to an uninitialized volume don't even talk to the Ceph OSDs, they just return immediately with zeroes in the client.
+- **fio_json_to_log**: (Optional) boolean to enable/disable sending job results in json format to client pod log.
 
 #### EXPERT: spec.global_overrides
 

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -77,6 +77,12 @@ spec:
 {% for i in loopvar %}
 {% for job in workload_args.jobs %}
              cat /tmp/fio/fiojob-{{job}}-{{i}}-{{numjobs}}; mkdir -p /tmp/fiod-{{uuid}}/fiojob-{{job}}-{{i}}-{{numjobs}}; run_snafu -t fio -H /tmp/host/hosts -j /tmp/fio/fiojob-{{job}}-{{i}}-{{numjobs}} -s {{workload_args.samples}} -d /tmp/fiod-{{ uuid }}/fiojob-{{job}}-{{i}}-{{numjobs}};
+{% if workload_args.fio_json_to_log is defined and workload_args.fio_json_to_log is sameas true %}
+             for fio_sample in $(seq 1 {{workload_args.samples}});
+             do echo START_FIO_JSON_OUTPUT_fiod-{{uuid}}_fiojob-{{job}}-{{i}}-{{numjobs}}_SAMPLE_$fio_sample;
+             test -f /tmp/fiod-{{uuid}}/fiojob-{{job}}-{{i}}-{{numjobs}}/$fio_sample/{{job}}/fio-result.json && cat /tmp/fiod-{{uuid}}/fiojob-{{job}}-{{i}}-{{numjobs}}/$fio_sample/{{job}}/fio-result.json || echo ERROR_FIO_JSON_FILE_NOT_AVAILABLE;
+             echo END_FIO_JSON_OUTPUT_fiod-{{uuid}}_fiojob-{{job}}-{{i}}-{{numjobs}}_SAMPLE_$fio_sample;done;
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
This commit adds the ability to send fio results to the client pod
logs. This was bought up in

https://github.com/cloud-bulldozer/benchmark-operator/issues/417

If workload_args include

fio_json_to_log: true

all the fio-result.json files found in /tmp/fiod-$uuid will
be sent to the log.