### PR TITLE
Remove ElasticSearch port variable and update references in documenta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,25 @@ a performance baseline of Kubernetes cluster on your provider.
 
 ## Workloads status
 
-| Workload                       | Use                    | Status in Operator | Reconciliation usage       | VM support (kubevirt) | Kata Containers |
+| Workload                       | Use                    | ElasticSearch indexing  | Reconciliation usage       | VM support (kubevirt) | Kata Containers |
 | ------------------------------ | ---------------------- | ------------------ | -------------------------- | --------------------- | --------------- |
-| [UPerf](docs/uperf.md)         | Network Performance    | Working            |  Used, default : 3second  | Working                | Working         |
-| [Iperf3](docs/iperf.md)       | Network Performance    | Working            |  Used, default : 3second  | Not Supported          | Preview         |
-| [fio](docs/fio_distributed.md) | Storage IO             | Working            |  Used, default : 3second  | Working                | Working         |
-| [Sysbench](docs/sysbench.md)   | System Performance     | Working            |  Used, default : 3second  | Not Supported          | Preview         |
-| [YCSB](docs/ycsb.md)           | Database Performance   | Working            |  Used, default : 3second  | Not Supported          | Preview         |
-| [Byowl](docs/byowl.md)         | User defined workload  | Working            |  Used, default : 3second  | Not Supported          | Preview         |
-| [Pgbench](docs/pgbench.md)     | Postgres Performance   | Working            |  Used, default : 3second  | Not Supported          | Preview         |
-| [Smallfile](docs/smallfile.md) | Storage IO Performance | Working            |  Used, default : 3second  | Not Supported          | Preview         |
-| [fs-drift](docs/fs-drift.md)   | Storage IO Longevity   | Working            |  Not used                 | Not Supported          | Preview         |
-| [hammerdb](docs/hammerdb.md)   | Database Performance   | Working            |  Used, default : 3second  | Not Supported          | Preview         |
-| [Service Mesh](docs/servicemesh.md) | Microservices     | Working            |  Used, default : 3second   | Not Supported         | Preview         |
-| [Vegeta](docs/vegeta.md)       | HTTP Performance       | Working            |  Used, default : 3second  | Not Supported          | Preview         |
-| [Scale Openshift](docs/scale_openshift.md) | Scale Openshift Cluster       | Working            |  Used, default : 3second  | Not Supported         | Preview        |
-| [stressng](docs/stressng.md)   | Stress system resources | Working            |  Used, default: 3second  | Not Supported         | Preview        |
-| [kube-burner](docs/kube-burner.md)  | k8s Performance   | Working            |  Used, default : 3second  | Not Supported          | Preview         |
-| [cyclictest](docs/cyclictest.md)  | Real-Time Performance   | Working       |  Used, default : 3second  | Not Supported          | Preview         |
-| [oslat](docs/oslat.md)         | Real-Time Latency      | Working           |  Used, default : 3second   | Not Supported          | Preview         |
-
+| [UPerf](docs/uperf.md)         | Network Performance    | Yes                |  Used, default : 3second  | Working                | Working         |
+| [Iperf3](docs/iperf.md)       | Network Performance     | No                 |  Used, default : 3second  | Not Supported          | Preview         |
+| [fio](docs/fio_distributed.md) | Storage IO             | Yes                |  Used, default : 3second  | Working                | Working         |
+| [Sysbench](docs/sysbench.md)   | System Performance     | No                 |  Used, default : 3second  | Not Supported          | Preview         |
+| [YCSB](docs/ycsb.md)           | Database Performance   | Yes            |  Used, default : 3second  | Not Supported          | Preview         |
+| [Byowl](docs/byowl.md)         | User defined workload  | Yes            |  Used, default : 3second  | Not Supported          | Preview         |
+| [Pgbench](docs/pgbench.md)     | Postgres Performance   | Yes            |  Used, default : 3second  | Not Supported          | Preview         |
+| [Smallfile](docs/smallfile.md) | Storage IO Performance | Yes            |  Used, default : 3second  | Not Supported          | Preview         |
+| [fs-drift](docs/fs-drift.md)   | Storage IO Longevity   | Yes            |  Not used                 | Not Supported          | Preview         |
+| [hammerdb](docs/hammerdb.md)   | Database Performance   | Yes            |  Used, default : 3second  | Not Supported          | Preview         |
+| [Service Mesh](docs/servicemesh.md) | Microservices     | No            |  Used, default : 3second   | Not Supported         | Preview         |
+| [Vegeta](docs/vegeta.md)       | HTTP Performance       | Yes            |  Used, default : 3second  | Not Supported          | Preview         |
+| [Scale Openshift](docs/scale_openshift.md) | Scale Openshift Cluster       | Yes            |  Used, default : 3second  | Not Supported         | Preview        |
+| [stressng](docs/stressng.md)   | Stress system resources | Yes            |  Used, default: 3second  | Not Supported         | Preview        |
+| [kube-burner](docs/kube-burner.md)  | k8s Performance   | Yes            |  Used, default : 3second  | Not Supported          | Preview         |
+| [cyclictest](docs/cyclictest.md)  | Real-Time Performance   | Yes       |  Used, default : 3second  | Not Supported          | Preview         |
+| [oslat](docs/oslat.md)         | Real-Time Latency      | Yes           |  Used, default : 3second   | Not Supported          | Preview         |
 
 
 ### Reconciliation
@@ -53,8 +52,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "my-es.foo.bar"
-    port: 9200
+    server: "http://my-es.foo.bar:80"
   metadata_collection: true
   cleanup: false
   workload:
@@ -80,8 +78,7 @@ metadata:
 spec:
   uuid: 6060004a-7515-424e-93bb-c49844600dde
   elasticsearch:
-    server: "my-es.foo.bar"
-    port: 9200
+    server: "http://my-es.foo.bar:80"
   metadata_collection: true
   cleanup: false
   workload:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "http://my-es.foo.bar:80"
+    url: "http://my-es.foo.bar:80"
   metadata_collection: true
   cleanup: false
   workload:
@@ -78,7 +78,7 @@ metadata:
 spec:
   uuid: 6060004a-7515-424e-93bb-c49844600dde
   elasticsearch:
-    server: "http://my-es.foo.bar:80"
+    url: "http://my-es.foo.bar:80"
   metadata_collection: true
   cleanup: false
   workload:

--- a/docs/cerberus.md
+++ b/docs/cerberus.md
@@ -40,7 +40,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "http://foo.bar.com:9200"
+    url: "http://foo.bar.com:9200"
   cerberus_url: "http://1.2.3.4:8080"
   workload:
     name: byowl

--- a/docs/cerberus.md
+++ b/docs/cerberus.md
@@ -40,8 +40,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "foo.bar.com"
-    port: 9200
+    server: "http://foo.bar.com:9200"
   cerberus_url: "http://1.2.3.4:8080"
   workload:
     name: byowl

--- a/docs/cyclictest.md
+++ b/docs/cyclictest.md
@@ -23,6 +23,8 @@ metadata:
   name: cyclictest
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: <ES_SERVER>
   workload:
     name: "cyclictest"
     args:

--- a/docs/elastic.md
+++ b/docs/elastic.md
@@ -54,7 +54,7 @@ To enable this functionality a few variables must be set in the workload CR file
 
 ```
 elasticsearch:
-  server: the elasticsearch server URL to upload to
+  url: the elasticsearch server URL to upload to
   parallel: enable parallel uploads to elasticsearch [default: false]
   index_name: the index name to use [default: workload defined]
   verify_cert: disable elasticsearch certificate verification [default: true]
@@ -62,15 +62,10 @@ elasticsearch:
 
 **NOTE**: The ElasticSearch URL MUST BE in the format http(s)://[address]:[port]
 
-In addition to the above, the following parameters can be also specified at the `spec` level to improve indexed documents metadata.
-- `test_user` user is a key that points to user triggering ripsaw, useful to search results in ES. Defaults to *ripsaw*.
-- `clustername` an arbitrary name for your system under test (SUT) that can aid indexing.
+*NOTE:* The only required parameters if using elasticsearch is `url`. The others are optional and will be
+defaulted if not provided. Additionally, enabling parallel uploading may impact Elasticsearch server performance.
+Ensure your environment is configured to handle the increased load before enabling
 
-*NOTE:* The only required parameter if using elasticsearch is the URL server. The others are optional and will be defaulted if not provided.
-Additionally, enabling parallel uploading may greatly impact Elasticsearch server performance. Ensure your environment is configured to handle the
-increased load before enabling
-
-Example CR with elasticsearch information provided
 
 ```yaml
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
@@ -82,7 +77,7 @@ spec:
   test_user: homer_simpson
   clustername: test_ci
   elasticsearch:
