### PR TITLE
Set writeable working directory for sysbench tests

### DIFF
--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -15,13 +15,17 @@ spec:
       containers:
       - name: sysbench
         command: ["/bin/sh", "-c"]
-        args: ["/tmp/sysbenchScript"]
+        args: ["cd /opt/sysbench && /tmp/sysbenchScript"]
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/sysbench:latest') }}
         imagePullPolicy: Always
         volumeMounts:
         - name: sysbench-volume
           mountPath: "/tmp/"
+        - name: sysbench-runtime
+          mountPath: "/opt/sysbench"
       volumes:
+      - name: sysbench-runtime
+        emptyDir: {}
       - name: sysbench-volume
         configMap:
           name: "sysbench-config-{{ trunc_uuid }}"


### PR DESCRIPTION
Adds a writeable emptyDir volume to use as working directory for sysbench so that fileio tests can complete.

Currently fileio tests fail as the container working directory is read only:
```bash
sysbench 1.0.17 (using system LuaJIT 2.1.0-beta3)

Running the test with following options:
Number of threads: 1
Initializing random number generator from current time


Extra file open flags: (none)
128 files, 16MiB each
2GiB total file size
Block size 16KiB
Periodic FSYNC enabled, calling fsync() each 100 requests.
Calling fsync() at the end of test, Enabled.
Using synchronous I/O mode
Doing sequential write (creation) test
FATAL: Cannot create file 'test_file.0' errno = 9 (Bad file descriptor)
````

After the change the fileio test completes:
```bash
sysbench 1.0.17 (using system LuaJIT 2.1.0-beta3)

128 files, 8192Kb each, 1024Mb total
Creating files for the test...
Extra file open flags: (none)
Creating file test_file.0
..
1073741824 bytes written in 7.06 seconds (144.97 MiB/sec).
..
Removing test files...
```
