### PR TITLE
adding prefill blocksize, used for compressed volumes

### DIFF
--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -30,6 +30,8 @@ spec:
     name: "fio_distributed"
     args:
       prefill: true
+      # for compressed volume uncomment the next line and make the cmp_bs same as bs
+      # prefill_bs: 8KiB
       samples: 3
       servers: 3
       # Chose to run servers in 'pod' or 'vm'
@@ -228,6 +230,8 @@ The workload loops are nested as such from the CR options:
   > Technical Note: If you are running kube/openshift on VMs make sure the diskimage or volume is preallocated.
 - **prefill**: (Optional) boolean to enable/disable prefill SDS
   - prefill requirement stems from Ceph RBD thin-provisioning - just creating the RBD volume doesn't mean that there is space allocated to read and write out there. For example, reads to an uninitialized volume don't even talk to the Ceph OSDs, they just return immediately with zeroes in the client.
+- **prefill_bs** (Optional) The Block size that need to used for the prefill.
+  - When running against compressed volumes, the prefill operation need to be done with the same block size as using in the test, otherwise the compression ratio will not be as expected.
 - **fio_json_to_log**: (Optional) boolean to enable/disable sending job results in json format to client pod log.
 
 #### EXPERT: spec.global_overrides

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -30,8 +30,9 @@ spec:
     name: "fio_distributed"
     args:
       prefill: true
-      # for compressed volume uncomment the next line and make the cmp_bs same as bs
+      # for compressed volume uncomment the next 2 lines and make the cmp_bs same as bs
       # prefill_bs: 8KiB
+      # cmp_ratio: 70
       samples: 3
       servers: 3
       # Chose to run servers in 'pod' or 'vm'
@@ -232,6 +233,7 @@ The workload loops are nested as such from the CR options:
   - prefill requirement stems from Ceph RBD thin-provisioning - just creating the RBD volume doesn't mean that there is space allocated to read and write out there. For example, reads to an uninitialized volume don't even talk to the Ceph OSDs, they just return immediately with zeroes in the client.
 - **prefill_bs** (Optional) The Block size that need to used for the prefill.
   - When running against compressed volumes, the prefill operation need to be done with the same block size as using in the test, otherwise the compression ratio will not be as expected.
+- **cmp_ratio** (Optional) When running against compressed volumes, the expected compression ratio (0-100)
 - **fio_json_to_log**: (Optional) boolean to enable/disable sending job results in json format to client pod log.
 
 #### EXPERT: spec.global_overrides

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -14,6 +14,8 @@ spec:
     args:
       # if true, do large sequential write to preallocate volume before using
       prefill: true
+      # for compressed volume uncomment the next line and make the cmp_bs same as bs
+      # prefill_bs: 8KiB
       # number of times each test
       samples: 3
       # number of fio pods generating workload

--- a/roles/fio_distributed/templates/configmap.yml.j2
+++ b/roles/fio_distributed/templates/configmap.yml.j2
@@ -15,7 +15,11 @@ data:
     unit_base=8
     ioengine=libaio
     size={{workload_args.filesize}}
+{% if workload_args.prefill_bs is defined %}
+    bs={{workload_args.prefill_bs}}
+{% else %}
     bs=4096KiB
+{% endif %}
     iodepth=1
     direct=1
     numjobs=1

--- a/roles/fio_distributed/templates/configmap.yml.j2
+++ b/roles/fio_distributed/templates/configmap.yml.j2
@@ -28,6 +28,10 @@ data:
     rw=write
     create_on_open=1
     fsync_on_close=1
+{% if workload_args.cmp_ratio is defined %}
+    buffer_compress_percentage={{ workload_args.cmp_ratio }}
+    buffer_pattern=0xdeadface
+{% endif %}
 {% endif %}
 {% if workload_args.bsrange is defined %}
 {% set loopvar = workload_args.bsrange %}


### PR DESCRIPTION
since the behavior of the Ceph compression, we need that the prefill block size will be the same as the tested block size on compressed volumes.