### PR TITLE
Rename the prometheus ES server|port|parallel to es_server|port|parallel

### DIFF
--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -16,11 +16,11 @@ To enable this functionality a few variables must be set in the workload CR file
 
 ```
 prometheus:
-  server: the elasticsearch server to upload to
-  port: the elasticsearch server port
+  es_server: the elasticsearch server to upload to
+  es_port: the elasticsearch server port
   prom_url: the prometheus URL
   prom_token: a valid access token for prometheus
-  parallel: enable parallel uploads to elasticsearch
+  es_parallel: enable parallel uploads to elasticsearch
 ```
 
 The prometheus token can be obtained by running the following.
@@ -50,11 +50,11 @@ spec:
     port: 8080
     index_name: ripsaw-smallfile
   prometheus:
-    server: my.other.es.server
-    port: 8080
+    es_server: my.other.es.server
+    es_port: 8080
     prom_url: my.prom.server:9100
     prom_token: 0921783409ufsd09752039ufgpods9u750239uge0p34
-    parallel: true
+    es_parallel: true
   metadata:
     collection: true
   workload:

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -38,11 +38,11 @@ spec:
               prometheus:
                 type: object
                 properties:
-                  server:
+                  es_server:
                     type: string
-                  port: 
+                  es_port: 
                     type: integer
-                  parallel:
+                  es_parallel:
                     type: boolean
                   prom_url:
                     type: string

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -45,11 +45,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -56,11 +56,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/hammerdb/templates/db_mssql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mssql_workload.yml.j2
@@ -34,11 +34,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
          - name: prom_url

--- a/roles/hammerdb/templates/db_mysql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mysql_workload.yml.j2
@@ -34,11 +34,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/hammerdb/templates/db_postgres_workload.yml.j2
+++ b/roles/hammerdb/templates/db_postgres_workload.yml.j2
@@ -34,11 +34,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/kube-burner/templates/cluster-density.yml.j2
+++ b/roles/kube-burner/templates/cluster-density.yml.j2
@@ -4,7 +4,7 @@ global:
 {% if prometheus is defined and prometheus.prom_url is defined %}
   indexerConfig:
     enabled: true
-    esServers: [{{ prometheus.server }}]
+    esServers: [{{ prometheus.es_server }}]
 {% if workload_args.prom_es_user is defined and workload_args.prom_es_pass is defined %}
     username: {{ workload_args.prom_es_user }}
     password: {{ workload_args.prom_es_pass }}

--- a/roles/kube-burner/templates/kubelet-density-heavy.yml.j2
+++ b/roles/kube-burner/templates/kubelet-density-heavy.yml.j2
@@ -4,7 +4,7 @@ global:
 {% if prometheus is defined and prometheus.prom_url is defined %}
   indexerConfig:
     enabled: true
-    esServers: [{{ prometheus.server }}]
+    esServers: [{{ prometheus.es_server }}]
 {% if workload_args.prom_es_user is defined and workload_args.prom_es_pass is defined %}
     username: {{ workload_args.prom_es_user }}
     password: {{ workload_args.prom_es_pass }}

--- a/roles/kube-burner/templates/kubelet-density.yml.j2
+++ b/roles/kube-burner/templates/kubelet-density.yml.j2
@@ -4,7 +4,7 @@ global:
 {% if prometheus is defined and prometheus.prom_url is defined %}
   indexerConfig:
     enabled: true
-    esServers: [{{ prometheus.server }}]
+    esServers: [{{ prometheus.es_server }}]
 {% if workload_args.prom_es_user is defined and workload_args.prom_es_pass is defined %}
     username: {{ workload_args.prom_es_user }}
     password: {{ workload_args.prom_es_pass }}

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -41,11 +41,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -53,11 +53,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -54,11 +54,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -39,11 +39,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -61,11 +61,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -51,11 +51,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.server }}"
+            value: "{{ prometheus.es_server }}"
           - name: prom_port
-            value: "{{ prometheus.port }}"
+            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default("false") }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/ycsb/templates/ycsb_load.yaml
+++ b/roles/ycsb/templates/ycsb_load.yaml
@@ -41,11 +41,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
         - name: prom_es
-          value: "{{ prometheus.server }}"
+          value: "{{ prometheus.es_server }}"
         - name: prom_port
-          value: "{{ prometheus.port }}"
+          value: "{{ prometheus.es_port }}"
         - name: prom_parallel
-          value: "{{ prometheus.parallel | default("false") }}"
+          value: "{{ prometheus.es_parallel | default("false") }}"
         - name: prom_token
           value: "{{ prometheus.prom_token | default() }}"
         - name: prom_url

--- a/roles/ycsb/templates/ycsb_run.yaml
+++ b/roles/ycsb/templates/ycsb_run.yaml
@@ -41,11 +41,11 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
         - name: prom_es
-          value: "{{ prometheus.server }}"
+          value: "{{ prometheus.es_server }}"
         - name: prom_port
-          value: "{{ prometheus.port }}"
+          value: "{{ prometheus.es_port }}"
         - name: prom_parallel
-          value: "{{ prometheus.parallel | default("false") }}"
+          value: "{{ prometheus.es_parallel | default("false") }}"
         - name: prom_token
           value: "{{ prometheus.prom_token | default() }}"
         - name: prom_url

--- a/tests/test_crs/valid_kube-burner.yaml
+++ b/tests/test_crs/valid_kube-burner.yaml
@@ -11,7 +11,7 @@ spec:
   metadata:
     collection: true
   prometheus:
-    server: http://ES_SERVER
+    es_server: http://ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:


### PR DESCRIPTION
Per our previous discussions this PR renames the prometheus.server|port|parallel to add es_server|port|parallel. This aims to reduce some confusion from the end user.

NOTE: this does not change the environment variable passed to benchmark-wrapper