### PR TITLE
Fix global overrides

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -56,6 +56,11 @@ spec:
                 items:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+              global_overrides:
+                type: array
+                items:
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
               metadata:
                 default: {}
                 properties:

--- a/tests/test_backpack.sh
+++ b/tests/test_backpack.sh
@@ -34,7 +34,7 @@ function functional_test_backpack {
     wait_for "kubectl -n my-ripsaw  wait --for=condition=complete -l app=byowl-$uuid jobs --timeout=500s" "500s" $byowl_pod
   fi
   
-  indexes="cpu_vulnerabilities-metadata cpuinfo-metadata dmidecode-metadata k8s_configmaps-metadata k8s_namespaces-metadata k8s_nodes-metadata k8s_pods-metadata lspci-metadata meminfo-metadata sysctl-metadata"
+  indexes="cpu_vulnerabilities-metadata cpuinfo-metadata dmidecode-metadata k8s_nodes-metadata lspci-metadata meminfo-metadata sysctl-metadata ocp_network_operator-metadata ocp_install_config-metadata ocp_kube_apiserver-metadata ocp_dns-metadata ocp_kube_controllermanager-metadata"
   if check_es "${long_uuid}" "${indexes}"
   then
     echo "Backpack test: Success"


### PR DESCRIPTION
Global_overrides was not present in the Benchmark CRD, so the parameters from this option vanish when creating the benchmark.

On the other hand, this is a quick fix for this. As a long term fix we should nest job_params, global_overrides among others under workload.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>