### PR TITLE
Standarize examples

### DIFF
--- a/resources/crds/ripsaw_v1alpha1_byowl_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_byowl_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: byowl-benchmark
+  name: byowl-benchmark-example
   namespace: my-ripsaw
 spec:
   workload:

--- a/resources/crds/ripsaw_v1alpha1_cyclictest_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_cyclictest_cr.yaml
@@ -1,11 +1,16 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: cyclictest
+  name: cyclictest-example
   namespace: my-ripsaw
 spec:
+  # where elastic search is running
   elasticsearch:
-    server: <ES_SERVER>
+    url: http://my.elasticsearch.server:80
+    verify_cert: false
+    parallel: false
+  # clustername: myk8scluster
+  # test_user: ripsaw
   workload:
     name: "cyclictest"
     args:

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_cr.yaml
@@ -1,14 +1,16 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: fio-benchmark
+  name: fio-benchmark-example
   namespace: my-ripsaw
 spec:
   # where elastic search is running
   elasticsearch:
     url: http://my.elasticsearch.server:80
-#  clustername: myk8scluster
-#  test_user: ripsaw
+    verify_cert: false
+    parallel: false
+  # clustername: myk8scluster
+  # test_user: ripsaw
   workload:
     name: "fio_distributed"
     args:

--- a/resources/crds/ripsaw_v1alpha1_fio_distributed_vm_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fio_distributed_vm_cr.yaml
@@ -1,14 +1,16 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: fio-vm-benchmark
+  name: fio-vm-benchmark-example
   namespace: my-ripsaw
 spec:
   # where elastic search is running
   elasticsearch:
     url: http://my.elasticsearch.server:80
-#  clustername: myk8scluster
-#  test_user: ripsaw
+    verify_cert: false
+    parallel: false
+  # clustername: myk8scluster
+  # test_user: ripsaw
   workload:
     name: "fio_distributed"
     args:

--- a/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_fs_drift_cr.yaml
@@ -1,15 +1,16 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: fs-drift-example
   namespace: my-ripsaw
 spec:
   # where elastic search is running
   elasticsearch:
     url: http://my.elasticsearch.server:80
-  test_user: homer_simpson
-  # to separate this test run from everyone else's
-  clustername: aws-2009-09-10
+    verify_cert: false
+    parallel: false
+  # clustername: myk8scluster
+  # test_user: ripsaw
   workload:
     name: fs-drift
     args:

--- a/resources/crds/ripsaw_v1alpha1_hammerdb_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_hammerdb_cr.yaml
@@ -1,11 +1,16 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: hammerdb-benchmark
+  name: hammerdb-benchmark-example
   namespace: my-ripsaw
 spec:
+  # where elastic search is running
   elasticsearch:
     url: http://my.elasticsearch.server:80
+    verify_cert: false
+    parallel: false
+  # clustername: myk8scluster
+  # test_user: ripsaw
   workload:
     name: hammerdb
     args:

--- a/resources/crds/ripsaw_v1alpha1_hammerdb_index_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_hammerdb_index_cr.yaml
@@ -1,13 +1,16 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: hammerdb-benchmark
+  name: hammerdb-benchmark-example
   namespace: my-ripsaw
 spec:
+  # where elastic search is running
   elasticsearch:
     url: http://my.elasticsearch.server:80
-# clustername: myk8scluster
-# test_user: username_to_attach_to_metadata
+    verify_cert: false
+    parallel: false
+  # clustername: myk8scluster
+  # test_user: ripsaw
   workload:
     # cleanup: true
     name: hammerdb

--- a/resources/crds/ripsaw_v1alpha1_iperf3_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_iperf3_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: iperf3-benchmark
+  name: iperf3-benchmark-example
   namespace: my-ripsaw
 spec:
   workload:

--- a/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_kube-burner_cr.yaml
@@ -1,20 +1,20 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: kube-burner-cluster-density
+  name: kube-burner-cluster-density-example
   namespace: my-ripsaw
 spec:
   # Metadata information
   elasticsearch:
     # Elastic search instance with full URL format. https://elastic.apps.org:9200
