### PR TITLE
adding fio nodeselector and tolerations with docs

### DIFF
--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -32,7 +32,6 @@ spec:
       prefill: true
       samples: 3
       servers: 3
-      pin_server: ''
       # Chose to run servers in 'pod' or 'vm'
       # 'vm' needs kubevirt to be available
       # Default: pod
@@ -105,7 +104,7 @@ spec:
         effect: "NoSchedule"
 ```
 
-> Note: Usage of `nodeselector` is not compatible with usage of `pin_server`. You must only use one. You can get the same behavior of pin_server with a node selector by doing this:
+> Note: The implementation of `nodeselector` has led to the deprecation of `pin_server`. You must only use `nodeslector`. You can get the same behavior of pin_server with a node selector by doing this:
 
 ```yaml
 nodeselector:
@@ -179,8 +178,7 @@ The workload loops are nested as such from the CR options:
 
 - **samples**: Number of times to run the exact same workload. This is the innermost loop, as [described above](#workload-loops)
 - **servers**: Number of fio servers that will run the specified workload concurrently
-- **pin_server**: K8S node name (per `kubectl get nodes`) on which to run server pods
-  > Note: Providing a node name to `pin_server` will result in *all* server pods running on the specified node.
+- **nodeselector**: K8S node selector (per `kubectl get nodes`) on which to run server pods
 - **jobs**: (list) fio job types to run, per `fio(1)` valid values for the `readwrite` option
   > Note: Under most circumstances, a `write` job should be provided as the first list item for `jobs`. This will
   > ensure that subsequent jobs in the list can use the files created by the `write` job instead of needing

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -88,6 +88,29 @@ spec:
 #        - key=value
 ```
 
+### NodeSelector and Taint/Tolerations vs. pin server
+
+You can add a node selector and/or taints/tolerations to the resulting Kubernetes resources like so:
+
+```yaml
+spec:
+  workload:
+    name: fio_distributed
+    args:
+      nodeselector:
+        foo: bar
+      tolerations:
+      - key: "taint-to-tolerate"
+        operator: "Exists"
+        effect: "NoSchedule"
+```
+
+> Note: Usage of `nodeselector` is not compatible with usage of `pin_server`. You must only use one. You can get the same behavior of pin_server with a node selector by doing this:
+
+```yaml
+nodeselector:
+  kubernetes.io/hostname: 'SERVER_TO_PIN'
+```
 ### Workload Loops
 
 The options provided in the CR file are designed to allow for a nested set of job execution loops.

--- a/roles/fio_distributed/templates/servers.yaml
+++ b/roles/fio_distributed/templates/servers.yaml
@@ -46,10 +46,7 @@ spec:
 {% endif %}
       restartPolicy: Never
       serviceAccountName: benchmark-operator
-{% if workload_args.pin_server|default('') %}
-      nodeSelector:
-        kubernetes.io/hostname: '{{ workload_args.pin_server }}'
-{% elif workload_args.nodeselector is defined %}
+{% if workload_args.nodeselector is defined %}
       nodeSelector: 
 {% for label, value in  workload_args.nodeselector.items() %}
         {{ label | replace ("_", "-" )}}:{{ value }}

--- a/roles/fio_distributed/templates/servers.yaml
+++ b/roles/fio_distributed/templates/servers.yaml
@@ -49,6 +49,15 @@ spec:
 {% if workload_args.pin_server|default('') %}
       nodeSelector:
         kubernetes.io/hostname: '{{ workload_args.pin_server }}'
+{% elif workload_args.nodeselector is defined %}
+      nodeSelector: 
+{% for label, value in  workload_args.nodeselector.items() %}
+        {{ label | replace ("_", "-" )}}:{{ value }}
+{% endfor %}
+{% endif  %}
+{% if workload_args.tolerations is defined %}
+      tolerations:
+        {{ workload_args.tolerations }}
 {% endif %}
 {% if workload_args.storageclass is defined %}
       volumes:


### PR DESCRIPTION
Changes:

* Fio workloads will be able to add generic node selectors as well as generic tolerations
* The `pin_server` arg will be removed, but the feature is still available by using the `nodeselector` with the `kubernetes.io/hostname` label