### PR TITLE
Add Iperf3 pod anti-affinity rules

### DIFF
--- a/roles/iperf3/templates/client.yml.j2
+++ b/roles/iperf3/templates/client.yml.j2
@@ -11,6 +11,18 @@ spec:
       labels:
         app: iperf3-bench-client-{{ trunc_uuid }}
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - iperf3-bench-server-{{ trunc_uuid }}
+              topologyKey: kubernetes.io/hostname
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}

--- a/roles/iperf3/templates/client_store.yml.j2
+++ b/roles/iperf3/templates/client_store.yml.j2
@@ -11,6 +11,18 @@ spec:
       labels:
         app: iperf3-bench-client-{{ trunc_uuid }}
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - iperf3-bench-server-{{ trunc_uuid }}
+              topologyKey: kubernetes.io/hostname
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}

--- a/roles/iperf3/templates/server.yml.j2
+++ b/roles/iperf3/templates/server.yml.j2
@@ -11,6 +11,18 @@ spec:
       labels:
         app: iperf3-bench-server-{{ trunc_uuid }}
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - iperf3-bench-client-{{ trunc_uuid }}
+              topologyKey: kubernetes.io/hostname
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}


### PR DESCRIPTION
Add pod anti-affinity rules to place iperf3 client and server benchmark pods on different nodes