### PR TITLE
container_memory_rss instead memory_usage.

### DIFF
--- a/roles/kube-burner/files/metrics-aggregated.yaml
+++ b/roles/kube-burner/files/metrics-aggregated.yaml
@@ -11,13 +11,13 @@ metrics:
   - query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH"}[5m])) by (le, verb)) > 0
     metricName: API99thLatency
 
-  - query: sum(container_memory_usage_bytes{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler)"}) by (pod, namespace, node) and on (node) kube_node_role{role="master"}
+  - query: sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler)"}) by (pod, namespace, node) and on (node) kube_node_role{role="master"}
     metricName: podMemory-Masters
 
-  - query: avg(container_memory_usage_bytes{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"} and on (node) kube_node_role{role="worker"}) by (container, namespace)
+  - query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"} and on (node) kube_node_role{role="worker"}) by (container, namespace)
     metricName: containerMemory-AggregatedWorkers
 
-  - query: avg(container_memory_usage_bytes{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring)"} and on (node) kube_node_role{role="infra"}) by (container, namespace)
+  - query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring)"} and on (node) kube_node_role{role="infra"}) by (container, namespace)
     metricName: containerMemory-AggregatedInfra
 
   - query: avg(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100 and on (node) kube_node_role{role="worker"})
@@ -41,7 +41,7 @@ metrics:
   - query: (avg((sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
     metricName: nodeCPU-AggregatedInfra
 
-  - query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)"))
+  - query: avg(node_memory_MemAvailable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
     metricName: nodeMemoryAvailable-Masters
 
   - query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
@@ -50,7 +50,7 @@ metrics:
   - query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
     metricName: nodeMemoryAvailable-AggregatedInfra
 
-  - query: avg(node_memory_Active_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)"))
+  - query: avg(node_memory_Active_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
     metricName: nodeMemoryActive-Masters
 
   - query: avg(node_memory_Active_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
@@ -131,6 +131,9 @@ metrics:
   - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
     metricName: etcdLeaderChangesRate
 
+  - query: etcd_server_is_leader > 0
+    metricName: etcdServerIsLeader
+
   - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
     metricName: 99thEtcdDiskBackendCommitDurationSeconds
 
@@ -152,9 +155,11 @@ metrics:
   - query: count(kube_configmap_info{})
     metricName: configmapCount
 
+  - query: count(kube_service_info{})
+    metricName: serviceCount
+
   - query: kube_node_role{role="master"}
     metricName: nodeRoles
 
   - query: sum(kube_node_status_condition{status="true"}) by (condition)
     metricName: nodeStatus
-

--- a/roles/kube-burner/files/metrics.yaml
+++ b/roles/kube-burner/files/metrics.yaml
@@ -5,20 +5,20 @@ metrics:
   - query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH"}[5m])) by (le, verb)) > 0
     metricName: API99thLatency
 
-  - query: sum(container_memory_usage_bytes{name!="",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler)"}) by (pod, namespace, node)
+  - query: sum(container_memory_rss{name!="",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler)"}) by (pod, namespace, node)
     metricName: podMemory
 
-  - query: sum(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100) by (node)
-    metricName: top10KubeletCPU
+  - query: topk(3,sum(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100) by (node))
+    metricName: top3KubeletCPU
 
-  - query: topk(10,sum(process_resident_memory_bytes{service="kubelet",job="kubelet"}) by (node))
-    metricName: top10KubeletMemory
+  - query: topk(3,sum(process_resident_memory_bytes{service="kubelet",job="kubelet"}) by (node))
+    metricName: top3KubeletMemory
 
-  - query: sum(irate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m]) * 100) by (node)
-    metricName: top10CrioCPU
+  - query: topk(3,sum(irate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m]) * 100) by (node))
+    metricName: top3CrioCPU
 
-  - query: topk(10,sum(process_resident_memory_bytes{service="kubelet",job="crio"}) by (node))
-    metricName: top10CrioMemory
+  - query: topk(3,sum(process_resident_memory_bytes{service="kubelet",job="crio"}) by (node))
+    metricName: top3CrioMemory
 
   - query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0
     metricName: nodeCPU
@@ -53,11 +53,11 @@ metrics:
   - query: node_nf_conntrack_entries
     metricName: nodeConntrackEntries
 
-  - query: etcd_server_has_leader
-    metricName: etcdServerHasLeader
-
   - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
     metricName: etcdLeaderChangesRate
+
+  - query: etcd_server_is_leader > 0
+    metricName: etcdServerIsLeader
 
   - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
     metricName: 99thEtcdDiskBackendCommitDurationSeconds
@@ -79,6 +79,9 @@ metrics:
 
   - query: count(kube_configmap_info{})
     metricName: configmapCount
+
+  - query: count(kube_service_info{})
+    metricName: serviceCount
 
   - query: kube_node_role
     metricName: nodeRoles

--- a/roles/kube-burner/tasks/main.yml
+++ b/roles/kube-burner/tasks/main.yml
@@ -67,7 +67,7 @@
           namespace: "{{ operator_namespace }}"
         data:
           config.yml: "{{ lookup('template', 'kubelet-density.yml.j2')}}"
-          metrics.yaml: "{{ lookup('file', 'metrics.yaml')}}"
+          metrics.yaml: "{{ lookup('file', workload_args.metrics_profile|default('metrics.yaml')) }}"
           pod.yml: "{{ lookup('file', 'pod.yml')}}"
     when: workload_args.workload == "kubelet-density"
 
@@ -81,7 +81,7 @@
           namespace: "{{ operator_namespace }}"
         data:
           config.yml: "{{ lookup('template', 'kubelet-density-heavy.yml.j2')}}"
-          metrics.yaml: "{{ lookup('file', 'metrics.yaml')}}"
+          metrics.yaml: "{{ lookup('file', workload_args.metrics_profile|default('metrics.yaml')) }}"
           app-deployment.yml: "{{ lookup('file', 'app-deployment.yml')}}"
           postgres-deployment.yml: "{{ lookup('file', 'postgres-deployment.yml')}}"
           postgres-service.yml: "{{ lookup('file', 'postgres-service.yml')}}"


### PR DESCRIPTION
Several changes in kube-burner metrics:
- kubelet-density and kubelet-density-heavy didn't allow selecting metric profile
- Add services count
- Add etcd is leader
- Replace top10 by top3 to cut down number of indexed documents

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>