### PR TITLE
Enable ssl verification for Elasticsearch in Backpack

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -55,6 +55,9 @@ the workload template with an init container section that looks like:
 {% if metadata.stockpile_skip_tags|length > 0 %}
             --skip-tags={{ metadata.stockpile_skip_tags|join(",") }}
 {% endif %}
+{% if metadata.ssl is sameas true %}
+            --sslskipverify
+{% endif %}
         imagePullPolicy: Always
         securityContext:
           privileged: {{ metadata.privileged }}
@@ -240,6 +243,18 @@ metadata:
 ```
 
 In the spec section of the benchmark yaml as outlined for the other variables.
+
+### Elasticsearch SSL Verification
+
+By default elasticsearch SSL verification is disabled. To enable it, set ssl
+to true in the metadata section.
+
+To enable ssl verification:
+
+```yaml
+metadata:
+  ssl: true
+```
 
 ### Additional k8s Information
 

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -97,6 +97,9 @@ spec:
                   targeted:
                     default: true
                     type: boolean
+                  ssl:
+                    default: false
+                    type: boolean
                 type: object
               cerberus_url:
                 type: string

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -55,6 +55,9 @@ spec:
 {% if metadata.stockpile_skip_tags|length > 0 %}
             --skip-tags={{ metadata.stockpile_skip_tags|join(",") }}
 {% endif %}
+{% if metadata.ssl is sameas true %}
+            --sslskipverify True
+{% endif %}
             && touch /tmp/indexed; sleep infinity
         imagePullPolicy: Always
         securityContext:

--- a/templates/metadata.yml.j2
+++ b/templates/metadata.yml.j2
@@ -24,6 +24,9 @@
 {% if metadata.stockpile_skip_tags|length > 0 %}
             --skip-tags={{ metadata.stockpile_skip_tags|join(",") }}
 {% endif %}
+{% if metadata.ssl is sameas true %}
+            --sslskipverify True
+{% endif %}
         imagePullPolicy: Always
         securityContext:
           privileged: {{ metadata.privileged }}


### PR DESCRIPTION
Allow ssl verification for elasticsearch in backpack. To enable add ssl: true to the metadata section of the cr.

```
metadata:
  ssl: true
```