-    server: "http://my.es.server:9200"
+    url: "http://my.es.server:9200"
     index_name: ripsaw-smallfile
   metadata:
     collection: true
@@ -101,12 +96,13 @@ To enable this functionality we must provide the following parameters to the wor
 
 ```
   prometheus:
-    es_server: my.es.server
-    es_port: 8080 
+    es_url: http://my.es.server:80
     prom_url: http://< URL > 
     prom_token: <token>
     es_parallel: true|false
 ```
+
+**Note**: It's possible to index documents in an authenticated ES instance using the notation `http(s)://[username]:[password]@[address]:[port]` in the es_url parameter.
 
 Depending on your infrastructure and desire to store prometheues data separately from your benchmark data, you are able 
 to specify the same or different ES server/port from the benchmark data instance. Users are also able to separately 
@@ -127,12 +123,10 @@ spec:
   test_user: homer_simpson
   clustername: test_ci
   elasticsearch:
-    server: my.es.server
-    port: 8080
+    server: http://my.es.server:80
     index_name: ripsaw-smallfile
   prometheus:
-    es_server: my.es.server
-    es_port: 8080 
+    es_url: http://my.es.server:80
     prom_url: http://< URL > 
     prom_token: <token>
     es_parallel: true
@@ -169,10 +163,10 @@ oc create clusterrolebinding grafana-cluster-monitoring-view --clusterrole=clust
 oc sa get-token snafu -n my-ripsaw
 ```
 
-*NOTE:* User tokens can expire, for long running test it is recommend to either set the necessary permissions 
+*NOTE:* User tokens can expire, for long running test it is recommend to either set the necessary permissions
 on the token, or use the Prometheus service account's token.
 
-Command to retrieve prometheus service account's token: 
+Command to retrieve prometheus service account's token:
 
 `oc -n openshift-monitoring sa get-token prometheus-k8s`
 
@@ -402,8 +396,3 @@ trigger_workload.py
     
         **yield sample_info_dict, "get_prometheus_trigger"**
 ```
-
-
-
-
-

--- a/docs/elastic.md
+++ b/docs/elastic.md
@@ -1,14 +1,16 @@
 # Indexing to Elasticsearch
 
 How To:
