### PR TITLE
Byowl Taint and Toleration

### DIFF
--- a/docs/byowl.md
+++ b/docs/byowl.md
@@ -14,12 +14,31 @@ metadata:
   name: byowl-benchmark
   namespace: my-ripsaw
 spec:
-  byowl:
-    image: "quay.io/jtaleric/uperf:testing"
-    clients: 1
-    commands: |
-      echo "This is my test workload";
-      echo "This is my test workload again..."
+  workload:
+    name: byowl
+    args:
+      image: "quay.io/me/myawesomebenchmarkimage"
+      clients: 1
+      commands: "echo Test"
+```
+
+
+### NodeSelector and Taint/Tolerations
+
+You can add a node selector and/or taints/tolerations to the resulting Kubernetes resources like so:
+
+```yaml
+spec:
+  workload:
+    name: byowl
+    args:
+      nodeselector:
+        foo: bar
+      tolerations:
+      - key: "taint-to-tolerate"
+        operator: "Exists"
+        effect: "NoSchedule"
+
 ```
 
 This will launch the uperf container, and simply print the messages

--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -18,7 +18,7 @@ spec:
         image: "{{ workload_args.image }}"
         imagePullPolicy: Always
       restartPolicy: OnFailure
-{% if workload_args.tolerations is defined %}
+{% if workload_args.nodeselector is defined %}
       nodeSelector: 
 {% for label, value in  workload_args.nodeselector.items() %}
         {{ label | replace ("_", "-" )}}:{{ value }}

--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -18,8 +18,14 @@ spec:
         image: "{{ workload_args.image }}"
         imagePullPolicy: Always
       restartPolicy: OnFailure
-{% if workload_args.nodeselector is defined %}
+{% if workload_args.tolerations is defined %}
       nodeSelector: 
-        {{ workload_args.nodeselector }}
+{% for label, value in  workload_args.nodeselector.items() %}
+        {{ label | replace ("_", "-" )}}:{{ value }}
+{% endfor %}
+{% endif  %}
+{% if workload_args.tolerations is defined %}
+      tolerations:
+        {{ workload_args.tolerations }}
 {% endif %}
 {% include "metadata.yml.j2" %}


### PR DESCRIPTION
Changes:

* Fixes issue with nodeSelectors not being able to take in hyphenated labels (i.e. node-role.kubernetes.io/master) due to jinja2 forcing yaml keys to not have hyphens.
* Adds tolerations to workload_args which can take in a list of tolerations