### PR TITLE
Revert "add image var in imagestream.yml"

### DIFF
--- a/roles/kube-burner/templates/cluster-density.yml.j2
+++ b/roles/kube-burner/templates/cluster-density.yml.j2
@@ -55,7 +55,6 @@ jobs:
         replicas: 6
         inputVars:
           prefix: cluster-density
-          image: quay.io/openshift-scale/mastervertical-build
 
       - objectTemplate: build.yml
         replicas: 6


### PR DESCRIPTION
Was fixed by https://github.com/cloud-bulldozer/benchmark-operator/pull/478, we don't need this change anymore