-    url: <ES_URL>
+    url: http://my.elasticsearch.server:80
   prometheus:
     # Elastic search instance with full URL format. https://elastic.apps.org:9200
-    es_url: <ES_URL>
+    es_url: http://my.elasticsearch.server:80
     # Prometheus bearer token
-    prom_token: <PROMETHEUS_BEARER_TOKEN>
+    prom_token: PROMETHEUS_BEARER_TOKEN
     # Prometheus URL with full URL format. https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    prom_url: <PROMETHEUS_URL>
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:
     name: kube-burner
     args:

--- a/resources/crds/ripsaw_v1alpha1_oslat_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_oslat_cr.yaml
@@ -1,11 +1,16 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: oslat
+  name: oslat-example
   namespace: my-ripsaw
 spec:
+  # where elastic search is running
   elasticsearch:
-    server: <ES_SERVER>
+    url: http://my.elasticsearch.server:80
+    verify_cert: false
+    parallel: false
+  # clustername: myk8scluster
+  # test_user: ripsaw
   workload:
     name: "oslat"
     args:

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -1,7 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: benchmarks.ripsaw.cloudbulldozer.io
 spec:
   group: ripsaw.cloudbulldozer.io
@@ -34,7 +33,7 @@ spec:
                   parallel:
                     type: boolean
                   verify_cert:
-                    type: string
+                    type: boolean
               prometheus:
                 type: object
                 properties:

--- a/resources/crds/ripsaw_v1alpha1_uperf_vm.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_vm.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   clustername: test-cluster
-  test_user: <user> # user is a key that points to user triggering ripsaw, useful to search results in ES
+  test_user: user # user is a key that points to user triggering ripsaw, useful to search results in ES
   elasticsearch:
     server: http://es.server.com:80
   cleanup: false

--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -45,9 +45,9 @@ spec:
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-cyclictest") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
@@ -55,7 +55,7 @@ spec:
           - name: prom_port
             value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -46,6 +46,8 @@ spec:
             value: "{{ elasticsearch.index_name | default("ripsaw-cyclictest") }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default("false") }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.verify_cert | default("true") }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -37,7 +37,7 @@ spec:
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-fio") }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.cert_verify | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default("true") }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -37,7 +37,7 @@ spec:
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-fio") }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -55,7 +55,7 @@ spec:
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -54,6 +54,8 @@ spec:
             value: "{{ elasticsearch.index_name | default("ripsaw-fs-drift") }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.verify_cert | default("true") }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -46,6 +46,8 @@ spec:
             value: "{{ elasticsearch.index_name | default("ripsaw-oslat") }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default("false") }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.verify_cert | default("true") }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -45,9 +45,9 @@ spec:
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-oslat") }}"
           - name: parallel
-            value: "{{ elasticsearch.parallel | default("false") }}"
+            value: "{{ elasticsearch.parallel | default(false) }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es
@@ -55,7 +55,7 @@ spec:
           - name: prom_port
             value: "{{ prometheus.es_port }}"
           - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default("false") }}"
+            value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
           - name: prom_url

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -40,7 +40,7 @@ spec:
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -39,6 +39,8 @@ spec:
             value: "{{ elasticsearch.index_name | default("ripsaw-pgbench") }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.verify_cert | default("true") }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -48,7 +48,7 @@ spec:
           - name: es_index
             value: "{{ elasticsearch.index_name | default("openshift-cluster-timings") }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.cert_verify | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default("true") }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -48,7 +48,7 @@ spec:
           - name: es_index
             value: "{{ elasticsearch.index_name | default("openshift-cluster-timings") }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -59,7 +59,7 @@ spec:
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -58,6 +58,8 @@ spec:
             value: "{{ elasticsearch.index_name | default("ripsaw-smallfile") }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.verify_cert | default("true") }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/stressng/tasks/main.yaml
+++ b/roles/stressng/tasks/main.yaml
@@ -82,6 +82,6 @@
       status:
         state: Benchmark Complete
         complete: true
