### PR TITLE
Remote configuration retrieval for kube-burner

### DIFF
--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -1,3 +1,13 @@
+- [Kube-burner](#kube-burner)
+  - [What is kube-burner?](#what-is-kube-burner)
+  - [Running kube-burner](#running-kube-burner)
+  - [Supported workloads](#supported-workloads)
+  - [Configuration](#configuration)
+  - [Metrics](#metrics)
+  - [Pin to server and tolerations](#pin-to-server-and-tolerations)
+  - [Using a remote configuration for kube-burner](#using-a-remote-configuration-for-kube-burner)
+
+
 # Kube-burner
 
 ## What is kube-burner?
@@ -125,4 +135,33 @@ workload:
     - key: role
       value: worker
       effect: NoSchedule
+```
+
+
+## Using a remote configuration for kube-burner
+
+Apart from the pre-defined workloads available in this integration with kube-burner, it's possible to make kube-burner to fetch a remote configuration file, from 
+a remote http server. This mechanism can be used by pointing the variable `remote_config` to the desired remote configuration file:
+
+
+```yaml
+workload:
+  args:
+    remote_config: https://your.domain.org/kube-burner-config.yaml
+```
+
+Keep in mind that the object templated declared in this remote configuration file need to be pointed to a remote source as well so that kube-burner will also be able to fetch them. i.e
+```yaml
+    objects:
+
+      - objectTemplate: https://your.domain.org/templates/pod.yml
+        replicas: 1
+```
+
+In addition to using remote configurations for kube-burner, it's also possible to use a remote metrics profile. It can be configured with the variable `remote_metrics_profile`
+
+```yaml
+workload:
+  args:
+    remote_metrics_profile: https://your.domain.org/metrics-profile.yaml
 ```

--- a/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
@@ -50,6 +50,10 @@ spec:
       step: 30s
       # kube-burner metrics profile
       metrics_profile: metrics.yaml
+      # Remote configuration file
+      # remote_config: http://yourdomain/kube-burner.yml
+      # Remote metrics profile
+      # remote_metrics_profile: http://yourdomain/metrics-profile.yml
       # kube-burner pod tolerations
       tolerations:
       - key: role

--- a/roles/kube-burner/tasks/main.yml
+++ b/roles/kube-burner/tasks/main.yml
@@ -37,6 +37,22 @@
 
 - block:
 
+  - name: Create metrics profile for remote configuration job
+    k8s:
+      definition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: kube-burner-config-{{ trunc_uuid }}
+          namespace: "{{ operator_namespace }}"
+        data:
+          metrics.yaml: "{{ lookup('file', workload_args.metrics_profile|default('metrics.yaml')) }}"
+    when: 
+      - workload_args.remote_config is defined
+      - workload_args.remote_config
+      - workload_args.remote_metrics_profile is not defined
+      - workload_args.remote_metrics_profile
+
   - name: Create cluster-density configmaps
     k8s:
       definition:

--- a/roles/kube-burner/templates/kube-burner.yml.j2
+++ b/roles/kube-burner/templates/kube-burner.yml.j2
@@ -26,11 +26,25 @@ spec:
         workingDir: /tmp/kube-burner
         command: ["/bin/sh", "-c"]
         args:
-{% if prometheus is defined and prometheus.prom_url is defined %}
-          - kube-burner init -c config.yml -m metrics.yaml -u {{ prometheus.prom_url }} -t {{ prometheus.prom_token }} --uuid={{ uuid }} --log-level={{ workload_args.log_level|default("info") }} --step={{ workload_args.step|default("30s") }}
+        - >
+          kube-burner init
+{% if workload_args.remote_config is defined and workload_args.remote_config %}
+          -c {{ workload_args.remote_config }}
 {% else %}
-          - kube-burner init -c config.yml --uuid={{ uuid }} --log-level={{ workload_args.log_level|default("info") }}
+          -c config.yml
 {% endif %}
+{% if prometheus is defined and prometheus.prom_url is defined %}
+          -u {{ prometheus.prom_url }}
+          -t {{ prometheus.prom_token }}
+          --step={{ workload_args.step|default("30s") }}
+{% if workload_args.remote_metrics_profile is defined and workload_args.remote_metrics_profile %}
+          -m {{ workload_args.remote_metrics_profile }}
+{% else %}
+          -m metrics.yaml
+{% endif %}
+{% endif %}
+          --uuid={{ uuid }}
+          --log-level={{ workload_args.log_level|default("info") }}
         volumeMounts:
           - name: kube-burner-config
             mountPath: /tmp/kube-burner


### PR DESCRIPTION
This PR enables kube-burner for remote config/metrics-profile retrieval.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>