### PR TITLE
Update node selector in stressng job spec

### DIFF
--- a/docs/stressng.md
+++ b/docs/stressng.md
@@ -49,7 +49,7 @@ Looking at the stressors individually:
 | runtype               | parallel or sequential                                        |
 | timeout               | time for the stressors to run                                 | 
 | instances             | number of instances (pods) to run                             |
-| nodeselector          | label for nodes on whiche the stressor pods will run          | 
+| nodeselector          | label for nodes on which the stressor pods will run           |
 | cpu_stressors         | number of cpu stressors                                       |
 | cpu_percentage        | percentage at which the stressor will run, e.g. 70% of a CPU  |
 | vm_stressors          | number of vm stressors                                        |

--- a/resources/crds/ripsaw_v1alpha1_stressng_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_stressng_cr.yaml
@@ -18,6 +18,8 @@ spec:
       timeout: "30"
       instances: 1
       # nodeselector:
+      #   key1: value1
+      #   key2: value2
       # cpu stressor options
       cpu_stressors: "1"
       cpu_percentage: "100"

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -12,14 +12,13 @@ spec:
       labels:
         app: stressng_workload-{{ trunc_uuid }}
     spec:
+{% if workload_args.nodeselector is defined %}
+      nodeSelector: {{ workload_args.nodeselector | to_json }}
+{% endif %}
       containers:
       - name: stressng
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/stressng:latest') }}
         imagePullPolicy: Always
-{% if workload_args.nodeselector is defined %}
-	nodeSelector:
-          "{{ workload_args.nodeselector }}"
-{% endif %}
         env:
           - name: uuid
             value: "{{ uuid }}"


### PR DESCRIPTION
Intendation for the nodeselector field in the stressng job template contained a hard tab, have updated to soft spaces like the rest of the template so the node selector is in the right level within the pod spec. Also converting the field to JSON to allow passing in a map of node selector key/value pairs similar to the vegeta workload.
 