-      when: stressng_workload_pod | json_query('resources[].status.succeeded')"
+    when: stressng_workload_pod | json_query('resources[].status.succeeded')
 
   when: resource_state.resources[0].status.state == "Benchmark running"

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -60,6 +60,8 @@ spec:
             value: "{{ elasticsearch.index_name | default("ripsaw-stressng") }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.verify_cert | default("true") }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -61,7 +61,7 @@ spec:
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/uperf/templates/configmap_script.yml.j2
+++ b/roles/uperf/templates/configmap_script.yml.j2
@@ -11,8 +11,8 @@ data:
 {% if elasticsearch.url is defined %}
     export es={{ elasticsearch.url }}
     export es_index={{ elasticsearch.index_name | default("ripsaw-uperf") }}
-    export es_verify_cert={{ elasticsearch.verify_cert | default("true") }}
-    export parallel={{ elasticsearch.parallel | default("false") }}
+    export es_verify_cert={{ elasticsearch.verify_cert | default(true) }}
+    export parallel={{ elasticsearch.parallel | default(false) }}
     export uuid={{uuid}}
 {% endif %}
 {% endif %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -56,6 +56,8 @@ spec:
             value: "{{ elasticsearch.index_name | default("ripsaw-uperf") }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.verify_cert | default("true") }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -57,7 +57,7 @@ spec:
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
 {% endif %}
 {% if prometheus is defined %}
           - name: prom_es

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -45,7 +45,7 @@ spec:
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-vegeta") }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.cert_verify | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default("true") }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -45,7 +45,7 @@ spec:
           - name: es_index
             value: "{{ elasticsearch.index_name | default("ripsaw-vegeta") }}"
           - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default("true") }}"
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
           - name: parallel
             value: "{{ elasticsearch.parallel | default(false) }}"
 {% endif %}

--- a/roles/ycsb/templates/ycsb_load.yaml
+++ b/roles/ycsb/templates/ycsb_load.yaml
@@ -40,7 +40,7 @@ spec:
         - name: parallel
           value: "{{ elasticsearch.parallel | default(false) }}"
         - name: es_verify_cert
-          value: "{{ elasticsearch.verify_cert | default("true") }}"
+          value: "{{ elasticsearch.verify_cert | default(true) }}"
 {% endif %}
 {% if prometheus is defined %}
         - name: prom_es

--- a/roles/ycsb/templates/ycsb_load.yaml
+++ b/roles/ycsb/templates/ycsb_load.yaml
@@ -39,6 +39,8 @@ spec:
           value: "{{ elasticsearch.index_name | default("ripsaw-ycsb") }}"
         - name: parallel
           value: "{{ elasticsearch.parallel | default(false) }}"
+        - name: es_verify_cert
+          value: "{{ elasticsearch.verify_cert | default("true") }}"
 {% endif %}
 {% if prometheus is defined %}
         - name: prom_es

--- a/roles/ycsb/templates/ycsb_run.yaml
+++ b/roles/ycsb/templates/ycsb_run.yaml
@@ -40,7 +40,7 @@ spec:
         - name: parallel
           value: "{{ elasticsearch.parallel | default(false) }}"
         - name: es_verify_cert
-          value: "{{ elasticsearch.verify_cert | default("true") }}"
+          value: "{{ elasticsearch.verify_cert | default(true) }}"
 {% endif %}
 {% if prometheus is defined %}
         - name: prom_es

--- a/roles/ycsb/templates/ycsb_run.yaml
+++ b/roles/ycsb/templates/ycsb_run.yaml
@@ -39,6 +39,8 @@ spec:
           value: "{{ elasticsearch.index_name | default("ripsaw-ycsb") }}"
         - name: parallel
           value: "{{ elasticsearch.parallel | default(false) }}"
+        - name: es_verify_cert
+          value: "{{ elasticsearch.verify_cert | default("true") }}"
 {% endif %}
 {% if prometheus is defined %}
         - name: prom_es


### PR DESCRIPTION
Several fixes/changes:

- stressng syntax error issues.
- So work in standardizing our examples.
- Enables `verify_cert` to all workloads wrapped by snafu.

Helps fixing some issues from https://github.com/cloud-bulldozer/benchmark-operator/issues/520