-* [What is it](#what-is-it)
-* [Enabling Collection](#enabling-collection)
-    * [Benchmark Data](#benchmark-data)
-    * [Prometheus Data](#prometheus-data)
-* [Extending Prometheus Collection](#extending-prometheus-collection)
-    * [Elasticsearch-Prometheus Data model](#elasticsearch-prometheus-data-model)
-    * [Explaining Workload Include Files](#explaining-workload-include-files)
-    * [Adding Prometheus collection trigger](#adding-prometheus-collection-trigger)
+- [Indexing to Elasticsearch](#indexing-to-elasticsearch)
+- [What is it](#what-is-it)
+- [Enabling Collection](#enabling-collection)
+    - [Benchmark Data](#benchmark-data)
+    - [Prometheus Data](#prometheus-data)
+      - [Retrieving Openshift Prometheus info](#retrieving-openshift-prometheus-info)
+- [Extending Prometheus Collection](#extending-prometheus-collection)
+    - [Elasticsearch-Prometheus Data Model](#elasticsearch-prometheus-data-model)
+    - [Explaining Workload Include Files](#explaining-workload-include-files)
+    - [Adding Prometheus collection trigger](#adding-prometheus-collection-trigger)
 
 
 # What is it
@@ -52,20 +54,25 @@ To enable this functionality a few variables must be set in the workload CR file
 
 ```
 elasticsearch:
-  server: the elasticsearch server to upload to
-  port: the elasticsearch server port
+  server: the elasticsearch server URL to upload to
   parallel: enable parallel uploads to elasticsearch [default: false]
   index_name: the index name to use [default: workload defined]
   verify_cert: disable elasticsearch certificate verification [default: true]
 ```
 
-*NOTE:* The only required parameters if using elasticsearch is the port and server. The others are optional and will be 
-defaulted if not provided. Additionally, enabling parallel uploading may impact Elasticsearch server performance. 
-Ensure your environment is configured to handle the increased load before enabling
+**NOTE**: The ElasticSearch URL MUST BE in the format http(s)://[address]:[port]
+
+In addition to the above, the following parameters can be also specified at the `spec` level to improve indexed documents metadata.
+- `test_user` user is a key that points to user triggering ripsaw, useful to search results in ES. Defaults to *ripsaw*.
+- `clustername` an arbitrary name for your system under test (SUT) that can aid indexing.
+
+*NOTE:* The only required parameter if using elasticsearch is the URL server. The others are optional and will be defaulted if not provided.
+Additionally, enabling parallel uploading may greatly impact Elasticsearch server performance. Ensure your environment is configured to handle the
+increased load before enabling
 
 Example CR with elasticsearch information provided
 
-```
+```yaml
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -75,8 +82,7 @@ spec:
   test_user: homer_simpson
   clustername: test_ci
   elasticsearch:
-    server: my.es.server
-    port: 8080
+    server: "http://my.es.server:9200"
     index_name: ripsaw-smallfile
   metadata:
     collection: true

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -22,8 +22,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: my.es.server
-    port: 9200
+    server: "http://my.es.server:9200"
   clustername: myk8scluster
   test_user: my_test_user_name
   workload:
@@ -297,5 +296,5 @@ The field for timestamp will always be `time_ms` .
 ### Changes to CR for indexing/visualization
 
 In order to index your fio results to elasticsearch, you will need to define the parameters appropriately in
-your workload CR file. The `spec.elasticsearch.server` and `spec.elasticsearch.port` values are required.
+your workload CR file. The `spec.elasticsearch.server` parameter is required.
 The `spec.clustername` and `spec.test_user` values are advised to allow for better indexing of your data.

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -22,7 +22,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "http://my.es.server:9200"
+    url: "http://my.es.server:9200"
   clustername: myk8scluster
   test_user: my_test_user_name
   workload:
@@ -296,5 +296,5 @@ The field for timestamp will always be `time_ms` .
 ### Changes to CR for indexing/visualization
 
 In order to index your fio results to elasticsearch, you will need to define the parameters appropriately in
-your workload CR file. The `spec.elasticsearch.server` parameter is required.
+your workload CR file. The `spec.elasticsearch.url` parameter is required.
 The `spec.clustername` and `spec.test_user` values are advised to allow for better indexing of your data.

--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -98,18 +98,18 @@ kube-burner is able to collect complex prometheus metrics and index them in a El
 ```yaml
 spec:
   prometheus:
-    es_server: http://foo.esserver.com:9200
+    es_url: http://foo.esserver.com:9200
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     prom_token: prometheusToken
   workload:
 ```
 
 Where:
-- **``es_server``**: Points to a valid ElasticSearch endpoint. Full URL format required. i.e. https://elastic.instance.apps.com:9200
+- **``es_url``**: Points to a valid ElasticSearch endpoint. Full URL format required. i.e. https://elastic.instance.apps.com:9200
 - **``prom_url``**: Points to a valid Prometheus endpoint. Full URL format required. i.e https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
 - **``prom_token``**: Refers to a valid prometheus token. It can be obtained with: `oc -n openshift-monitoring sa get-token prometheus-k8s`
 
-**Note**: It's possible to index documents in an authenticated ES instance using the notation `http(s)://[username]:[password]@[address]:[port]` in the url parameter.
+**Note**: It's possible to index documents in an authenticated ES instance using the notation `http(s)://[username]:[password]@[address]:[port]` in the es_url parameter.
 
 ## Metrics
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -112,7 +112,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "http://my.elastic.server.foo:9200"
+    url: "http://my.elastic.server.foo:9200"
   metadata:
     collection: true
     targeted: false
@@ -202,7 +202,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "http://my.elastic.server.foo:9200"
+    url: "http://my.elastic.server.foo:9200"
   metadata:
     collection: true
   workload:
@@ -357,9 +357,9 @@ While upon initial creation metadata is collected, it may be useful to collect
 additional runs of data at other times. To do this you will need to loop through
 each backpack Pod and exec the python command below:
 ```
-python3 stockpile-wrapper.py -s [es_server] -u [uuid]
+python3 stockpile-wrapper.py -s [es_url] -u [uuid]
 ```
-Where es_server points to the Elasticsearch server to index to.
+Where es_url points to the Elasticsearch server to index to.
 The UUID can be any uuid string you would like (if you do not supply one it
 will create one for you and you will see it defined in the output). On the
 initial run at boot this is the same UUID as the benchmark UUID.

--- a/docs/oslat.md
+++ b/docs/oslat.md
@@ -24,7 +24,6 @@ metadata:
 spec:
   elasticsearch:
     server: <ES_SERVER>
-    port: <ES_PORT>
   workload:
     name: "oslat"
     args:

--- a/docs/pgbench.md
+++ b/docs/pgbench.md
@@ -129,8 +129,7 @@ spec:
   test_user: milton
   # My elasticsearch server information
   elasticsearch:
-    server: my.elasticsearch.server
-    port: 9200
+    server: "htttp://my.elasticsearch.server:9200"
   workload:
     name: "pgbench"
     args:

--- a/docs/pgbench.md
+++ b/docs/pgbench.md
@@ -129,7 +129,7 @@ spec:
   test_user: milton
   # My elasticsearch server information
   elasticsearch:
-    server: "htttp://my.elasticsearch.server:9200"
+    url: "htttp://my.elasticsearch.server:9200"
   workload:
     name: "pgbench"
     args:

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,8 +1,9 @@
 # Collecting Prometheus Data
 
 How To:
-* [What is it](#what-is-it)
-* [Configuring](#configuring)
+- [Collecting Prometheus Data](#collecting-prometheus-data)
+- [What is it](#what-is-it)
+- [Configuring](#configuring)
 
 # What is it
 
@@ -17,11 +18,12 @@ To enable this functionality a few variables must be set in the workload CR file
 ```
 prometheus:
   es_server: the elasticsearch server to upload to
-  es_port: the elasticsearch server port
   prom_url: the prometheus URL
   prom_token: a valid access token for prometheus
   es_parallel: enable parallel uploads to elasticsearch
 ```
+
+**Note**: Full URL format required for ElasticSearch. i.e. http://myesinstance.domain.com:9200
 
 The prometheus token can be obtained by running the following.
 
@@ -36,7 +38,7 @@ Elasticsearch instance sized appropriately.
 
 Example CR with prometheus uploads enabled
 
-```
+```yaml
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
@@ -46,12 +48,10 @@ spec:
   test_user: homer_simpson
   clustername: test_ci
   elasticsearch:
-    server: my.es.server
-    port: 8080
+    server: "http://my.es.server:9200"
     index_name: ripsaw-smallfile
   prometheus:
-    es_server: my.other.es.server
-    es_port: 8080
+    es_server: "http://my.other.es.server:80"
     prom_url: my.prom.server:9100
     prom_token: 0921783409ufsd09752039ufgpods9u750239uge0p34
     es_parallel: true

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -17,7 +17,7 @@ To enable this functionality a few variables must be set in the workload CR file
 
 ```
 prometheus:
-  es_server: the elasticsearch server to upload to
+  es_url: the elasticsearch server to upload to
   prom_url: the prometheus URL
   prom_token: a valid access token for prometheus
   es_parallel: enable parallel uploads to elasticsearch
@@ -48,10 +48,10 @@ spec:
   test_user: homer_simpson
   clustername: test_ci
   elasticsearch:
-    server: "http://my.es.server:9200"
+    url: "http://my.es.server:9200"
     index_name: ripsaw-smallfile
   prometheus:
-    es_server: "http://my.other.es.server:80"
+    es_url: "http://my.other.es.server:80"
     prom_url: my.prom.server:9100
     prom_token: 0921783409ufsd09752039ufgpods9u750239uge0p34
     es_parallel: true
@@ -66,3 +66,5 @@ spec:
       file_size: 0
       files: 100000
 ```
+
+**Note**: It's possible to index documents in an authenticated ES instance using the notation `http(s)://[username]:[password]@[address]:[port]` in the url parameter.

--- a/docs/scale_openshift.md
+++ b/docs/scale_openshift.md
@@ -38,7 +38,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "http://es-instance.com:9200"
+    url: "http://es-instance.com:9200"
     index_name: ripsaw-scale
   workload:
     name: scale_openshift

--- a/docs/scale_openshift.md
+++ b/docs/scale_openshift.md
@@ -38,8 +38,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: foo
-    port: 9090
+    server: "http://es-instance.com:9200"
     index_name: ripsaw-scale
   workload:
     name: scale_openshift

--- a/docs/servicemesh.md
+++ b/docs/servicemesh.md
@@ -4,7 +4,7 @@ This is an automated benchmark of basic [Red Hat Openshift Service Mesh](https:/
 
 The benchmark creates two namespaces: one for the Service Mesh [Control Plane](https://istio.io/docs/ops/deployment/architecture/), the other for the workload applications. Hyperfoil driver and the pod used to gather results is installed in the same namespace where Ripsaw is installed. When the benchmark completes those namespaces are destroyed along with other resources in Ripsaw namespace; you can inspect the results in JSON format in the benchmark job's pod output.
 
-## Prerequisities
+## Prerequisites
 
 As this benchmark requires the operator to create new namespaces, you have to grant it an extra permission:
 

--- a/docs/stressng.md
+++ b/docs/stressng.md
@@ -21,8 +21,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: <ES_SERVER>
-    port: <ES_PORT>
+    server: "http://es-instance.com:9200"
     index_name: ripsaw-stressng
   metadata:
     collection: true

--- a/docs/stressng.md
+++ b/docs/stressng.md
@@ -21,7 +21,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "http://es-instance.com:9200"
+    url: "http://es-instance.com:9200"
     index_name: ripsaw-stressng
   metadata:
     collection: true

--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -15,7 +15,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "http://es-instance.com:9200"
+    url: "http://es-instance.com:9200"
   workload:
     name: uperf
     args:

--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -14,6 +14,8 @@ metadata:
   name: uperf-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "http://es-instance.com:9200"
   workload:
     name: uperf
     args:
@@ -264,98 +266,6 @@ podman push <imageurl>
 You can either access results by indexing them directly or by accessing the console.
 The results are stored in /tmp/ directory
 
-
-
-### Storing results into Elasticsearch
-
-```yaml
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
-metadata:
-  name: example-benchmark
-  namespace: my-ripsaw
-spec:
-  clustername: myk8scluster
-  test_user: test_user # user is a key that points to user triggering ripsaw, useful to search results in ES
-  elasticsearch:
-    server: <es_host>
-    port: <es_port>
-  workload:
-    name: uperf
-    args:
-      hostnetwork: false
-      pin: false
-      pin_server: "node-0"
-      pin_client: "node-1"
-      kind: pod
-      samples: 1
-      pair: 1
-      test_types:
-        - stream
-      protos:
-        - tcp
-      sizes:
-        - 16384
-      nthrs:
-        - 1
-      runtime: 30
-```
-
-The new fields :
-
-`elasticsearch.server` this is the elasticsearch cluster ip you want to send the result data to for long term storage.
-
-`elasticsearch.port` port which elasticsearch is listening, typically `9200`.
-
-`user` provide a user id to the metadata that will be sent to Elasticsearch, this makes finding the results easier.
-
-By default we will utilize the `uperf-results` index for Elasticsearch.
-
-Deploying the above(assuming pairs is set to 1) would result in
-
-```bash
-# kubectl get -o wide pods
-NAME                                                    READY   STATUS      RESTARTS   AGE     IP             NODE       NOMINATED NODE   READINESS GATES
-benchmark-operator-6679867fb7-p2fzb                     2/2     Running     0          6h1m    10.130.0.56    master-2   <none>           <none>
-uperf-benchmark-nohost-uperf-client-10.128.1.29-kbw4b   0/1     Completed   0          3h11m   10.129.1.214   master-1   <none>           <none>
-
-```
-
-The first pod is our Operator orchestrating the UPerf workload.
-
-To review the results, `kubectl logs <client>`, the top of the output is
-the actual workload that was passed to UPerf (From the values in the custom resource).
-
-Note: If cleanup is not set in the spec file then the client pods will be killed after
-600 seconds from it's completion. The server pods will be cleaned up immediately
-after client job completes
-
-```
-... Trimmed output ...
-+-------------------------------------------------- UPerf Results --------------------------------------------------+
-Run : 1
-Uperf Setup
-
-          hostnetwork : False
-          client: 10.129.1.214
-          server: 10.128.1.29
-
-UPerf results for :
-
-          test_type: stream
-          protocol: tcp
-          message_size: 64
-
-UPerf results (bytes/sec):
-
-          min: 0
-          max: 75938816
-          median: 72580096.0
-          average: 63342843.6066
-          95th: 75016192.0
-+-------------------------------------------------------------------------------------------------------------------+
-
-```
 
 ### Dashboard example
 

--- a/docs/vegeta.md
+++ b/docs/vegeta.md
@@ -19,7 +19,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: "http://esinstance.com:9200"
+    url: "http://esinstance.com:9200"
     index_name: ripsaw-vegeta
   workload:
     name: vegeta

--- a/docs/vegeta.md
+++ b/docs/vegeta.md
@@ -18,6 +18,9 @@ metadata:
   name: vegeta-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: "http://esinstance.com:9200"
+    index_name: ripsaw-vegeta
   workload:
     name: vegeta
     args:
@@ -85,42 +88,6 @@ Vegeta jobs make usage of pod anti-affinity rules to to deploy vegeta clients on
 
 ## Storing results into Elasticsearch
 
-It's possible to index reults in Elasticseach specifing using a configuration like the below.
-
-```yaml
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
-metadata:
-  name: vegeta-benchmark
-  namespace: my-ripsaw
-spec:
-  elasticsearch:
-    server: esinstance.com
-    port: 9200
-    index_name: ripsaw-vegeta
-  workload:
-    name: vegeta
-    args:
-      hostnetwork: false
-      image: quay.io/cloud-bulldozer/vegeta:latest
-      targets:
-        - name: 100w-ka
-          urls:
-            - GET https://mydomain.com/test.png
-            - GET http://myunsecuredomain.com
-          duration: 10
-```
-
-Where:
-
-- `elasticsearch.server` this is the elasticsearch cluster ip you want to send the result data to for long term storage.
-- `elasticsearch.port` port which elasticsearch is listening, typically `9200`.
-- `elasticsearch.index_name` Elasticseach to index the logs in. This parameter is optional, and defaults to *ripsaw-vegeta*.
-
-In addition, the following parameters can be also specified at the `spec` level to improve ES indexing.
-- `test_user` user is a key that points to user triggering ripsaw, useful to search results in ES. Defaults to *ripsaw*.
-- `clustername` an arbitrary name for your system under test (SUT) that can aid indexing.
-
 The following metrics are indexed at one second intervals:
 
 - rps: Rate of sent requests per second..
@@ -128,7 +95,10 @@ The following metrics are indexed at one second intervals:
 - status_codes: Breakdown of the number status codes observed over the interval.
 - requests: Total number of requests executed until that moment.
 - p99_latency: 99th percentile of the request latency observed over the interval in µs.
+- p97_latency: 95th percentile of the request latency observed over the interval in µs.
 - req_latency: Average latency of all requests observed over the interval in µs.
+- max_latency: Maximum latency observed during the Benchmark.
+- min_latency: Minimum latency observed during the Benchmark.
 - bytes_in: Incoming byte metrics over the interval.
 - bytes_out: Outgoing byte metrics over the interval.
 - targets: Targets file used.
@@ -137,10 +107,9 @@ The following metrics are indexed at one second intervals:
 - hostname: Hostname from the host where the test is launched.
 - keepalive: Whether keepalive is used or not.
 
-
 ### Dashboard example
 
-Using the Elasticsearch storage described above, we can build dashboards like the below.
+Using the ElasticSearch metrics described above, we can build dashboards like the below.
 
 ![Vegeta dashboard](https://i.imgur.com/YWophlP.png)
 

--- a/resources/crds/ripsaw_v1alpha1_cyclictest_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_cyclictest_cr.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: <ES_SERVER>
-    port: <ES_PORT>
   workload:
     name: "cyclictest"
     args:

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -4,9 +4,9 @@ metadata:
   name: fio-benchmark
   namespace: my-ripsaw
 spec:
-#  elasticsearch:
-#    server: <es_server>
-#    port: 9200
+  # where elastic search is running
+  elasticsearch:
+    server: http://my.elasticsearch.server:80
 #  clustername: myk8scluster
 #  test_user: ripsaw
   workload:

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   # where elastic search is running
   elasticsearch:
-    server: http://my.elasticsearch.server:80
+    url: http://my.elasticsearch.server:80
 #  clustername: myk8scluster
 #  test_user: ripsaw
   workload:

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_vm_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_vm_cr.yaml
@@ -4,9 +4,9 @@ metadata:
   name: fio-vm-benchmark
   namespace: my-ripsaw
 spec:
-#  elasticsearch:
-#    server: <es_server>
-#    port: 9200
+  # where elastic search is running
+  elasticsearch:
+    server: http://my.elasticsearch.server:80
 #  clustername: myk8scluster
 #  test_user: ripsaw
   workload:

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_vm_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_vm_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   # where elastic search is running
   elasticsearch:
-    server: http://my.elasticsearch.server:80
+    url: http://my.elasticsearch.server:80
 #  clustername: myk8scluster
 #  test_user: ripsaw
   workload:

--- a/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
@@ -4,13 +4,12 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  # where elastic search is running
+  elasticsearch:
+    server: http://my.elasticsearch.server:80
   test_user: homer_simpson
   # to separate this test run from everyone else's
   clustername: aws-2009-09-10
-  # where elastic search is running
-  elasticsearch:
-    server: my.elasticsearch.server
-    port: 9200
   workload:
     name: fs-drift
     args:

--- a/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   # where elastic search is running
   elasticsearch:
-    server: http://my.elasticsearch.server:80
+    url: http://my.elasticsearch.server:80
   test_user: homer_simpson
   # to separate this test run from everyone else's
   clustername: aws-2009-09-10

--- a/resources/crds/ripsaw_v1alpha1_hammerdb_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_hammerdb_cr.yaml
@@ -4,6 +4,8 @@ metadata:
   name: hammerdb-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: http://my.elasticsearch.server:80
   workload:
     name: hammerdb
     args:

--- a/resources/crds/ripsaw_v1alpha1_hammerdb_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_hammerdb_cr.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: http://my.elasticsearch.server:80
+    url: http://my.elasticsearch.server:80
   workload:
     name: hammerdb
     args:

--- a/resources/crds/ripsaw_v1alpha1_hammerdb_index_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_hammerdb_index_cr.yaml
@@ -4,11 +4,10 @@ metadata:
   name: hammerdb-benchmark
   namespace: my-ripsaw
 spec:
-  # elasticsearch:
-  #   server: elk.server.com
-  #   port: 9200
-  # clustername: myk8scluster
-  # test_user: username_to_attach_to_metadata
+  elasticsearch:
+    server: http://my.elasticsearch.server:80
+# clustername: myk8scluster
+# test_user: username_to_attach_to_metadata
   workload:
     # cleanup: true
     name: hammerdb

--- a/resources/crds/ripsaw_v1alpha1_hammerdb_index_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_hammerdb_index_cr.yaml
@@ -1,11 +1,11 @@
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
   name: hammerdb-benchmark
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: http://my.elasticsearch.server:80
+    url: http://my.elasticsearch.server:80
 # clustername: myk8scluster
 # test_user: username_to_attach_to_metadata
   workload:

--- a/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
@@ -7,10 +7,10 @@ spec:
   # Metadata information
   elasticsearch:
     # Elastic search instance with full URL format. https://elastic.apps.org:9200
-    server: <ES_URL>
+    url: <ES_URL>
   prometheus:
     # Elastic search instance with full URL format. https://elastic.apps.org:9200
-    es_server: <ES_URL>
+    es_url: <ES_URL>
     # Prometheus bearer token
     prom_token: <PROMETHEUS_BEARER_TOKEN>
     # Prometheus URL with full URL format. https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091

--- a/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   # Metadata information
   elasticsearch:
+    # Elastic search instance with full URL format. https://elastic.apps.org:9200
     server: <ES_URL>
-    port: <ES_PORT>
   prometheus:
     # Elastic search instance with full URL format. https://elastic.apps.org:9200
     es_server: <ES_URL>

--- a/resources/crds/ripsaw_v1alpha1_oslat_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_oslat_cr.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: <ES_SERVER>
-    port: <ES_PORT>
   workload:
     name: "oslat"
     args:

--- a/resources/crds/ripsaw_v1alpha1_pgbench_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_pgbench_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clustername: myk8scluster
   elasticsearch:
-    server: http://my.elasticsearch.server:80
+    url: http://my.elasticsearch.server:80
   #test_user: milton
   workload:
     name: "pgbench"

--- a/resources/crds/ripsaw_v1alpha1_pgbench_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_pgbench_cr.yaml
@@ -5,9 +5,8 @@ metadata:
   namespace: my-ripsaw
 spec:
   clustername: myk8scluster
-  #elasticsearch:
-  #  server: my.elasticsearch.server
-  #  port: 9200
+  elasticsearch:
+    server: http://my.elasticsearch.server:80
   #test_user: milton
   workload:
     name: "pgbench"

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -27,7 +27,7 @@ spec:
               elasticsearch:
                 type: object
                 properties:
-                  server:
+                  url:
                     type: string
                   index_name:
                     type: string
@@ -38,7 +38,7 @@ spec:
               prometheus:
                 type: object
                 properties:
-                  es_server:
+                  es_url:
                     type: string
                   es_parallel:
                     type: boolean
@@ -69,7 +69,7 @@ spec:
                     default: false
                     type: boolean
                   image:
-                    default: "quay.io/rsevilla/backpack:latest"
+                    default: "quay.io/cloud-bulldozer/backpack:latest"
                     type: string
                   label:
                     type: object

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -29,8 +29,6 @@ spec:
                 properties:
                   server:
                     type: string
-                  port:
-                    type: integer
                   index_name:
                     type: string
                   parallel:
@@ -42,8 +40,6 @@ spec:
                 properties:
                   es_server:
                     type: string
-                  es_port: 
-                    type: integer
                   es_parallel:
                     type: boolean
                   prom_url:
@@ -73,7 +69,7 @@ spec:
                     default: false
                     type: boolean
                   image:
-                    default: "quay.io/cloud-bulldozer/backpack:latest"
+                    default: "quay.io/rsevilla/backpack:latest"
                     type: string
                   label:
                     type: object

--- a/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
@@ -7,8 +7,7 @@ spec:
   test_user: homer_simpson
   clustername: aws-2009-09-10
   elasticsearch:
-    server: my.elasticsearch.server
-    port: 9020
+    server: "http://my.elasticsearch.server:9200"
   workload:
     name: smallfile
     args:

--- a/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_smallfile_cr.yaml
@@ -7,7 +7,7 @@ spec:
   test_user: homer_simpson
   clustername: aws-2009-09-10
   elasticsearch:
-    server: "http://my.elasticsearch.server:9200"
+    url: http://my.elasticsearch.server:9200
   workload:
     name: smallfile
     args:

--- a/resources/crds/ripsaw_v1alpha1_stressng_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_stressng_cr.yaml
@@ -5,8 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: http://my.elasticsearch.server:80
-    index_name: ripsaw-stressng
+    url: http://my.elasticsearch.server:80
   metadata:
     collection: true
   workload:

--- a/resources/crds/ripsaw_v1alpha1_stressng_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_stressng_cr.yaml
@@ -5,8 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: <ES_SERVER>
-    port: <ES_PORT>
+    server: http://my.elasticsearch.server:80
     index_name: ripsaw-stressng
   metadata:
     collection: true

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -5,9 +5,8 @@ metadata:
   namespace: my-ripsaw
 spec:
   clustername: myk8scluster
-  #elasticsearch:
-  #   server: elk.server.com
-  #   port: 9200
+  elasticsearch:
+    server: http://es.server.com:80
   #test_user: username_to_attach_to_metadata
   workload:
     # cleanup: true

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clustername: myk8scluster
   elasticsearch:
-    server: http://es.server.com:80
+    url: http://es.server.com:80
   #test_user: username_to_attach_to_metadata
   workload:
     # cleanup: true

--- a/resources/crds/ripsaw_v1alpha1_uperf_vm.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_vm.yaml
@@ -7,8 +7,7 @@ spec:
   clustername: test-cluster
   test_user: <user> # user is a key that points to user triggering ripsaw, useful to search results in ES
   elasticsearch:
-    server: <elastic_host>
-    port: <elastic_port>
+    server: http://es.server.com:80
   cleanup: false
   workload:
     name: uperf

--- a/resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml
@@ -4,12 +4,12 @@ metadata:
   name: vegeta-benchmark
   namespace: my-ripsaw
 spec:
-# elasticsearch:
-#   server: <es_instance>
-#   port: 9200
-#   index_name: ripsaw-vegeta
+  elasticsearch:
+    # Elastic search instance with full URL format. https://elastic.apps.org:9200
+    server: "https://elastic.apps.org:9200"
+    index_name: ripsaw-vegeta
 # test_user: username_to_attach_to_metadata
-  clustername: myk8scluster
+#  clustername: myk8scluster
   workload:
     name: vegeta
     args:

--- a/resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml
@@ -6,10 +6,9 @@ metadata:
 spec:
   elasticsearch:
     # Elastic search instance with full URL format. https://elastic.apps.org:9200
-    server: "https://elastic.apps.org:9200"
-    index_name: ripsaw-vegeta
+    url: https://elastic.apps.org:9200
 # test_user: username_to_attach_to_metadata
-#  clustername: myk8scluster
+  clustername: myk8scluster
   workload:
     name: vegeta
     args:

--- a/resources/crds/ripsaw_v1alpha1_ycsb_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ycsb_cr.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: http://my.elasticsearch.server:80
-    index_name: ripsaw-ycsb
   clustername: myk8scluster
   workload:
     name: ycsb

--- a/resources/crds/ripsaw_v1alpha1_ycsb_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ycsb_cr.yaml
@@ -4,6 +4,9 @@ metadata:
   name: ycsb-couchbase-benchmark
   namespace: my-ripsaw
 spec:
+  elasticsearch:
+    server: http://my.elasticsearch.server:80
+    index_name: ripsaw-ycsb
   clustername: myk8scluster
   workload:
     name: ycsb

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -41,7 +41,7 @@ spec:
           - >
             python3
             stockpile-wrapper.py
-            -s={{ elasticsearch.server }}
+            -s={{ elasticsearch.url }}
             -u={{ uuid }}
             -n=${my_node_name}
             -N=${my_pod_name}

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -58,6 +58,7 @@ spec:
         imagePullPolicy: Always
         securityContext:
           privileged: {{ metadata.privileged }}
+          runAsNonRoot: false
         readinessProbe:
           exec:
             command:

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -42,7 +42,6 @@ spec:
             python3
             stockpile-wrapper.py
             -s={{ elasticsearch.server }}
-            -p={{ elasticsearch.port }}
             -u={{ uuid }}
             -n=${my_node_name}
             -N=${my_pod_name}

--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -49,7 +49,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_port
             value: "{{ prometheus.es_port }}"
           - name: prom_parallel

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -34,22 +34,18 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-fio") }}"
           - name: es_verify_cert
             value: "{{ elasticsearch.cert_verify | default("true") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -33,7 +33,7 @@ spec:
             value: "{{ kernel_cache_drop_svc_port }}"
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-fio") }}"
           - name: es_verify_cert
@@ -43,7 +43,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token

--- a/roles/fio_distributed/templates/server_vm.yml.j2
+++ b/roles/fio_distributed/templates/server_vm.yml.j2
@@ -49,13 +49,13 @@ spec:
 {% if workload_args.metadata is defined
     and (workload_args.metadata.collection|default(false))
     and (workload_args.metadata.targeted|default(true)) %}
-            - export ES_SERVER={{ elasticsearch.server }}
+            - export ES_SERVER={{ elasticsearch.url }}
 {% if workload_args.vm_image is undefined %}
             - wget https://raw.githubusercontent.com/cloud-bulldozer/bohica/master/stockpile-wrapper/stockpile-wrapper.py
             - pip3 install elasticsearch-dsl openshift kubernetes redis
 {% endif %}
             # TODO: start stockpile-wrapper script
-            python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -u {{ uuid }} -n "$my_node_name" -N "$my_pod_name" --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force
+            python3 stockpile-wrapper.py -s {{ elasticsearch.url }} -u {{ uuid }} -n "$my_node_name" -N "$my_pod_name" --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force
 {% endif %}
             - fio --server
 {% if workload_args.storageclass is defined %}

--- a/roles/fio_distributed/templates/server_vm.yml.j2
+++ b/roles/fio_distributed/templates/server_vm.yml.j2
@@ -50,13 +50,12 @@ spec:
     and (workload_args.metadata.collection|default(false))
     and (workload_args.metadata.targeted|default(true)) %}
             - export ES_SERVER={{ elasticsearch.server }}
-            - export ES_PORT={{ elasticsearch.port }}
 {% if workload_args.vm_image is undefined %}
             - wget https://raw.githubusercontent.com/cloud-bulldozer/bohica/master/stockpile-wrapper/stockpile-wrapper.py
             - pip3 install elasticsearch-dsl openshift kubernetes redis
 {% endif %}
             # TODO: start stockpile-wrapper script
-            python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -p {{ elasticsearch.port }} -u {{ uuid }} -n "$my_node_name" -N "$my_pod_name" --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force
+            python3 stockpile-wrapper.py -s {{ elasticsearch.server }} -u {{ uuid }} -n "$my_node_name" -N "$my_pod_name" --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force
 {% endif %}
             - fio --server
 {% if workload_args.storageclass is defined %}

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -49,7 +49,7 @@ spec:
             value: "{{ clustername }}"
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-fs-drift") }}"
           - name: parallel
@@ -57,7 +57,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -50,20 +50,16 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-fs-drift") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/hammerdb/templates/db_mssql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mssql_workload.yml.j2
@@ -28,20 +28,16 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-hammerdb") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
          - name: prom_url

--- a/roles/hammerdb/templates/db_mssql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mssql_workload.yml.j2
@@ -27,7 +27,7 @@ spec:
             value: "{{ clustername }}"
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-hammerdb") }}"
           - name: parallel
@@ -35,7 +35,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token

--- a/roles/hammerdb/templates/db_mysql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mysql_workload.yml.j2
@@ -27,7 +27,7 @@ spec:
             value: "{{ clustername }}"
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-hammerdb") }}"
           - name: parallel
@@ -35,7 +35,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token

--- a/roles/hammerdb/templates/db_mysql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mysql_workload.yml.j2
@@ -28,20 +28,16 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-hammerdb") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/hammerdb/templates/db_postgres_workload.yml.j2
+++ b/roles/hammerdb/templates/db_postgres_workload.yml.j2
@@ -27,7 +27,7 @@ spec:
             value: "{{ clustername }}"
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-hammerdb") }}"
           - name: parallel
@@ -35,7 +35,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token

--- a/roles/hammerdb/templates/db_postgres_workload.yml.j2
+++ b/roles/hammerdb/templates/db_postgres_workload.yml.j2
@@ -28,20 +28,16 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-hammerdb") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/kube-burner/templates/cluster-density.yml.j2
+++ b/roles/kube-burner/templates/cluster-density.yml.j2
@@ -1,10 +1,10 @@
 ---
 global:
   writeToFile: false
-{% if prometheus is defined and prometheus.prom_url is defined %}
+{% if prometheus is defined and prometheus.prom_url is defined and prometheus.es_url != "" %}
   indexerConfig:
     enabled: true
-    esServers: ["{{ prometheus.es_server }}"]
+    esServers: ["{{ prometheus.es_url }}"]
     insecureSkipVerify: true
     defaultIndex: {{ workload_args.default_index|default("ripsaw-kube-burner") }}
     type: elastic

--- a/roles/kube-burner/templates/kubelet-density-heavy.yml.j2
+++ b/roles/kube-burner/templates/kubelet-density-heavy.yml.j2
@@ -1,10 +1,10 @@
 ---
 global:
   writeToFile: false
-{% if prometheus is defined and prometheus.prom_url is defined %}
+{% if prometheus is defined and prometheus.prom_url is defined and prometheus.es_url != "" %}
   indexerConfig:
     enabled: true
-    esServers: ["{{ prometheus.es_server }}"]
+    esServers: ["{{ prometheus.es_url }}"]
     insecureSkipVerify: true
     defaultIndex: {{ workload_args.default_index|default("ripsaw-kube-burner") }}
     type: elastic

--- a/roles/kube-burner/templates/kubelet-density.yml.j2
+++ b/roles/kube-burner/templates/kubelet-density.yml.j2
@@ -1,10 +1,10 @@
 ---
 global:
   writeToFile: false
-{% if prometheus is defined and prometheus.prom_url is defined %}
+{% if prometheus is defined and prometheus.prom_url is defined and prometheus.es_url != "" %}
   indexerConfig:
     enabled: true
-    esServers: ["{{ prometheus.es_server }}"]
+    esServers: ["{{ prometheus.es_url }}"]
     insecureSkipVerify: true
     defaultIndex: {{ workload_args.default_index|default("ripsaw-kube-burner") }}
     type: elastic

--- a/roles/kube-burner/templates/max-namespaces.yml.j2
+++ b/roles/kube-burner/templates/max-namespaces.yml.j2
@@ -4,7 +4,7 @@ global:
 {% if prometheus is defined and prometheus.prom_url is defined %}
   indexerConfig:
     enabled: true
-    esServers: ["{{ prometheus.es_server }}"]
+    esServers: ["{{ prometheus.es_url }}"]
     insecureSkipVerify: true
     defaultIndex: {{ workload_args.default_index|default("ripsaw-kube-burner") }}
     type: elastic

--- a/roles/kube-burner/templates/max-services.yml.j2
+++ b/roles/kube-burner/templates/max-services.yml.j2
@@ -4,7 +4,7 @@ global:
 {% if prometheus is defined and prometheus.prom_url is defined %}
   indexerConfig:
     enabled: true
-    esServers: ["{{ prometheus.es_server }}"]
+    esServers: ["{{ prometheus.es_url }}"]
     insecureSkipVerify: true
     defaultIndex: {{ workload_args.default_index|default("ripsaw-kube-burner") }}
     type: elastic

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -49,7 +49,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_port
             value: "{{ prometheus.es_port }}"
           - name: prom_parallel

--- a/roles/pgbench/defaults/main.yml
+++ b/roles/pgbench/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 db_port: 5432
-pgb_base_image: "quay.io/cloud-bulldozer/pgbench"
-pgb_version: "latest"
+pgb_base_image: "quay.io/cloud-bulldozer/pgbench:latest"
 timeout_min: 300
 num_databases_pattern: "{{ workload_args.num_databases_pattern|default('all') }}"
 run_time: "{{ workload_args.run_time|default('') }}"

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -16,7 +16,7 @@ spec:
 {% endif %}
       containers:
       - name: benchmark
-        image: "{{ pgb_base_image }}:{{ pgb_version }}"
+        image: "{{ pgb_base_image }}"
         imagePullPolicy: Always
         env:
           - name: PGPASSWORD
@@ -34,7 +34,7 @@ spec:
             value: '{{ clustername }}'
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-pgbench") }}"
           - name: parallel
@@ -42,7 +42,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
@@ -64,7 +64,7 @@ spec:
                    echo 'GO!';
                  {% for clients in workload_args.clients|default('1') %}
                    export database='{{ item.1.host }}/{{ item.1.db_name }}';
-                   export description='scaling factor: {{ workload_args.scaling_factor }} | threads: {{ workload_args.threads }} | clients: {{ clients }}'
+                   export description='scaling factor: {{ workload_args.scaling_factor }} | threads: {{ workload_args.threads }} | clients: {{ clients }}';
                    echo '';
                    echo 'Running PGBench with {{ clients }} clients on database {{ item.1.host }}/{{ item.1.db_name }}';
                    for i in `seq 1 {{ workload_args.samples|int }}`; do

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -35,20 +35,16 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-pgbench") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -45,22 +45,18 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("openshift-cluster-timings") }}"
           - name: es_verify_cert
             value: "{{ elasticsearch.cert_verify | default("true") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -44,7 +44,7 @@ spec:
             value: "{{ clustername }}"
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("openshift-cluster-timings") }}"
           - name: es_verify_cert
@@ -54,7 +54,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -54,20 +54,16 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-smallfile") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -53,7 +53,7 @@ spec:
 {% endif %}
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-smallfile") }}"
           - name: parallel
@@ -61,7 +61,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -56,20 +56,16 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-stressng") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -55,7 +55,7 @@ spec:
 {% endif %}
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-stressng") }}"
           - name: parallel
@@ -63,7 +63,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token

--- a/roles/uperf/templates/configmap_script.yml.j2
+++ b/roles/uperf/templates/configmap_script.yml.j2
@@ -8,8 +8,8 @@ data:
   run_script.sh : |
     export h={{item.status.interfaces[0].ipAddress}}
 {% if elasticsearch is defined %}
-{% if elasticsearch.server is defined %}
-    export es={{elasticsearch.server}}
+{% if elasticsearch.url is defined %}
+    export es={{ elasticsearch.url }}
     export es_index={{ elasticsearch.index_name | default("ripsaw-uperf") }}
     export es_verify_cert={{ elasticsearch.verify_cert | default("true") }}
     export parallel={{ elasticsearch.parallel | default("false") }}

--- a/roles/uperf/templates/configmap_script.yml.j2
+++ b/roles/uperf/templates/configmap_script.yml.j2
@@ -10,7 +10,6 @@ data:
 {% if elasticsearch is defined %}
 {% if elasticsearch.server is defined %}
     export es={{elasticsearch.server}}
-    export es_port={{elasticsearch.port}}
     export es_index={{ elasticsearch.index_name | default("ripsaw-uperf") }}
     export es_verify_cert={{ elasticsearch.verify_cert | default("true") }}
     export parallel={{ elasticsearch.parallel | default("false") }}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -51,7 +51,7 @@ spec:
             value: "{{ clustername }}"
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-uperf") }}"
           - name: parallel
@@ -59,7 +59,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -52,20 +52,16 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-uperf") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -41,7 +41,7 @@ spec:
             value: "{{ clustername }}"
 {% if elasticsearch is defined %}
           - name: es
-            value: "{{ elasticsearch.server }}"
+            value: "{{ elasticsearch.url }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-vegeta") }}"
           - name: es_verify_cert
@@ -51,7 +51,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
-            value: "{{ prometheus.es_server }}"
+            value: "{{ prometheus.es_url }}"
           - name: prom_parallel
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -42,22 +42,18 @@ spec:
 {% if elasticsearch is defined %}
           - name: es
             value: "{{ elasticsearch.server }}"
-          - name: es_port
-            value: "{{ elasticsearch.port }}"
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-vegeta") }}"
           - name: es_verify_cert
             value: "{{ elasticsearch.cert_verify | default("true") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
             value: "{{ prometheus.es_server }}"
-          - name: prom_port
-            value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/ycsb/templates/ycsb_load.yaml
+++ b/roles/ycsb/templates/ycsb_load.yaml
@@ -34,7 +34,7 @@ spec:
           value: "{{uuid}}"
 {% if elasticsearch is defined %}
         - name: es
-          value: "{{ elasticsearch.server }}"
+          value: "{{ elasticsearch.url }}"
         - name: es_index
           value: "{{ elasticsearch.index_name | default("ripsaw-ycsb") }}"
         - name: parallel
@@ -42,7 +42,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
         - name: prom_es
-          value: "{{ prometheus.es_server }}"
+          value: "{{ prometheus.es_url }}"
         - name: prom_parallel
           value: "{{ prometheus.es_parallel | default(false) }}"
         - name: prom_token

--- a/roles/ycsb/templates/ycsb_load.yaml
+++ b/roles/ycsb/templates/ycsb_load.yaml
@@ -35,20 +35,16 @@ spec:
 {% if elasticsearch is defined %}
         - name: es
           value: "{{ elasticsearch.server }}"
-        - name: es_port
-          value: "{{ elasticsearch.port }}"
         - name: es_index
           value: "{{ elasticsearch.index_name | default("ripsaw-ycsb") }}"
         - name: parallel
-          value: "{{ elasticsearch.parallel | default("false") }}"
+          value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
         - name: prom_es
           value: "{{ prometheus.es_server }}"
-        - name: prom_port
-          value: "{{ prometheus.es_port }}"
         - name: prom_parallel
-          value: "{{ prometheus.es_parallel | default("false") }}"
+          value: "{{ prometheus.es_parallel | default(false) }}"
         - name: prom_token
           value: "{{ prometheus.prom_token | default() }}"
         - name: prom_url

--- a/roles/ycsb/templates/ycsb_run.yaml
+++ b/roles/ycsb/templates/ycsb_run.yaml
@@ -34,7 +34,7 @@ spec:
           value: "{{uuid}}"
 {% if elasticsearch is defined %}
         - name: es
-          value: "{{ elasticsearch.server }}"
+          value: "{{ elasticsearch.url }}"
         - name: es_index
           value: "{{ elasticsearch.index_name | default("ripsaw-ycsb") }}"
         - name: parallel
@@ -42,7 +42,7 @@ spec:
 {% endif %}
 {% if prometheus is defined %}
         - name: prom_es
-          value: "{{ prometheus.es_server }}"
+          value: "{{ prometheus.es_url }}"
         - name: prom_parallel
           value: "{{ prometheus.es_parallel | default(false) }}"
         - name: prom_token

--- a/roles/ycsb/templates/ycsb_run.yaml
+++ b/roles/ycsb/templates/ycsb_run.yaml
@@ -35,20 +35,16 @@ spec:
 {% if elasticsearch is defined %}
         - name: es
           value: "{{ elasticsearch.server }}"
-        - name: es_port
-          value: "{{ elasticsearch.port }}"
         - name: es_index
           value: "{{ elasticsearch.index_name | default("ripsaw-ycsb") }}"
         - name: parallel
-          value: "{{ elasticsearch.parallel | default("false") }}"
+          value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}
 {% if prometheus is defined %}
         - name: prom_es
           value: "{{ prometheus.es_server }}"
-        - name: prom_port
-          value: "{{ prometheus.es_port }}"
         - name: prom_parallel
-          value: "{{ prometheus.es_parallel | default("false") }}"
+          value: "{{ prometheus.es_parallel | default(false) }}"
         - name: prom_token
           value: "{{ prometheus.prom_token | default() }}"
         - name: prom_url

--- a/templates/metadata.yml.j2
+++ b/templates/metadata.yml.j2
@@ -11,7 +11,6 @@
             python3
             stockpile-wrapper.py
             -s={{ elasticsearch.server }}
-            -p={{ elasticsearch.port }}
             -u={{ uuid }}
             -n=${my_node_name}
             -N=${my_pod_name}

--- a/templates/metadata.yml.j2
+++ b/templates/metadata.yml.j2
@@ -26,6 +26,7 @@
         imagePullPolicy: Always
         securityContext:
           privileged: {{ metadata.privileged }}
+          runAsNonRoot: false
         env:
           - name: my_node_name
             valueFrom:

--- a/templates/metadata.yml.j2
+++ b/templates/metadata.yml.j2
@@ -10,7 +10,7 @@
           - >
             python3
             stockpile-wrapper.py
-            -s={{ elasticsearch.server }}
+            -s={{ elasticsearch.url }}
             -u={{ uuid }}
             -n=${my_node_name}
             -N=${my_pod_name}

--- a/test.sh
+++ b/test.sh
@@ -7,13 +7,12 @@ max_concurrent=3
 # Presetting test_choice to be blank. 
 test_choice=''
 
-while getopts p:t:s:x: flag
+while getopts p:t:s: flag
 do
     case "${flag}" in
         p) max_concurrent=${OPTARG};;
         t) test_choice=${OPTARG};;
         s) ES_SERVER=${OPTARG};;
-        x) ES_PORT=${OPTARG};;
     esac
 done
 
@@ -69,8 +68,7 @@ UUID=${NEW_UUID%-*}
 #Tag name
 tag_name="${NODE_NAME:-master}"
 
-sed -i "s/ES_SERVER/$ES_SERVER/g" tests/test_crs/*
-sed -i "s/ES_PORT/$ES_PORT/g" tests/test_crs/*
+sed -i "s#ES_SERVER#$ES_SERVER#g" tests/test_crs/*
 sed -i "s/sql-server/sql-server-$UUID/g" tests/mssql.yaml tests/test_crs/valid_hammerdb.yaml tests/test_hammerdb.sh
 sed -i "s/benchmarks.ripsaw.cloudbulldozer.io/benchmarks-$UUID.ripsaw.cloudbulldozer.io/g" resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
 sed -i "s/kind: Benchmark/kind: Benchmark-$UUID/g" resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -3,7 +3,7 @@
 ERRORED=false
 image_location=${RIPSAW_CI_IMAGE_LOCATION:-quay.io}
 image_account=${RIPSAW_CI_IMAGE_ACCOUNT:-rht_perf_ci}
-es_server=${ES_SERVER:-http://foo.esserver.com:9200}
+es_url=${ES_SERVER:-http://foo.esserver.com:9200}
 echo "using container image location $image_location and account $image_account"
 
 function populate_test_list {
@@ -303,7 +303,7 @@ function check_es() {
   local uuid=$1
   local index=${@:2}
   for my_index in $index; do
-    python3 tests/check_es.py -s $es_server -u $uuid -i $my_index \
+    python3 tests/check_es.py -s $es_url -u $uuid -i $my_index \
       || return 1
   done
 }

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -3,8 +3,7 @@
 ERRORED=false
 image_location=${RIPSAW_CI_IMAGE_LOCATION:-quay.io}
 image_account=${RIPSAW_CI_IMAGE_ACCOUNT:-rht_perf_ci}
-es_server=${ES_SERVER:-foo.esserver.com}
-es_port=${ES_PORT:-80}
+es_server=${ES_SERVER:-http://foo.esserver.com:9200}
 echo "using container image location $image_location and account $image_account"
 
 function populate_test_list {
@@ -304,7 +303,7 @@ function check_es() {
   local uuid=$1
   local index=${@:2}
   for my_index in $index; do
-    python3 tests/check_es.py -s $es_server -p $es_port -u $uuid -i $my_index \
+    python3 tests/check_es.py -s $es_server -u $uuid -i $my_index \
       || return 1
   done
 }

--- a/tests/test_crs/valid_backpack_daemonset.yaml
+++ b/tests/test_crs/valid_backpack_daemonset.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
   metadata:
     collection: true
     targeted: false

--- a/tests/test_crs/valid_backpack_daemonset.yaml
+++ b/tests/test_crs/valid_backpack_daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
   metadata:
     collection: true
     targeted: false

--- a/tests/test_crs/valid_backpack_init.yaml
+++ b/tests/test_crs/valid_backpack_init.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
   metadata:
     collection: true
     privileged: true

--- a/tests/test_crs/valid_backpack_init.yaml
+++ b/tests/test_crs/valid_backpack_init.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
   metadata:
     collection: true
     privileged: true

--- a/tests/test_crs/valid_byowl.yaml
+++ b/tests/test_crs/valid_byowl.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
   metadata:
     collection: true
   workload:

--- a/tests/test_crs/valid_byowl.yaml
+++ b/tests/test_crs/valid_byowl.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
   metadata:
     collection: true
   workload:

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-fio
   metadata:
     collection: true

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-fio
   metadata:
     collection: true

--- a/tests/test_crs/valid_fiod_bsrange.yaml
+++ b/tests/test_crs/valid_fiod_bsrange.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-fio
   metadata:
     collection: true

--- a/tests/test_crs/valid_fiod_bsrange.yaml
+++ b/tests/test_crs/valid_fiod_bsrange.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-fio
   metadata:
     collection: true

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-fio
   metadata:
     collection: true

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-fio
   metadata:
     collection: true

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -9,7 +9,7 @@ spec:
   clustername: test_ci
   # where elastic search is running
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-fs-drift
   metadata:
     collection: true

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -10,7 +10,6 @@ spec:
   # where elastic search is running
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-fs-drift
   metadata:
     collection: true

--- a/tests/test_crs/valid_fs_drift_hostpath.yaml
+++ b/tests/test_crs/valid_fs_drift_hostpath.yaml
@@ -9,7 +9,7 @@ spec:
   clustername: test_ci
   # where elastic search is running
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-fs-drift
   metadata:
     collection: true

--- a/tests/test_crs/valid_fs_drift_hostpath.yaml
+++ b/tests/test_crs/valid_fs_drift_hostpath.yaml
@@ -10,7 +10,6 @@ spec:
   # where elastic search is running
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-fs-drift
   metadata:
     collection: true

--- a/tests/test_crs/valid_hammerdb.yaml
+++ b/tests/test_crs/valid_hammerdb.yaml
@@ -5,14 +5,14 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-hammerdb
   metadata:
     collection: true
   workload:
     name: "hammerdb"
     args:
-      image: "quay.io/mkarg/hammerdb:latest"
+      # image: "quay.io/mkarg/hammerdb:latest"
       db_type: "mssql"
       timed_test: true
       test_type: "tpc-c"

--- a/tests/test_crs/valid_hammerdb.yaml
+++ b/tests/test_crs/valid_hammerdb.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-hammerdb
   metadata:
     collection: true

--- a/tests/test_crs/valid_iperf3.yaml
+++ b/tests/test_crs/valid_iperf3.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
   metadata:
     collection: true
   workload:

--- a/tests/test_crs/valid_iperf3.yaml
+++ b/tests/test_crs/valid_iperf3.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
   metadata:
     collection: true
   workload:

--- a/tests/test_crs/valid_kube-burner.yaml
+++ b/tests/test_crs/valid_kube-burner.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
   metadata:
     collection: true
   prometheus:

--- a/tests/test_crs/valid_kube-burner.yaml
+++ b/tests/test_crs/valid_kube-burner.yaml
@@ -6,11 +6,11 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
   metadata:
     collection: true
   prometheus:
-    es_server: http://ES_SERVER
+    es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:

--- a/tests/test_crs/valid_pgbench.yaml
+++ b/tests/test_crs/valid_pgbench.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-pgbench
   metadata:
     collection: true

--- a/tests/test_crs/valid_pgbench.yaml
+++ b/tests/test_crs/valid_pgbench.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-pgbench
   metadata:
     collection: true

--- a/tests/test_crs/valid_scale_down.yaml
+++ b/tests/test_crs/valid_scale_down.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: openshift-cluster-timings
   workload:
     name: scale_openshift

--- a/tests/test_crs/valid_scale_down.yaml
+++ b/tests/test_crs/valid_scale_down.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: openshift-cluster-timings
   workload:
     name: scale_openshift

--- a/tests/test_crs/valid_scale_up.yaml
+++ b/tests/test_crs/valid_scale_up.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: openshift-cluster-timings
   workload:
     name: scale_openshift

--- a/tests/test_crs/valid_scale_up.yaml
+++ b/tests/test_crs/valid_scale_up.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: openshift-cluster-timings
   workload:
     name: scale_openshift

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -9,7 +9,7 @@ spec:
   clustername: test_ci
   # where elastic search is running
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-smallfile
   metadata:
     collection: true

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -10,7 +10,6 @@ spec:
   # where elastic search is running
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-smallfile
   metadata:
     collection: true

--- a/tests/test_crs/valid_smallfile_hostpath.yaml
+++ b/tests/test_crs/valid_smallfile_hostpath.yaml
@@ -10,7 +10,6 @@ spec:
   clustername: test_ci
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-smallfile
   metadata:
     collection: true

--- a/tests/test_crs/valid_smallfile_hostpath.yaml
+++ b/tests/test_crs/valid_smallfile_hostpath.yaml
@@ -9,7 +9,7 @@ spec:
   # to separate this test run from everyone else's
   clustername: test_ci
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-smallfile
   metadata:
     collection: true

--- a/tests/test_crs/valid_stressng.yaml
+++ b/tests/test_crs/valid_stressng.yaml
@@ -5,8 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
-    port: ES_PORT
+    url: ES_SERVER
     index_name: ripsaw-stressng
   metadata:
     collection: true

--- a/tests/test_crs/valid_sysbench.yaml
+++ b/tests/test_crs/valid_sysbench.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
   metadata:
     collection: true
   workload:

--- a/tests/test_crs/valid_sysbench.yaml
+++ b/tests/test_crs/valid_sysbench.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
   metadata:
     collection: true
   workload:

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-uperf
   metadata:
     collection: true

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-uperf
   metadata:
     collection: true

--- a/tests/test_crs/valid_uperf_networkpolicy.yaml
+++ b/tests/test_crs/valid_uperf_networkpolicy.yaml
@@ -5,8 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
-    port: ES_PORT
+    url: ES_SERVER
     index_name: ripsaw-uperf
   metadata:
     collection: true

--- a/tests/test_crs/valid_uperf_resources.yaml
+++ b/tests/test_crs/valid_uperf_resources.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-uperf
   metadata:
     collection: true

--- a/tests/test_crs/valid_uperf_resources.yaml
+++ b/tests/test_crs/valid_uperf_resources.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-uperf
   metadata:
     collection: true

--- a/tests/test_crs/valid_uperf_serviceip.yaml
+++ b/tests/test_crs/valid_uperf_serviceip.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-uperf
   metadata:
     collection: true

--- a/tests/test_crs/valid_uperf_serviceip.yaml
+++ b/tests/test_crs/valid_uperf_serviceip.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-uperf
   metadata:
     collection: true

--- a/tests/test_crs/valid_vegeta.yaml
+++ b/tests/test_crs/valid_vegeta.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-vegeta
   metadata:
     collection: true

--- a/tests/test_crs/valid_vegeta.yaml
+++ b/tests/test_crs/valid_vegeta.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-vegeta
   metadata:
     collection: true

--- a/tests/test_crs/valid_vegeta_hostnetwork.yaml
+++ b/tests/test_crs/valid_vegeta_hostnetwork.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-vegeta
   metadata:
     collection: true

--- a/tests/test_crs/valid_vegeta_hostnetwork.yaml
+++ b/tests/test_crs/valid_vegeta_hostnetwork.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-vegeta
   metadata:
     collection: true

--- a/tests/test_crs/valid_ycsb-mongo.yaml
+++ b/tests/test_crs/valid_ycsb-mongo.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ES_SERVER
+    url: ES_SERVER
     index_name: ripsaw-ycsb
   metadata:
     collection: true

--- a/tests/test_crs/valid_ycsb-mongo.yaml
+++ b/tests/test_crs/valid_ycsb-mongo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   elasticsearch:
     server: ES_SERVER
-    port: ES_PORT
     index_name: ripsaw-ycsb
   metadata:
     collection: true


### PR DESCRIPTION
…tion.

With this change, the ElasticSearch URL should be passed through the variable elasticsearch.url and prometheus.es_url.
Further changes will be required in [benchmark-wrapper](https://github.com/cloud-bulldozer/benchmark-wrapper/pull/219), [e2e-benchmarking](https://github.com/cloud-bulldozer/e2e-benchmarking/pull/61)

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>