### PR TITLE
Fix uperf in VMs

### DIFF
--- a/roles/uperf/templates/configmap_script.yml.j2
+++ b/roles/uperf/templates/configmap_script.yml.j2
@@ -11,6 +11,8 @@ data:
 {% if elasticsearch.server is defined %}
     export es={{elasticsearch.server}}
     export es_port={{elasticsearch.port}}
+    export es_index={{ elasticsearch.index_name | default("ripsaw-uperf") }}
+    export parallel={{ elasticsearch.parallel | default("false") }}
     export uuid={{uuid}}
 {% endif %}
 {% endif %}
@@ -21,13 +23,13 @@ data:
     export hostnet={{workload_args.hostnetwork}}
     export ips=$(hostname -I)
     while true; do
-      if [[ ($(redis-cli -h {{bo.resources[0].status.podIP}} get start) =~ 'true') && ($(redis-cli -h {{bo.resources[0].status.podIP}} get {{ trunc_uuid }}) =~ 'true')]]; then
+      if [[ ($(redis-cli -h {{bo.resources[0].status.podIP}} get start) =~ 'true') && ($(redis-cli -h {{bo.resources[0].status.podIP}} get {{ trunc_uuid }}) =~ 'true') ]]; then
 {% for test in workload_args.test_types %}
 {% for proto in workload_args.protos %}
 {% for size in workload_args.sizes %}
 {% for nthr in workload_args.nthrs %}
         cat /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{size}}-{{nthr}};
-        python /opt/snafu/-wrapper/uperf-wrapper.py -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{size}}-{{nthr}} -s {{workload_args.samples}} --resourcetype {{resource_kind}} -u {{uuid}} --user {{test_user | default("ripsaw")}};
+        run_snafu --tool uperf -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{size}}-{{nthr}} -s {{workload_args.samples}} --resourcetype {{resource_kind}} -u {{ uuid }} --user {{test_user | default("ripsaw")}};
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/roles/uperf/templates/server_vm.yml.j2
+++ b/roles/uperf/templates/server_vm.yml.j2
@@ -55,12 +55,10 @@ spec:
         chpasswd: { expire: False }
         runcmd:
 {% if workload_args.server_vm.network.multiqueue.enabled %}
-          - yum install -y ethtool
+          - dnf install -y ethtool
           - ethtool -L eth0 combined {{ workload_args.server_vm.network.multiqueue.queues }}
 {% endif %}
-          - yum install -y yum-plugin-copr
-          - yum copr enable ndokos/pbench -y
-          - yum install -y pbench-uperf redis git
+          - dnf install -y uperf redis
           - redis-cli -h {{ bo.resources[0].status.podIP }} set {{ trunc_uuid }} true
           - uperf -s -v -P 20000
     name: cloudinitdisk

--- a/roles/uperf/templates/workload_vm.yml.j2
+++ b/roles/uperf/templates/workload_vm.yml.j2
@@ -72,12 +72,8 @@ spec:
           - yum install -y ethtool
           - ethtool -L eth0 combined {{ workload_args.client_vm.network.multiqueue.queues }}
 {% endif %}
-          - yum install -y yum-plugin-copr
-          - yum copr enable ndokos/pbench -y
-          - yum install -y pbench-uperf redis git python-pip numpy
-          - pip install --upgrade pip
-          - pip install "elasticsearch>=6.0.0,<=7.0.2"
-          - git clone https://github.com/cloud-bulldozer/snafu /opt/snafu
+          - dnf install -y uperf redis
+          - pip install git+https://github.com/cloud-bulldozer/benchmark-wrapper
           - bash /tmp/uperf_script/run_script.sh
     name: cloudinitdisk
   - configMap:


### PR DESCRIPTION
Fix uperf test in virtualized environments. Use uperf from the official Fedora repositories instead the pbench ones.
Fixes: https://github.com/cloud-bulldozer/benchmark-operator/pull/431

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>