### PR TITLE
Add runtime-class option to remainder of benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,22 @@ a performance baseline of Kubernetes cluster on your provider.
 | Workload                       | Use                    | Status in Operator | Reconciliation usage       | VM support (kubevirt) | Kata Containers |
 | ------------------------------ | ---------------------- | ------------------ | -------------------------- | --------------------- | --------------- |
 | [UPerf](docs/uperf.md)         | Network Performance    | Working            |  Used, default : 3second  | Working                | Working         |
-| [Iperf3](docs/iperf.md)       | Network Performance    | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
+| [Iperf3](docs/iperf.md)       | Network Performance    | Working            |  Used, default : 3second  | Not Supported          | Preview         |
 | [fio](docs/fio_distributed.md) | Storage IO             | Working            |  Used, default : 3second  | Working                | Working         |
-| [Sysbench](docs/sysbench.md)   | System Performance     | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
-| [YCSB](docs/ycsb.md)           | Database Performance   | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
-| [Byowl](docs/byowl.md)         | User defined workload  | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
-| [Pgbench](docs/pgbench.md)     | Postgres Performance   | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
-| [Smallfile](docs/smallfile.md) | Storage IO Performance | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
-| [fs-drift](docs/fs-drift.md)   | Storage IO Longevity   | Working            |  Not used                 | Not Supported          | Not Supported   |
-| [hammerdb](docs/hammerdb.md)   | Database Performance   | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
-| [Service Mesh](docs/servicemesh.md) | Microservices     | Working            |  Used, default : 3second   | Not Supported         | Not Supported   |
-| [Vegeta](docs/vegeta.md)       | HTTP Performance       | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
-| [Scale Openshift](docs/scale_openshift.md) | Scale Openshift Cluster       | Working            |  Used, default : 3second  | Not Supported         | Not Supported  |
-| [stressng](docs/stressng.md)   | Stress system resources | Working            |  Used, default: 3second  | Not Supported         | Not Supported  |
-| [kube-burner](docs/kube-burner.md)  | k8s Performance   | Working            |  Used, default : 3second  | Not Supported          | Not Supported   |
-| [cyclictest](docs/cyclictest.md)  | Real-Time Performance   | Working       |  Used, default : 3second  | Not Supported          | Not Supported   |
-| [oslat](docs/oslat.md)         | Real-Time Latency      | Working           |  Used, default : 3second   | Not Supported          | Not Supported   |
+| [Sysbench](docs/sysbench.md)   | System Performance     | Working            |  Used, default : 3second  | Not Supported          | Preview         |
+| [YCSB](docs/ycsb.md)           | Database Performance   | Working            |  Used, default : 3second  | Not Supported          | Preview         |
+| [Byowl](docs/byowl.md)         | User defined workload  | Working            |  Used, default : 3second  | Not Supported          | Preview         |
+| [Pgbench](docs/pgbench.md)     | Postgres Performance   | Working            |  Used, default : 3second  | Not Supported          | Preview         |
+| [Smallfile](docs/smallfile.md) | Storage IO Performance | Working            |  Used, default : 3second  | Not Supported          | Preview         |
+| [fs-drift](docs/fs-drift.md)   | Storage IO Longevity   | Working            |  Not used                 | Not Supported          | Preview         |
+| [hammerdb](docs/hammerdb.md)   | Database Performance   | Working            |  Used, default : 3second  | Not Supported          | Preview         |
+| [Service Mesh](docs/servicemesh.md) | Microservices     | Working            |  Used, default : 3second   | Not Supported         | Preview         |
+| [Vegeta](docs/vegeta.md)       | HTTP Performance       | Working            |  Used, default : 3second  | Not Supported          | Preview         |
+| [Scale Openshift](docs/scale_openshift.md) | Scale Openshift Cluster       | Working            |  Used, default : 3second  | Not Supported         | Preview        |
+| [stressng](docs/stressng.md)   | Stress system resources | Working            |  Used, default: 3second  | Not Supported         | Preview        |
+| [kube-burner](docs/kube-burner.md)  | k8s Performance   | Working            |  Used, default : 3second  | Not Supported          | Preview         |
+| [cyclictest](docs/cyclictest.md)  | Real-Time Performance   | Working       |  Used, default : 3second  | Not Supported          | Preview         |
+| [oslat](docs/oslat.md)         | Real-Time Latency      | Working           |  Used, default : 3second   | Not Supported          | Preview         |
 
 
 

