### PR TITLE
Add missing space between nodeSelector key and value

### DIFF
--- a/roles/fio_distributed/templates/servers.yaml
+++ b/roles/fio_distributed/templates/servers.yaml
@@ -49,7 +49,7 @@ spec:
 {% if workload_args.nodeselector is defined %}
       nodeSelector: 
 {% for label, value in  workload_args.nodeselector.items() %}
-        {{ label | replace ("_", "-" )}}:{{ value }}
+        {{ label | replace ("_", "-" )}}: {{ value }}
 {% endfor %}
 {% endif  %}
 {% if workload_args.tolerations is defined %}


### PR DESCRIPTION
W/o this fix, we've detected issues when using nodeselector in a CR like:

```yaml
apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
kind: Benchmark
metadata:
  name: etcd-fio
  namespace: my-ripsaw
spec:
  elasticsearch:
    url: https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
  clustername: test_cloud
  test_user: test_cloud
  metadata:
    collection: true
    serviceaccount: backpack-view
  workload:
    name: blablabla
    args:
      nodeselector:
        foo: bar
      iodepth: 1
      log_sample_rate: 1000
      samples: 5
      servers: 1
      jobs:
      - write
      bs:
      - 2300
      numjobs:
      - 1
      filesize: 50MiB
  global_overrides:
    - fdatasync=1
    - ioengine=sync
```

Using the above CR Benchmark-operator prints the following error

```
                            "nodeSelector": "foo:bar",                                                                                                                                                                                        
                            "restartPolicy": "Never",                                                                                                                                                                                         
                            "serviceAccountName": "backpack-view",                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
                        }                                                                                                                                                                                                                     
                    },                                                                                                                                                                                                                        
                    "ttlSecondsAfterFinished": 600                                                                                                                                                                                            
                }                                                                                                                                                                                                                             
            },                                                                                                                                                                                                                                
            "src": null,                                                                                                                                                                                                                      
            "state": "present",                                                                                                                                                                                                               
            "username": null,                                                                                                                                                                                                                 
            "validate": null,                                                                                                                                                                                                                 
            "validate_certs": null,                                                                                                                                                                                                           
            "wait": false,                                                                                                                                                                                                                    
            "wait_condition": null,                                                                                                                                                                                                           
            "wait_sleep": 5,                                                                                                                                                                                                                  
            "wait_timeout": 120                                                                                                                                                                                                               
        }                                                                                                                                                                                                                                     
    },                                                                                                                                                                                                                                        
    "item": "1",                                                                                                                                                                                                                              
    "msg": "Failed to create object: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"Job in version \\\\\"v1\\\\\" cannot be handled as a Job: v1.Job.Spec: v1.JobSpec.Template: v1.PodTempl
ateSpec.Spec: v1.PodSpec.NodeSelector: ReadMapCB: expect { or n, but found \\\\\", error found in #10 byte of ...|elector\\\\\":\\\\\"foo:bar\\\\\",\\\\\"|..., bigger context ...|ged\\\\\":true,\\\\\"runAsNonRoot\\\\\":false}}],\\\\\"node
Selector\\\\\":\\\\\"foo:bar\\\\\",\\\\\"restartPolicy\\\\\":\\\\\"Never\\\\\",\\\\\"serviceAccountNa|...\",\"reason\":\"BadRequest\",\"code\":400}\\n'",
    "reason": "Bad Request",
    "status": 400
```

Note the incorrect value of nodeSelector, this is happening becuase the template needs the missing space included in this PR to make the API interpret this value as a dictionary rather than a string

cc: @ekuric 
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>