### PR TITLE
Fix uperf hostNetwork and add test case for it

### DIFF
--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -66,14 +66,6 @@ spec:
 
 `networkpolicy` will create a simple networkpolicy for ingress
 
-*Note:* If you want to run with hostnetwork on `OpenShift`, you will need to execute the following:
-
-```bash
-
-$ oc adm policy add-scc-to-user privileged -z benchmark-operator
-
-```
-
 `pin` will allow the benchmark runner place nodes on specific nodes, using the `hostname` label.
 
 `pin_server` what node to pin the server pod to.

--- a/roles/iperf3/templates/client.yml.j2
+++ b/roles/iperf3/templates/client.yml.j2
@@ -14,7 +14,6 @@ spec:
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator
-      serviceAccount: benchmark-operator
 {% endif %}
       containers:
       - name: benchmark

--- a/roles/iperf3/templates/client_store.yml.j2
+++ b/roles/iperf3/templates/client_store.yml.j2
@@ -14,7 +14,6 @@ spec:
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator
-      serviceAccount: benchmark-operator
 {% endif %}
       containers:
       - name: benchmark

--- a/roles/iperf3/templates/server.yml.j2
+++ b/roles/iperf3/templates/server.yml.j2
@@ -14,7 +14,6 @@ spec:
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator
-      serviceAccount: benchmark-operator
 {% endif %}
       containers:
       - name: benchmark

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -23,7 +23,6 @@ spec:
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator
-      serviceAccount: benchmark-operator
 {% endif %}
       containers:
       - name: benchmark

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -22,6 +22,8 @@ spec:
 {% endif %}
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
+      serviceAccountName: benchmark-operator
+      serviceAccount: benchmark-operator
 {% endif %}
       containers:
       - name: benchmark

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -126,6 +126,6 @@ spec:
       restartPolicy: OnFailure
 {% if workload_args.pin is sameas true %}
       nodeSelector:
-          kubernetes.io/hostname: '{{ workload_args.pin_client }}'
+        kubernetes.io/hostname: '{{ workload_args.pin_client }}'
 {% endif %}
 {% include "metadata.yml.j2" %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -26,7 +26,6 @@ spec:
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator
-      serviceAccount: benchmark-operator
 {% endif %}
       affinity:
         podAntiAffinity:

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -13,7 +13,6 @@ spec:
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork : true
       serviceAccountName: benchmark-operator
-      serviceAccount: benchmark-operator
 {% endif %}
       affinity:
         podAntiAffinity:

--- a/tests/test_crs/valid_uperf_resources.yaml
+++ b/tests/test_crs/valid_uperf_resources.yaml
@@ -22,7 +22,7 @@ spec:
         requests:
           cpu: 100m
           memory: 100Mi
-      hostnetwork: false
+      hostnetwork: true
       serviceip: false
       pin: false
       pin_server: "node-0"

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -47,5 +47,5 @@ function functional_test_uperf {
 figlet $(basename $0)
 functional_test_uperf "Uperf without resources definition" tests/test_crs/valid_uperf.yaml
 functional_test_uperf "Uperf with ServiceIP" tests/test_crs/valid_uperf_serviceip.yaml
-functional_test_uperf "Uperf with resources definition" tests/test_crs/valid_uperf_resources.yaml
+functional_test_uperf "Uperf with resources definition and hostNetwork" tests/test_crs/valid_uperf_resources.yaml
 functional_test_uperf "Uperf with networkpolicy" tests/test_crs/valid_uperf_networkpolicy.yaml


### PR DESCRIPTION
The title says it all.
The benchmark-operator and backpack (this one is used in case of privileged metadata collection) SAs are already bound to the privileged SCC, so no further actions are required.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>