--- a/docs/byowl.md
+++ b/docs/byowl.md
@@ -23,9 +23,9 @@ spec:
 ```
 
 
-### NodeSelector and Taint/Tolerations
+### NodeSelector, Taint/Tolerations, and RuntimeClass
 
-You can add a node selector and/or taints/tolerations to the resulting Kubernetes resources like so:
+You can add a node selector, taints/tolerations, and/or runtimeclass to the resulting Kubernetes resources like so:
 
 ```yaml
 spec:
@@ -38,6 +38,7 @@ spec:
       - key: "taint-to-tolerate"
         operator: "Exists"
         effect: "NoSchedule"
+	  runtimeclassname: "MyRuntimeClass"
 
 ```
 

--- a/docs/fs-drift.md
+++ b/docs/fs-drift.md
@@ -49,6 +49,10 @@ The following fs-drift parameters will be overridden when fs-drift is used in ri
 The default value of **threads** parameter is 1, because we depend on creation of a large set of pods to distribute the
 workload across not only other cores, but also other hosts.  However, this can be increased if desired.
 
+The option **runtime_class** can be set to specify an optional
+runtime_class to the podSpec runtimeClassName.  This is primarily
+intended for Kata containers.
+
 Once done creating/editing the CR file below, one can run it by:
 
 ```bash

--- a/docs/hammerdb.md
+++ b/docs/hammerdb.md
@@ -47,6 +47,10 @@ The tpcc benchmark which we use can set up an arbitrary number of warehouses bet
 
 With `runtime`, `rampup` and `samples` the time for a single run, the rampup time per run and the number of runs can be controlled. 
 
+The option **runtime_class** can be set to specify an optional
+runtime_class to the podSpec runtimeClassName.  This is primarily
+intended for Kata containers.
+
 Once done creating/editing the resource file, you can run it by:
 
 ```bash

--- a/docs/iperf.md
+++ b/docs/iperf.md
@@ -35,7 +35,7 @@ spec:
     extra_options_server: ' '
     #retries: 200
 ```
-Optional argument:
+Optional arguments:
 `retries` is an optional argument that can be used if you are running long tests
 and don't want the logic to exit early, this is due to iperf logic using ansible's
 retries to wait for iperf client job to be finish running. Note that the delay is
@@ -45,6 +45,10 @@ an integer value.
 
 So for example: if you estimate a job to not take more than 900s,
 then you'd probably give a `retries` of 60, as 60*15 is 900s.
+
+`runtime_class` can be set to specify an optional
+runtime_class to the podSpec runtimeClassName.  This is primarily
+intended for Kata containers.
 
 The rest of the args are compulsory arguments that need to be passed and can cause
 issues if missed, they are:

--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -88,6 +88,7 @@ Where key defaults to __node-role.kubernetes.io/worker__ and value defaults to e
 - **pin_server** and **tolerations**: Detailed in the section [Pin to server and tolerations](#Pin-to-server-and-tolerations)
 - **step**: Prometheus step size, useful for long benchmarks. Defaults to 30s
 - **metrics_profile**: kube-burner metric profile that indicates what prometheus metrics kube-burner will collect. Defaults to `metrics.yaml` in kubelet-density workloads and `metrics-aggregated.yaml` in the remaining. Detailed in the [Metrics section](#Metrics) of this document
+- **runtime_class** : If this is set, the benchmark-operator will apply the runtime_class to the podSpec runtimeClassName.
 
 kube-burner is able to collect complex prometheus metrics and index them in a ElasticSearch instance. This feature can be configured by the prometheus object of kube-burner's CR.
 

--- a/docs/oslat.md
+++ b/docs/oslat.md
@@ -9,6 +9,10 @@ Given that you followed instructions to deploy operator, you can modify [cr.yaml
 It is recommended to define pod requests and limits when running oslat test, to give guaranteed CPUs to the pods. It is also expected to have the
 realtime kernel installed with required isolation for pods using the [Performance Add-On Operator](https://github.com/openshift-kni/performance-addon-operators).
 
+The option **runtime_class** can be set to specify an optional
+runtime_class to the podSpec runtimeClassName.  This is primarily
+intended for Kata containers.
+
 An example CR might look like this
 
 ```yaml

--- a/docs/pgbench.md
+++ b/docs/pgbench.md
@@ -74,6 +74,10 @@ The `log2` value will increment through a set of values on a log2 scale up to th
 
 Note that the `add2` and `log2` values may not end up testing 100% of the databases listed, since `add2` will always end on an even number and `log2` will always end on the highest integer on the log2 curve up to the total number of databases (i.e., if you provide 100 databases in the list, the last `log2` test will be against 64 databases since the next log2 value would be 128)
 
+The `runtime_class` option can be set to specify an optional
+runtime_class to the podSpec runtimeClassName.  This is primarily
+intended for Kata containers.
+
 Once done creating/editing the resource file, you can run it by:
 
 ```bash

--- a/docs/scale_openshift.md
+++ b/docs/scale_openshift.md
@@ -26,6 +26,8 @@ Optional variables:
 `tolerations` a dictionary consisting of a 'key', 'value' and 'effect'. If provided it will add a toleration
         for the matching key/value/effect
 
+`runtime_class` If this is set, the benchmark-operator will apply the runtime_class to the podSpec runtimeClassName.
+
 Your resource file may look like this when using all avaible options:
 
 ```yaml

--- a/docs/servicemesh.md
+++ b/docs/servicemesh.md
@@ -14,6 +14,12 @@ oc apply -f resources/self_provisioner_binding.yaml
 
 Service Mesh and Hyperfoil operators must be [already installed](https://docs.openshift.com/container-platform/4.4/operators/olm-adding-operators-to-cluster.html) to the cluster before the benchmark starts.
 
+## Optional setting
+
+The option **runtime_class** can be set to specify an optional
+runtime_class to the podSpec runtimeClassName.  This is primarily
+intended for Kata containers.
+
 ## Running the benchmark
 
 Here is an example of the [benchmark CR](../resources/crds/ripsaw_v1alpha1_servicemesh_cr.yaml):

--- a/docs/smallfile.md
+++ b/docs/smallfile.md
@@ -101,6 +101,7 @@ previous runs for example)
   lives in a different directory on the target hosts and the test-driver host.
  * **pause** -- integer (microseconds) each thread will wait before starting next
   file.
+ * **runtime_class** - If this is set, the benchmark-operator will apply the runtime_class to the podSpec runtimeClassName.
 
 
 Once done creating/editing the resource file, one can run it by:

--- a/docs/stressng.md
+++ b/docs/stressng.md
@@ -7,6 +7,10 @@
 Given that you followed instructions to deploy operator,
 you can modify [cr.yaml](../resources/crds/ripsaw_v1alpha1_stressng.yaml) to your needs.
 
+The optional argument **runtime_class** can be set to specify an
+optional runtime_class to the podSpec runtimeClassName.  This is
+primarily intended for Kata containers.
+
 An example CR might look like this
 
 ```yaml

--- a/docs/sysbench.md
+++ b/docs/sysbench.md
@@ -7,6 +7,10 @@
 Given that you followed instructions to deploy operator,
 you can modify [cr.yaml](../resources/crds/ripsaw_v1alpha1_sysbench_cr.yaml)
 
+The optional argument **runtime_class** can be set to specify an
+optional runtime_class to the podSpec runtimeClassName.  This is
+primarily intended for Kata containers.
+
 Note: please ensure you set 0 for other workloads if editing the
 [cr.yaml](../resources/crds/ripsaw_v1alpha1_sysbench_cr.yaml) file otherwise
 

--- a/docs/vegeta.md
+++ b/docs/vegeta.md
@@ -7,6 +7,10 @@
 Given that you followed instructions to deploy operator,
 you can modify Vegeta's [cr.yaml](../resources/crds/ripsaw_v1alpha1_vegeta_cr.yaml) to make it fit with your requirements.
 
+The option **runtime_class** can be set to specify an optional
+runtime_class to the podSpec runtimeClassName.  This is primarily
+intended for Kata containers.
+
 ```yaml
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark

--- a/docs/ycsb.md
+++ b/docs/ycsb.md
@@ -66,6 +66,7 @@ so that the ycsb pod can access the API of database.
 
 `pin_node` what node to pin the pod to.
 
+`runtime_class`: If this is set, the benchmark-operator will apply the runtime_class to the podSpec runtimeClassName.
 
 Once done creating/editing the resource file, you can run it by:
 

--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -11,6 +11,9 @@ spec:
       labels:
        app: byowl-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: byowl
         command: ["/bin/sh", "-c"]

--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -9,6 +9,9 @@ spec:
       labels:
         app: cyclictest-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       ttlSecondsAfterFinished: 600
       containers:
       - name: cyclictest

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -12,6 +12,9 @@ spec:
       labels:
         app: fs-drift-benchmark-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/roles/hammerdb/templates/db_creation.yml
+++ b/roles/hammerdb/templates/db_creation.yml
@@ -10,6 +10,9 @@ spec:
       labels:
         app: hammerdb_creator-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: hammerdb
         command: ["/bin/sh", "-c"]

--- a/roles/hammerdb/templates/db_mssql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mssql_workload.yml.j2
@@ -11,6 +11,9 @@ spec:
       labels:
         app: hammerdb_workload-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: hammerdb
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/hammerdb:master') }}

--- a/roles/hammerdb/templates/db_mysql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mysql_workload.yml.j2
@@ -11,6 +11,9 @@ spec:
       labels:
         app: hammerdb_workload-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: hammerdb
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/hammerdb:master') }}

--- a/roles/hammerdb/templates/db_postgres_workload.yml.j2
+++ b/roles/hammerdb/templates/db_postgres_workload.yml.j2
@@ -11,6 +11,9 @@ spec:
       labels:
         app: hammerdb_workload-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: hammerdb
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/hammerdb:master') }}

--- a/roles/iperf3/templates/client.yml.j2
+++ b/roles/iperf3/templates/client.yml.j2
@@ -11,6 +11,9 @@ spec:
       labels:
         app: iperf3-bench-client-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator

--- a/roles/iperf3/templates/client_store.yml.j2
+++ b/roles/iperf3/templates/client_store.yml.j2
@@ -11,6 +11,9 @@ spec:
       labels:
         app: iperf3-bench-client-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator

--- a/roles/iperf3/templates/server.yml.j2
+++ b/roles/iperf3/templates/server.yml.j2
@@ -11,6 +11,9 @@ spec:
       labels:
         app: iperf3-bench-server-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
       serviceAccountName: benchmark-operator

--- a/roles/kube-burner/templates/kube-burner.yml.j2
+++ b/roles/kube-burner/templates/kube-burner.yml.j2
@@ -12,6 +12,9 @@ spec:
       labels:
         app: kube-burner-benchmark-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       tolerations: {{ workload_args.tolerations|default([]) }}
       restartPolicy: Never
       serviceAccountName: kube-burner

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -9,6 +9,9 @@ spec:
       labels:
         app: oslat-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       ttlSecondsAfterFinished: 600
       containers:
       - name: oslat

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -11,6 +11,9 @@ spec:
       labels:
         app: pgbench-client-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: benchmark
         image: "{{ pgb_base_image }}:{{ pgb_version }}"

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -11,6 +11,9 @@ spec:
       labels:
         app: scale-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
 {% if workload_args.tolerations is defined %}
       tolerations:
       - key: {{ workload_args.tolerations.key }}

--- a/roles/servicemesh/templates/job.yaml.j2
+++ b/roles/servicemesh/templates/job.yaml.j2
@@ -11,6 +11,9 @@ spec:
       labels:
       app: "{{ meta.name }}-{{ trunc_uuid }}"
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: command
         image: "{{ hf_pod.resources[0].spec.containers[0].image }}"

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -12,6 +12,9 @@ spec:
       labels:
         app: smallfile-benchmark-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -12,6 +12,9 @@ spec:
       labels:
         app: stressng_workload-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
 {% if workload_args.nodeselector is defined %}
       nodeSelector: {{ workload_args.nodeselector | to_json }}
 {% endif %}

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -12,6 +12,9 @@ spec:
       labels:
        app: sysbench-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: sysbench
         command: ["/bin/sh", "-c"]

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -10,6 +10,9 @@ spec:
       labels:
         app: vegeta-benchmark-{{ trunc_uuid }}
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork : true
       serviceAccountName: benchmark-operator

--- a/roles/ycsb/templates/ycsb_load.yaml
+++ b/roles/ycsb/templates/ycsb_load.yaml
@@ -12,6 +12,9 @@ spec:
       labels:
         name: 'ycsb-load-{{ trunc_uuid }}'
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: ycsb
         image: "{{ workload_args.image | default('quay.io/cloud-bulldozer/ycsb-server:latest') }}"

--- a/roles/ycsb/templates/ycsb_run.yaml
+++ b/roles/ycsb/templates/ycsb_run.yaml
@@ -12,6 +12,9 @@ spec:
       labels:
         name: 'ycsb-run-{{ trunc_uuid }}'
     spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
       containers:
       - name: ycsb
         image: "{{ workload_args.image | default('quay.io/cloud-bulldozer/ycsb-server:latest') }}"


### PR DESCRIPTION
Add runtimeClassSupport (stable as of Kubernetes 1.20) to the remaining benchmarks that do not support this option.
Closes https://github.com/cloud-bulldozer/benchmark-operator/issues/501