### PR TITLE
Add ConfigMaps to cluster-density kube-burner tests

### DIFF
--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -19,11 +19,12 @@ Each iteration of this workload creates the following objects:
   - 12 imagestreams
   - 3 buidconfigs
   - 6 builds
-  - 1 deployment with 2 pod replicas (sleep) mounting two secrets each. *deployment-2pod*
-  - 2 deployments with 1 pod replicas (sleep) mounting two secrets. *deployment-1pod*
+  - 1 deployment with 2 pod replicas (sleep) mounting two secrets and two configmaps each. *deployment-2pod*
+  - 2 deployments with 1 pod replicas (sleep) mounting two secrets and two configmaps. *deployment-1pod*
   - 3 services, one pointing to *deployment-2pod*, and other two pointing to *deployment-1pod*.
   - 3 route. 1 pointing to the service *deployment-2pod* and other two pointing to *deployment-1pod*
-  - 20 secrets
+  - 10 secrets
+  - 10 configmaps
 
 - **kubelet-density**: Creates a single namespace with a number of Deployments equal to **job_iterations**.
 Each iteration of this workload creates the following object:

--- a/roles/kube-burner/files/configmap.yml
+++ b/roles/kube-burner/files/configmap.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.JobName}}-{{.Replica}}-{{.UUID}}
+data:
+  key1: "3"
+  key2: "value"

--- a/roles/kube-burner/files/deployment.yml
+++ b/roles/kube-burner/files/deployment.yml
@@ -25,6 +25,10 @@ spec:
           mountPath: /secret1
         - name: secret-2
           mountPath: /secret2
+        - name: configmap-1
+          mountPath: /configmap1
+        - name: configmap-2
+          mountPath: /configmap2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -46,6 +50,12 @@ spec:
       - name: secret-2
         secret:
           secretName: {{.JobName}}-2-{{.UUID}}
+      - name: configmap-1
+        configMap:
+          name: {{.JobName}}-1-{{.UUID}}
+      - name: configmap-2
+        configMap:
+          name: {{.JobName}}-2-{{.UUID}}
       # Add not-ready/unreachable tolerations for 15 minutes so that node
       # failure doesn't trigger pod deletion.
       tolerations:

--- a/roles/kube-burner/tasks/main.yml
+++ b/roles/kube-burner/tasks/main.yml
@@ -55,6 +55,7 @@
           route.yml: "{{ lookup('file', 'route.yml')}}"
           secret.yml: "{{ lookup('file', 'secret.yml')}}"
           service.yml: "{{ lookup('file', 'service.yml')}}"
+          configmap.yml: "{{ lookup('file', 'configmap.yml')}}"
     when: workload_args.workload == "cluster-density"
 
   - name: Create kubelet-density configmaps

--- a/roles/kube-burner/templates/cluster-density.yml.j2
+++ b/roles/kube-burner/templates/cluster-density.yml.j2
@@ -102,4 +102,8 @@ jobs:
           name: deployment-1pod
 
       - objectTemplate: secret.yml
-        replicas: 20
+        replicas: 10
+
+      - objectTemplate: configmap.yml
+        replicas: 10
+


### PR DESCRIPTION
It is common in production deployments for pods in deployments to use
ConfigMaps. We should try to replicate that.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>