### PR TITLE
Fix pinned server in uperf workload vm template. Courtesy of @jeniferh.

### DIFF
--- a/roles/uperf/templates/workload_vm.yml.j2
+++ b/roles/uperf/templates/workload_vm.yml.j2
@@ -47,7 +47,7 @@ spec:
   terminationGracePeriodSeconds: 0
 {% if workload_args.pin is sameas true %}
   nodeSelector:
-    kubernetes.io/hostname: '{{ workload_args.pin_server }}'
+    kubernetes.io/hostname: '{{ workload_args.pin_client }}'
 {% endif %}
   networks:
     - name: default


### PR DESCRIPTION
@jeniferh found uperf VM workload had same host pinned as server.
Thank you for finding this! 😃 