### PR TITLE
Support elasticsearch.verify_cert for benchmark-wrapper

### DIFF
--- a/docs/elastic.md
+++ b/docs/elastic.md
@@ -18,6 +18,7 @@ elasticsearch:
   port: the elasticsearch server port
   parallel: enable parallel uploads to elasticsearch [default: false]
   index_name: the index name to use [default: workload defined]
+  verify_cert: disable elasticsearch certificate verification [default: true]
 ```
 
 *NOTE:* The only required parameters if using elasticsearch and the port and server. The others are optional and will be defaulted if not provided.

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -35,6 +35,8 @@ spec:
                     type: string
                   parallel:
                     type: boolean
+                  verify_cert:
+                    type: string
               prometheus:
                 type: object
                 properties:

--- a/roles/uperf/templates/configmap_script.yml.j2
+++ b/roles/uperf/templates/configmap_script.yml.j2
@@ -12,6 +12,7 @@ data:
     export es={{elasticsearch.server}}
     export es_port={{elasticsearch.port}}
     export es_index={{ elasticsearch.index_name | default("ripsaw-uperf") }}
+    export es_verify_cert={{ elasticsearch.verify_cert | default("true") }}
     export parallel={{ elasticsearch.parallel | default("false") }}
     export uuid={{uuid}}
 {% endif %}


### PR DESCRIPTION
Add option to disable certificate verification when connecting to Elasticsearch.
This functionality was already supported by benchmark-wrapper.
Using for ES clusters with self-signed certs.
