### PR TITLE
Update rook_ceph_drop_cache_pod.yaml

### DIFF
--- a/resources/rook_ceph_drop_cache_pod.yaml
+++ b/resources/rook_ceph_drop_cache_pod.yaml
@@ -10,7 +10,7 @@ spec:
     imagePullPolicy: Always
     command: [/bin/sh, -c]
     args:
-      - cd /opt/bohica/ceph-cache-dropper; python ./osd-cache-drop-websvc.py
+      - cd /opt/bohica/ceph-cache-dropper; python3 ./osd-cache-drop-websvc.py
     env:
       - name: ROOK_ADMIN_SECRET
         valueFrom:


### PR DESCRIPTION
Running the osd-cache-drop-websvc.py script with python is failing, modifying the container run args with python3 to fix the issue