### PR TITLE
Fixing doc and kube-burner cr for updated prometheus.es_server

### DIFF
--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -75,14 +75,14 @@ kube-burner is able to collect complex prometheus metrics and index them in a El
 ```yaml
 spec:
   prometheus:
-    server: https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com:443
+    es_server: https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com:443
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     prom_token: prometheusToken
   workload:
 ```
 
 Where:
-- server: Points to a valid ElasticSearch endpoint. Full URL format required. i.e. https://elastic.instance.apps.com:9200
+- es_server: Points to a valid ElasticSearch endpoint. Full URL format required. i.e. https://elastic.instance.apps.com:9200
 - prom_url: Points to a valid Prometheus endpoint. Full URL format required. i.e https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
 - prom_token: Refers to a valid prometheus token. It can be obtained with: `oc -n openshift-monitoring sa get-token prometheus-k8s`
 

--- a/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
@@ -10,7 +10,7 @@ spec:
     port: <ES_PORT>
   prometheus:
     # Elastic search instance with full URL format. https://elastic.apps.org:9200
-    server: <ES_URL>
+    es_server: <ES_URL>
     # Prometheus bearer token
     prom_token: <PROMETHEUS_BEARER_TOKEN>
     # Prometheus URL with full URL format. https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091


### PR DESCRIPTION
Fixing doc and kube-burner cr for updated prometheus.es_server. These were missed w/ the last PR