### PR TITLE
Remove conntrack metrics

### DIFF
--- a/roles/kube-burner/files/metrics-aggregated.yaml
+++ b/roles/kube-burner/files/metrics-aggregated.yaml
@@ -1,6 +1,6 @@
 metrics:
-  - query: (sum(irate(container_cpu_usage_seconds_total{name!="",namespace=~"openshift-(etcd|oauth-apiserver|sdn|ovn-kubernetes|.*apiserver|authentication|.*controller-manager|.*scheduler)"}[2m]) * 100) by (pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
-    metricName: podCPU-Masters
+  - query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|sdn|ovn-kubernetes|.*apiserver|authentication|.*controller-manager|.*scheduler)"}[2m]) * 100) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
+    metricName: containerCPU-Masters
 
   - query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"}[2m]) * 100 and on (node) kube_node_role{role="worker"}) by (namespace, container)) > 0
     metricName: containerCPU-AggregatedWorkers
@@ -11,8 +11,8 @@ metrics:
   - query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH"}[5m])) by (le, verb)) > 0
     metricName: API99thLatency
 
-  - query: sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler)"}) by (pod, namespace, node) and on (node) kube_node_role{role="master"}
-    metricName: podMemory-Masters
+  - query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
+    metricName: containerMemory-Masters
 
   - query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"} and on (node) kube_node_role{role="worker"}) by (container, namespace)
     metricName: containerMemory-AggregatedWorkers
@@ -121,12 +121,6 @@ metrics:
 
   - query: avg(rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
     metricName: nodeDiskReadBytes-AggregatedInfra
-
-  - query: node_nf_conntrack_entries and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
-    metricName: nodeConntrackEntries-Workers
-
-  - query: node_nf_conntrack_entries and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
-    metricName: nodeConntrackEntries-Infra
 
   - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
     metricName: etcdLeaderChangesRate

--- a/roles/kube-burner/files/metrics.yaml
+++ b/roles/kube-burner/files/metrics.yaml
@@ -50,9 +50,6 @@ metrics:
   - query: rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m])
     metricName: nodeDiskReadBytes
 
-  - query: node_nf_conntrack_entries
-    metricName: nodeConntrackEntries
-
   - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
     metricName: etcdLeaderChangesRate
 

--- a/roles/kube-burner/templates/cluster-density.yml.j2
+++ b/roles/kube-burner/templates/cluster-density.yml.j2
@@ -14,7 +14,7 @@ global:
 {% endif %}
 
 jobs:
-  - name: cluster-density-{{ uuid }}
+  - name: cluster-density
     jobIterations: {{ workload_args.job_iterations }}
     qps: {{ workload_args.qps|default(5) }}
     burst: {{ workload_args.burst|default(10) }}

--- a/roles/kube-burner/templates/kubelet-density-heavy.yml.j2
+++ b/roles/kube-burner/templates/kubelet-density-heavy.yml.j2
@@ -14,7 +14,7 @@ global:
 {% endif %}
 
 jobs:
-  - name: kubelet-density-heavy-{{ uuid }}
+  - name: kubelet-density-heavy
     jobIterations: {{ workload_args.job_iterations }}
     qps: {{ workload_args.qps|default(5) }}
     burst: {{ workload_args.burst|default(10) }}

--- a/roles/kube-burner/templates/kubelet-density.yml.j2
+++ b/roles/kube-burner/templates/kubelet-density.yml.j2
@@ -14,7 +14,7 @@ global:
 {% endif %}
 
 jobs:
-  - name: kubelet-density-{{ uuid }}
+  - name: kubelet-density
     jobIterations: {{ workload_args.job_iterations }}
     qps: {{ workload_args.qps|default(5) }}
     burst: {{ workload_args.burst|default(10) }}


### PR DESCRIPTION
Remove conntrack metrics, and get per container CPU and memory metrics on master nodes.
Conntrack metrics are not useful in final reporting (this metric is more meaningful in real time as presented in the ocp performance-dashboard)

Per container CPU and memory metrics is useful to have more granularity and also improve benchmark-comparison.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>