### PR TITLE
Add UPERF Scale Mode Telco-5G

### DIFF
--- a/deploy/25_role.yaml
+++ b/deploy/25_role.yaml
@@ -1,13 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: benchmark-operator
 rules:
 - apiGroups:
-  - "*"
+  - ""
   resources:
-  - "*"
+  - nodes
   verbs:
-  - '*'
+  - get
+  - list
+  - patch
 

--- a/deploy/25_role.yaml
+++ b/deploy/25_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: benchmark-operator
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - '*'
+

--- a/deploy/35_role_binding.yaml
+++ b/deploy/35_role_binding.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: benchmark-operator
+subjects:
+- kind: ServiceAccount
+  name: benchmark-operator
+  namespace: my-ripsaw
+roleRef:
+  kind: ClusterRole
+  name: benchmark-operator
+  apiGroup: rbac.authorization.k8s.io
+

--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -221,7 +221,7 @@ Here is one scale example:
       step_size: log2
       ...
 ```
-Note, the `scale` mode is mutual exlusive to `pin` mode with the `pin` mode has higher precedence.
+Note, the `scale` mode is mutually exlusive to `pin` mode with the `pin` mode having higher precedence.
 In other words, if `pin:true` the test will deploy pods on `pin_server` and `pin_client` nodes
 and ignore `colocate`, `node_range`, and the number of pairs to deploy is specified by the
  `density_range.high` value.

--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -41,6 +41,7 @@ spec:
       kind: pod
       pin_server: "node-0"
       pin_client: "node-1"
+      pair: 1
       multus:
         enabled: false
       samples: 1
@@ -77,6 +78,11 @@ spec:
 
 `pin_client` what node to pin the client pod to.
 
+`pair` how many instances of uperf client-server pairs. `pair` is applicable for `pin: true` only.
+If `pair` is not specified, the operator will use the value in `density_range` to detemine the number of pairs.
+See **Scale** section for more info. `density_range` can do more than `pair` can, but `pair` support is retained 
+for backward compatibility.
+
 `multus[1]` Configure our pods to use multus.
 
 `samples` how many times to run the tests. For example
@@ -85,7 +91,7 @@ spec:
 
 ```yaml
       samples: 3
-      density: [1,1]
+      density_range: [1,1]
       test_types:
         - stream
       protos:
@@ -111,7 +117,7 @@ size.
 For example:
 ```yaml
       samples: 3
-      density: [1,1]
+      density_range: [1,1]
       test_types:
         - rr
       protos:

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -123,6 +123,19 @@ spec:
                 type: string
               cerberus:
                 type: string
+              pod_hi_idx:
+                type: string
+              pod_low_idx:
+               type: string
+              node_hi_idx:
+                type: string
+              node_low_idx:
+               type: string
+              pod_idx:
+               type: string
+              node_idx:
+               type: string
+
     additionalPrinterColumns:
     - name: Type
       type: string

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -36,8 +36,16 @@ spec:
       # The following variables are for scale uperf.
       # The scale mode will be activated with 'node_range' defined.
       
-      #colocate: True 
-      #density_range: [1, 2]
-      #node_range: [1, 2]
-      #excluded_node: [ worker001 ]
+      # colocate: True 
+      # density_range: [1, 32]
+      # node_range: [1, 10]
+      # step_size: log2
+      #   Valid step_size values are: addN or log2
+      #   N can be any decimal number
+      #   Enumeration examples:
+      #      add1:  1,2,3,4 ,,,
+      #      add2:  1,3,5,7 ...
+      #      add10: 1,11,21,31 ...
+      #      log2:  1,2,4,8,16,32 ,,,
+      # excluded_node: [ worker001 ]
 

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -47,5 +47,7 @@ spec:
       #      add2:  1,3,5,7 ...
       #      add10: 1,11,21,31 ...
       #      log2:  1,2,4,8,16,32 ,,,
-      # excluded_node: [ worker001 ]
+      # exclude_labels:  (OR conditional, every node that matches any of these labels is excluded)
+      #    - "bad=true"
+      #    - "fc640=true"
 

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -32,3 +32,12 @@ spec:
       nthrs:
         - 1
       runtime: 30
+
+      # The following variables are for scale uperf.
+      # The scale mode will be activated with 'node_range' defined.
+      
+      #colocate: True 
+      #density_range: [1, 2]
+      #node_range: [1, 2]
+      #excluded_node: [ worker001 ]
+

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -20,7 +20,7 @@ spec:
       pin: false
       #
       # pin: true/false - default=false
-      #    - true will run 'Pin' mode using 1 pin_server and 1 pin_client nodes.
+      #    - true will run 'Pin' mode using 1 server (pin_server:) and 1 client (pin_clien:) nodes.
       #    - false will run 'Scale' mode. See colocate, density_range, node_range and step_size.
       pin_server: "node-0"
       pin_client: "node-1"
@@ -28,9 +28,9 @@ spec:
       kind: pod
       pair: 1
       #
-      # 'pair' is obsolete. Instead, use 'density_range' which allows fixed or enumerated 
-      #    number of pairs. Enumeration is an enhanced capability of the 'Pin' mode.
-      #
+      # 'pair' sepcifies fixed number of client-server pairs for "Pin" mode,
+      #  If 'pair' is NOT present, it will use 'density_range' which allows
+      #  enumeration in addition to fixed number of pair.
       test_types:
         - stream
       protos:
@@ -43,7 +43,7 @@ spec:
 
       # The following variables are for 'Scale' mode.
       # The 'Scale' mode is activated when 'pin=false' or undefined.
-      # The Scale mode op params are: colocate, denstisy_range, node_range and step_size.
+      # The Scale mode params are: colocate, denstisy_range, node_range and step_size.
       #
       # colocate: true/false - default=false
       # density_range: [n, m] - default=[1,1]
@@ -57,7 +57,7 @@ spec:
       #      add10: 1,11,21,31 ...
       #      log2:  1,2,4,8,16,32 ,,,
       #
-      # The 'exlude_labels' is the list of ineligible worker nodes.
+      # 'exclude_labels' specifies the list of ineligible worker nodes.
       # exclude_labels:  (OR conditional, every node that matches any of these labels is excluded)
       #    - "bad=true"
       #    - "fc640=true"

--- a/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_uperf_cr.yaml
@@ -15,14 +15,22 @@ spec:
       serviceip: false
       hostnetwork: false
       networkpolicy: false
-      pin: false
       multus:
         enabled: false
+      pin: false
+      #
+      # pin: true/false - default=false
+      #    - true will run 'Pin' mode using 1 pin_server and 1 pin_client nodes.
+      #    - false will run 'Scale' mode. See colocate, density_range, node_range and step_size.
       pin_server: "node-0"
       pin_client: "node-1"
       samples: 1
       kind: pod
       pair: 1
+      #
+      # 'pair' is obsolete. Instead, use 'density_range' which allows fixed or enumerated 
+      #    number of pairs. Enumeration is an enhanced capability of the 'Pin' mode.
+      #
       test_types:
         - stream
       protos:
@@ -33,13 +41,14 @@ spec:
         - 1
       runtime: 30
 
-      # The following variables are for scale uperf.
-      # The scale mode will be activated with 'node_range' defined.
-      
-      # colocate: True 
-      # density_range: [1, 32]
-      # node_range: [1, 10]
-      # step_size: log2
+      # The following variables are for 'Scale' mode.
+      # The 'Scale' mode is activated when 'pin=false' or undefined.
+      # The Scale mode op params are: colocate, denstisy_range, node_range and step_size.
+      #
+      # colocate: true/false - default=false
+      # density_range: [n, m] - default=[1,1]
+      # node_range: [x, y]  - default=[1,1]
+      # step_size: log2 - default=add1
       #   Valid step_size values are: addN or log2
       #   N can be any decimal number
       #   Enumeration examples:
@@ -47,6 +56,8 @@ spec:
       #      add2:  1,3,5,7 ...
       #      add10: 1,11,21,31 ...
       #      log2:  1,2,4,8,16,32 ,,,
+      #
+      # The 'exlude_labels' is the list of ineligible worker nodes.
       # exclude_labels:  (OR conditional, every node that matches any of these labels is excluded)
       #    - "bad=true"
       #    - "fc640=true"

--- a/resources/operator.yaml
+++ b/resources/operator.yaml
@@ -34,14 +34,14 @@ spec:
           - /usr/local/bin/ao-logs
           - /tmp/ansible-operator/runner
           - stdout
-          image: quay.io/hnhan/benchmark-operator:uperf-scale
+          image: quay.io/benchmark-operator/benchmark-operator:master
           imagePullPolicy: "Always"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
         - name: benchmark-operator
-          image: quay.io/hnhan/benchmark-operator:uperf-scale
+          image: quay.io/benchmark-operator/benchmark-operator:master
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/resources/operator.yaml
+++ b/resources/operator.yaml
@@ -34,14 +34,14 @@ spec:
           - /usr/local/bin/ao-logs
           - /tmp/ansible-operator/runner
           - stdout
-          image: quay.io/benchmark-operator/benchmark-operator:master
+          image: quay.io/hnhan/benchmark-operator:uperf-scale
           imagePullPolicy: "Always"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
         - name: benchmark-operator
-          image: quay.io/benchmark-operator/benchmark-operator:master
+          image: quay.io/hnhan/benchmark-operator:uperf-scale
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -70,7 +70,7 @@ spec:
             - containerPort: 6379
           resources:
             limits:
-              cpu: "0.1"
+              cpu: "2.0"
           volumeMounts:
             - mountPath: /redis-master-data
               name: data

--- a/roles/uperf/tasks/cleanup.yml
+++ b/roles/uperf/tasks/cleanup.yml
@@ -31,8 +31,10 @@
     when: cleanup
 
   - name: Cleanup redis
-     command: "redis-cli del num_completion-{{trunc_uuid}}"
-     command: "redis-cli del start-{{trunc_uuid}}"
+    command: "{{ item }}"
+    with_items:
+      - redis-cli del num_completion-{{trunc_uuid}}
+      - redis-cli del start-{{trunc_uuid}}
 
   when: resource_kind == "pod"
 

--- a/roles/uperf/tasks/cleanup.yml
+++ b/roles/uperf/tasks/cleanup.yml
@@ -1,0 +1,45 @@
+---
+
+- block:
+
+  - block:
+    - name: P29 Get Server Pods
+      k8s_facts:
+        kind: Pod
+        api_version: v1
+        namespace: '{{ operator_namespace }}'
+        label_selectors:
+          - type = uperf-bench-server-{{ trunc_uuid }}
+      register: server_pods
+
+    - name: P30 Pod names - to clean
+      set_fact:
+        clean_pods: |
+            [
+            {% for item in server_pods.resources %}
+              "{{ item['metadata']['name'] }}",
+            {% endfor %}
+            ]
+
+    - name: P31 Cleanup run
+      k8s:
+        kind: pod
+        api_version: v1
+        namespace: '{{ operator_namespace }}'
+        state: absent
+        name: "{{ item }}"
+      with_items: "{{ clean_pods }}"
+      when: cleanup
+    when: resource_kind == "pod"
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Complete
+        complete: true
+
+  when: resource_state.resources[0].status.state == "Cleanup"
+

--- a/roles/uperf/tasks/cleanup.yml
+++ b/roles/uperf/tasks/cleanup.yml
@@ -1,45 +1,46 @@
 ---
 
 - block:
+  ### <POD> kind
+  - name: Get Server Pods
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_pods
 
-  - block:
-    - name: Get Server Pods
-      k8s_facts:
-        kind: Pod
-        api_version: v1
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - type = uperf-bench-server-{{ trunc_uuid }}
-      register: server_pods
+  - name: Pod names - to clean
+    set_fact:
+      clean_pods: |
+          [
+          {% for item in server_pods.resources %}
+            "{{ item['metadata']['name'] }}",
+          {% endfor %}
+          ]
 
-    - name: Pod names - to clean
-      set_fact:
-        clean_pods: |
-            [
-            {% for item in server_pods.resources %}
-              "{{ item['metadata']['name'] }}",
-            {% endfor %}
-            ]
+  - name: Cleanup run
+    k8s:
+      kind: pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      state: absent
+      name: "{{ item }}"
+    with_items: "{{ clean_pods }}"
+    when: cleanup
+  when: resource_kind == "pod"
 
-    - name: Cleanup run
-      k8s:
-        kind: pod
-        api_version: v1
-        namespace: '{{ operator_namespace }}'
-        state: absent
-        name: "{{ item }}"
-      with_items: "{{ clean_pods }}"
-      when: cleanup
-    when: resource_kind == "pod"
+#
+# no <VM> kind block - We leave VM running
+#
 
-  - operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: Complete
-        complete: true
-
-  when: resource_state.resources[0].status.state == "Cleanup"
+- operator_sdk.util.k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      state: Complete
+      complete: true
 

--- a/roles/uperf/tasks/cleanup.yml
+++ b/roles/uperf/tasks/cleanup.yml
@@ -2,6 +2,16 @@
 
 - block:
   ### <POD> kind
+  # Cleanup servers, but leave clients around mostly for further examining of results.
+  - name: Get Server Jobs
+    k8s_facts:
+      kind: Job
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_jobs
+
   - name: Get Server Pods
     k8s_facts:
       kind: Pod
@@ -11,8 +21,14 @@
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_pods
 
-  - name: Pod names - to clean
+  - name: Server Job and Pod names - to clean
     set_fact:
+      clean_jobs: |
+          [
+          {% for item in server_jobs.resources %}
+            "{{ item['metadata']['name'] }}",
+          {% endfor %}
+          ]
       clean_pods: |
           [
           {% for item in server_pods.resources %}
@@ -20,23 +36,34 @@
           {% endfor %}
           ]
 
-  - name: Cleanup run
+  - name: Cleanup server Job 
     k8s:
-      kind: pod
+      kind: Job
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      state: absent
+      name: "{{ item }}"
+    with_items: "{{ clean_jobs }}"
+
+  - name: Cleanup server Pod 
+    k8s:
+      kind: Pod
       api_version: v1
       namespace: '{{ operator_namespace }}'
       state: absent
       name: "{{ item }}"
     with_items: "{{ clean_pods }}"
-    when: cleanup
 
+  when: resource_kind == "pod" and cleanup == True
+
+- block:
   - name: Cleanup redis
     command: "{{ item }}"
     with_items:
       - redis-cli del num_completion-{{trunc_uuid}}
       - redis-cli del start-{{trunc_uuid}}
+  when: resource_kind == "pod" 
 
-  when: resource_kind == "pod"
 
 
 

--- a/roles/uperf/tasks/cleanup.yml
+++ b/roles/uperf/tasks/cleanup.yml
@@ -3,7 +3,7 @@
 - block:
 
   - block:
-    - name: P29 Get Server Pods
+    - name: Get Server Pods
       k8s_facts:
         kind: Pod
         api_version: v1
@@ -12,7 +12,7 @@
           - type = uperf-bench-server-{{ trunc_uuid }}
       register: server_pods
 
-    - name: P30 Pod names - to clean
+    - name: Pod names - to clean
       set_fact:
         clean_pods: |
             [
@@ -21,7 +21,7 @@
             {% endfor %}
             ]
 
-    - name: P31 Cleanup run
+    - name: Cleanup run
       k8s:
         kind: pod
         api_version: v1

--- a/roles/uperf/tasks/cleanup.yml
+++ b/roles/uperf/tasks/cleanup.yml
@@ -29,7 +29,14 @@
       name: "{{ item }}"
     with_items: "{{ clean_pods }}"
     when: cleanup
+
+  - name: Cleanup redis
+     command: "redis-cli del num_completion-{{trunc_uuid}}"
+     command: "redis-cli del start-{{trunc_uuid}}"
+
   when: resource_kind == "pod"
+
+
 
 #
 # no <VM> kind block - We leave VM running

--- a/roles/uperf/tasks/cleanup.yml
+++ b/roles/uperf/tasks/cleanup.yml
@@ -9,7 +9,7 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
+        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_jobs
 
   - name: Get Server Pods
@@ -18,7 +18,7 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
+        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_pods
 
   - name: Server Job and Pod names - to clean

--- a/roles/uperf/tasks/init.yml
+++ b/roles/uperf/tasks/init.yml
@@ -1,6 +1,5 @@
 ---
 
-
 - name: Clear start flag 
   command: "redis-cli set start 0"
 

--- a/roles/uperf/tasks/init.yml
+++ b/roles/uperf/tasks/init.yml
@@ -21,10 +21,4 @@
         node_idx: "{{node_low_idx}}"
         pod_idx: "{{pod_low_idx}}"
 
-# Set redis starting Node and Pod
-- name: Set starting node_idx
-  command: "redis-cli set node_idx {{ node_low_idx }}"
-
-- name: Set redis starting pod_idx
-  command: "redis-cli set pod_idx {{ pod_low_idx }}"
 

--- a/roles/uperf/tasks/init.yml
+++ b/roles/uperf/tasks/init.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Clear start flag 
-  command: "redis-cli set start 0"
+  command: "redis-cli set start-{{trunc_uuid}} 0"
 
 - name: Clear num_completion
-  command: "redis-cli set num_completion 0"
+  command: "redis-cli set num_completion-{{trunc_uuid}} 0"
 
 - name: Init node and pod indices in benchmark context
   operator_sdk.util.k8s_status:

--- a/roles/uperf/tasks/init.yml
+++ b/roles/uperf/tasks/init.yml
@@ -7,25 +7,24 @@
 - name: Clear num_completion
   command: "redis-cli set num_completion 0"
 
-# Node
-- name: Init node_hi_idx
-  command: "redis-cli set node_hi_idx {{ node_hi_idx }}"
+- name: Init node and pod indices in benchmark context
+  operator_sdk.util.k8s_status:
+     api_version: ripsaw.cloudbulldozer.io/v1alpha1
+     kind: Benchmark
+     name: "{{ meta.name }}"
+     namespace: "{{ operator_namespace }}"
+     status:
+        pod_hi_idx: "{{pod_hi_idx}}"
+        pod_low_idx: "{{pod_low_idx}}"
+        node_hi_idx: "{{node_hi_idx}}"
+        node_low_idx: "{{node_low_idx}}"
+        node_idx: "{{node_low_idx}}"
+        pod_idx: "{{pod_low_idx}}"
 
-- name: Init node_low_idx
-  command: "redis-cli set node_low_idx {{ node_low_idx }}"
-
- # Pod
-- name: Init pod_hi_idx
-  command: "redis-cli set pod_hi_idx {{ pod_hi_idx }}"
-
-- name: Init pod_low_idx
-  command: "redis-cli set pod_low_idx {{ pod_low_idx }}"
-
- # Starting Node and Pod
-- name: Init node_idx
+# Set redis starting Node and Pod
+- name: Set starting node_idx
   command: "redis-cli set node_idx {{ node_low_idx }}"
 
-- name: Init pod_idx
+- name: Set redis starting pod_idx
   command: "redis-cli set pod_idx {{ pod_low_idx }}"
-
 

--- a/roles/uperf/tasks/init.yml
+++ b/roles/uperf/tasks/init.yml
@@ -21,4 +21,3 @@
         node_idx: "{{node_low_idx}}"
         pod_idx: "{{pod_low_idx}}"
 
-

--- a/roles/uperf/tasks/init.yml
+++ b/roles/uperf/tasks/init.yml
@@ -1,0 +1,31 @@
+---
+
+
+- name: Clear start flag 
+  command: "redis-cli set start 0"
+
+- name: Clear num_completion
+  command: "redis-cli set num_completion 0"
+
+# Node
+- name: Init node_hi_idx
+  command: "redis-cli set node_hi_idx {{ node_hi_idx }}"
+
+- name: Init node_low_idx
+  command: "redis-cli set node_low_idx {{ node_low_idx }}"
+
+ # Pod
+- name: Init pod_hi_idx
+  command: "redis-cli set pod_hi_idx {{ pod_hi_idx }}"
+
+- name: Init pod_low_idx
+  command: "redis-cli set pod_low_idx {{ pod_low_idx }}"
+
+ # Starting Node and Pod
+- name: Init node_idx
+  command: "redis-cli set node_idx {{ node_low_idx }}"
+
+- name: Init pod_idx
+  command: "redis-cli set pod_idx {{ pod_low_idx }}"
+
+

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -16,8 +16,9 @@
   - include_tasks: wait_client_ready.yml
     when: resource_state.resources[0].status.state == "Waiting for Clients"
 
-  # LOOP BEGIN
-  #
+  # LOOP BEGIN 
+  # This loop iterates density_range[] and node_range[] for "scale" mode
+
   - include_tasks: run_a_set.yml
     when: resource_state.resources[0].status.state == "Clients Running"
 
@@ -27,9 +28,10 @@
 
   - include_tasks: next_set.yml
     when: resource_state.resources[0].status.state == "Run Next Set"
-    # will loop back to "Client Running" state, or FALLTHRU to "Running" state below and finish
-    #
-  # LOOP END
+    # will loop back to "Client Running" state, or FALLTHRU to "Running" 
+    # state below and finish
+
+  # LOOP END 
 
   - include_tasks: wait_client_done.yml
     when: resource_state.resources[0].status.state == "Running"
@@ -39,7 +41,9 @@
 
   when:  resource_kind == "pod"
 
-
+#
+# <VM> kind does not support "scale" mode yet 
+#
 
 - block:
 

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -16,6 +16,8 @@
   - include_tasks: wait_client_ready.yml
     when: resource_state.resources[0].status.state == "Waiting for Clients"
 
+  # LOOP BEGIN
+  #
   - include_tasks: run_a_set.yml
     when: resource_state.resources[0].status.state == "Clients Running"
 
@@ -26,10 +28,8 @@
   - include_tasks: next_set.yml
     when: resource_state.resources[0].status.state == "Run Next Set"
     # will loop back to "Client Running" state, or FALLTHRU to "Running" state below and finish
-
-#  - include_tasks: send_client_run_signal.yml
-#    when: resource_state.resources[0].status.state == "Clients Running"
-
+    #
+  # LOOP END
 
   - include_tasks: wait_client_done.yml
     when: resource_state.resources[0].status.state == "Running"

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -45,26 +45,29 @@
   register: serviceip
   when: workload_args.serviceip is defined and workload_args.serviceip
 
-### V2 vs V1
-- name: A6 Record num server (V1) pods
+#
+# "pin" mode exists prior to "scale" mode. If "pin: true", we will
+# do the old way using pin_server and pin_client
+#
+- name: A6 Record num server (V1) pods using workload_args.pair - TBD
   set_fact:
       num_server_pods: "{{ workload_args.pair | default('1')|int }}"
   when: workload_args.max_node is not defined
 
+####
+
 - name: A7 V2 Setup eligible node (static) list - Tobe replaced by real node list builder
   set_fact:
-      server_node_list: [ worker0, worker2 ]
+      worker_node_list: "{{workload_args.node_list}}"
 
-- name: A8 V2 Record num server pods
+- name: A8 V2 Record num server pods using new worker_node_list
   set_fact:
-      num_server_pods: "{{ server_node_list|length * workload_args.density | default('1')|int }}"
+      num_server_pods: "{{ worker_node_list|length * workload_args.density | default('1')|int }}"
   when: workload_args.max_node is defined
 
 - name: A8_1 show num_server_pods
   debug:
       var: num_server_pods
-
-### </ V2 vs V1>
 
 - block:
 
@@ -87,7 +90,7 @@
     k8s:
        definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
     with_nested:
-      - "{{ server_node_list }}" 
+      - "{{ worker_node_list }}" 
       - "{{ range(0, workload_args.density | default('1'|int)) | list }}"
     when: workload_args.max_node is defined
 
@@ -114,6 +117,8 @@
   when: resource_state.resources[0].status.state == "Building" and resource_kind == "pod"
  
 ########### <VM block>
+# VM remains scale agnostic for now
+###########
 - block:
 
   - name: V11 Start Server(s)
@@ -144,7 +149,7 @@
 
 ########### </VM vlock>
 
-########### <POD>
+########### <POD> mode
 - block:
 
   - name: P13 Get server pods
@@ -171,6 +176,7 @@
   when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "pod"
 
 ######## </POD>
+#
 ######## <VM>
 - block:
 
@@ -204,7 +210,7 @@
 
 #### </VM block>
 
-- block:   #HN while state is "start client"
+- block:   #HN while state is "start client" for pod
 
   - name: A17 Get pod info
     k8s_facts:
@@ -219,18 +225,67 @@
     k8s:
       definition: "{{ lookup('template', 'configmap.yml.j2') | from_yaml }}"
 
-  - block:
-    - name: P19 Start Client(s)
+  - block:   # Starting Clients"
+    - set_fact:
+        cpod_affi_list: []
+
+    - block:
+      - name: HN colocate TBD
+        debug:
+            msg: "HN colocate TBD"
+      when: workload_args.colocate is defined and workload_args.colocate|bool == True
+
+    #### generate affinity list
+    - block:
+
+      - name: Pass 1 - Build client list for node[1:]
+        set_fact:
+            cpod_affi_list: "{{ cpod_affi_list  + [ item[0]] }}"
+        with_nested:
+            - "{{ worker_node_list[1:] }}"
+            - "{{ range(0, workload_args.density | default('1'|int)) | list }}"
+
+      - name: HNC_0 debug cpod_list
+        debug:
+              var: cpod_affi_list
+
+      - name: Pass 2 - Append client list with node[0] to the end
+        set_fact:
+            cpod_affi_list: "{{cpod_affi_list  + [ item[0] ] }}"
+        with_nested:
+            - "{{ worker_node_list[0] }}"
+            - "{{ range(0, workload_args.density | default('1'|int)) | list }}"
+
+
+      - name: HNC_1 debug cpod_list
+        debug:
+              var: cpod_affi_list 
+
+
+      when: workload_args.colocate is not defined or workload_args.colocate|bool == False
+    #### End generate cpod affinity list
+    
+    - name: P19 Start Client(s) w/o serviceIP
       k8s:
         definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
-      with_items: "{{ server_pods.resources }}"
+      with_together: 
+        - "{{ server_pods.resources }}"
+        - "{{ cpod_affi_list }}"
       when: workload_args.serviceip is defined and not workload_args.serviceip|default('false') and server_pods.resources|length > 0
 
-    - name: P20 Start Client(s) - ServiceIP
+    - name: P20 Start Client(s) with serviceIP
       k8s:
         definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
-      with_items: "{{ serviceip.resources }}"
+      with_together: 
+        - "{{ serviceip.resources }}"
+        - "{{ cpod_affi_list }}"
+
       when: workload_args.serviceip is defined and workload_args.serviceip and serviceip.resources|length > 0
+
+    - name: compare worker000 versus pin_server
+      debug:
+          msg: "HN equal"
+      when: worker_node_list[0] == workload_args.pin_server 
 
     when: resource_kind == "pod"
  
@@ -270,7 +325,7 @@
 
 - block:
 
-  - block: #P block
+  - block: # Pod block
     - name: P22 Get client pod status
       k8s_facts:
         kind: Pod

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -56,18 +56,20 @@
 
 ####
 
-- name: A7 V2 Setup eligible node (static) list - Tobe replaced by real node list builder
+- name: A7 V2 scale run -  Setup eligible node (static) list - Tobe replaced by real node list builder
+  set_fact:
+      worker_node_list: "{{workload_args.node_list[0]}}"
+  when: workload_args.max_node is not defined
+
+- name: A7 V1 non-scale Setup eligible node (static) list - Tobe replaced by real node list builder
   set_fact:
       worker_node_list: "{{workload_args.node_list}}"
+  when: workload_args.max_node is defined
 
 - name: A8 V2 Record num server pods using new worker_node_list
   set_fact:
       num_server_pods: "{{ worker_node_list|length * workload_args.density | default('1')|int }}"
   when: workload_args.max_node is defined
-
-- name: A8_1 show num_server_pods
-  debug:
-      var: num_server_pods
 
 - block:
 
@@ -90,9 +92,12 @@
     k8s:
        definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
     with_nested:
-      - "{{ worker_node_list }}" 
+      - "{{ range(0, worker_node_list|length| default('0'|int)) | list }}"
       - "{{ range(0, workload_args.density | default('1'|int)) | list }}"
-    when: workload_args.max_node is defined
+    #
+    # Each server annotates a "node_idx" which will allow its peer client
+    # to derive its affinity according the 'colocate' variable
+    #
 
 ############ </V2>
 
@@ -226,66 +231,24 @@
       definition: "{{ lookup('template', 'configmap.yml.j2') | from_yaml }}"
 
   - block:   # Starting Clients"
-    - set_fact:
-        cpod_affi_list: []
-
-    - block:
-      - name: HN colocate TBD
-        debug:
-            msg: "HN colocate TBD"
-      when: workload_args.colocate is defined and workload_args.colocate|bool == True
-
-    #### generate affinity list
-    - block:
-
-      - name: Pass 1 - Build client list for node[1:]
-        set_fact:
-            cpod_affi_list: "{{ cpod_affi_list  + [ item[0]] }}"
-        with_nested:
-            - "{{ worker_node_list[1:] }}"
-            - "{{ range(0, workload_args.density | default('1'|int)) | list }}"
-
-      - name: HNC_0 debug cpod_list
-        debug:
-              var: cpod_affi_list
-
-      - name: Pass 2 - Append client list with node[0] to the end
-        set_fact:
-            cpod_affi_list: "{{cpod_affi_list  + [ item[0] ] }}"
-        with_nested:
-            - "{{ worker_node_list[0] }}"
-            - "{{ range(0, workload_args.density | default('1'|int)) | list }}"
-
-
-      - name: HNC_1 debug cpod_list
-        debug:
-              var: cpod_affi_list 
-
-
-      when: workload_args.colocate is not defined or workload_args.colocate|bool == False
-    #### End generate cpod affinity list
-    
     - name: P19 Start Client(s) w/o serviceIP
       k8s:
         definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
-      with_together: 
+      with_items: 
         - "{{ server_pods.resources }}"
-        - "{{ cpod_affi_list }}"
       when: workload_args.serviceip is defined and not workload_args.serviceip|default('false') and server_pods.resources|length > 0
+
+     #
+     # Each server annotates a "node_idx". Each peer client will
+     # derive its affinity according the 'colocate' variable.
+     #
 
     - name: P20 Start Client(s) with serviceIP
       k8s:
         definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
-      with_together: 
+      with_items: 
         - "{{ serviceip.resources }}"
-        - "{{ cpod_affi_list }}"
-
       when: workload_args.serviceip is defined and workload_args.serviceip and serviceip.resources|length > 0
-
-    - name: compare worker000 versus pin_server
-      debug:
-          msg: "HN equal"
-      when: worker_node_list[0] == workload_args.pin_server 
 
     when: resource_kind == "pod"
  
@@ -364,13 +327,6 @@
         status:
           state: Clients Running
       when: "workload_args.pair|default('1')|int == clients_ready_count.stdout|int"
-
-    - name: V14 debug state
-      debug: 
-        msg: "HN ater V24 {{ resource_state.resources[0].status.state }}"
-
-    when: resource_kind == "vm"
-
 
   when: resource_state.resources[0].status.state == "Waiting for Clients"
 

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -1,438 +1,67 @@
 ---
 
-- name: A1 Get current state
-  k8s_facts:
-    api_version: ripsaw.cloudbulldozer.io/v1alpha1
-    kind: Benchmark
-    name: '{{ meta.name }}'
-    namespace: '{{ operator_namespace }}'
-  register: resource_state
+- include_tasks: setup.yml
 
-- operator_sdk.util.k8s_status:
-    api_version: ripsaw.cloudbulldozer.io/v1alpha1
-    kind: Benchmark
-    name: "{{ meta.name }}"
-    namespace: "{{ operator_namespace }}"
-    status:
-      state: Building
-      complete: false
-  when: resource_state.resources[0].status.state is not defined
-
-- name: A3 Get current state - If it has changed
-  k8s_facts:
-    api_version: ripsaw.cloudbulldozer.io/v1alpha1
-    kind: Benchmark
-    name: '{{ meta.name }}'
-    namespace: '{{ operator_namespace }}'
-  register: resource_state
-
-- name: A4 Capture operator information
-  k8s_facts:
-    kind: Pod
-    api_version: v1
-    namespace: '{{ operator_namespace }}'
-    label_selectors:
-      - name = benchmark-operator
-  register: bo
-
-- name: A5 Capture ServiceIP
-  k8s_facts:
-    kind: Service
-    api_version: v1
-    namespace: '{{ operator_namespace }}'
-    label_selectors:
-      - type = uperf-bench-server-{{ trunc_uuid }}
-  register: serviceip
-  when: workload_args.serviceip is defined and workload_args.serviceip
-
-#
-# "pin" mode exists prior to "scale" mode. If "pin: true", we will
-# do the old way using pin_server and pin_client
-#
-- name: A6 Record num server (V1) pods using workload_args.pair - TBD
-  set_fact:
-      num_server_pods: "{{ workload_args.pair | default('1')|int }}"
-  when: workload_args.max_node is not defined
-
-####
-
-- name: A7 V2 scale run -  Setup eligible node (static) list - Tobe replaced by real node list builder
-  set_fact:
-      worker_node_list: "{{workload_args.node_list[0]}}"
-  when: workload_args.max_node is not defined
-
-- name: A7 V1 non-scale Setup eligible node (static) list - Tobe replaced by real node list builder
-  set_fact:
-      worker_node_list: "{{workload_args.node_list}}"
-  when: workload_args.max_node is defined
-
-- name: A8 V2 Record num server pods using new worker_node_list
-  set_fact:
-      num_server_pods: "{{ worker_node_list|length * workload_args.density | default('1')|int }}"
-  when: workload_args.max_node is defined
+- include_tasks: start_server.yml
+  when: resource_state.resources[0].status.state == "Building" 
 
 - block:
 
-  - name: P8 Create service for server pods
-    k8s:
-      definition: "{{ lookup('template', 'service.yml.j2') | from_yaml }}"
-    with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
-    when: workload_args.serviceip is defined and workload_args.serviceip
+  - include_tasks: wait_server_ready.yml
+    when: resource_state.resources[0].status.state == "Starting Servers" 
 
-  - name: P9 Start Server(s)
-    k8s:
-      definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
-    register: servers
-    with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
-    when: workload_args.max_node is not defined
+  - include_tasks: start_client.yml
+    when: resource_state.resources[0].status.state == "Starting Clients"
 
-############ <V2>
+  - include_tasks: wait_client_ready.yml
+    when: resource_state.resources[0].status.state == "Waiting for Clients"
 
-  - name: P10 V2 Start Server(s) - total = eligible nodes * density
-    k8s:
-       definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
-    with_nested:
-      - "{{ range(0, worker_node_list|length| default('0'|int)) | list }}"
-      - "{{ range(0, workload_args.density | default('1'|int)) | list }}"
-    #
-    # Each server annotates a "node_idx" which will allow its peer client
-    # to derive its affinity according the 'colocate' variable
-    #
+  - include_tasks: run_a_set.yml
+    when: resource_state.resources[0].status.state == "Clients Running"
 
-############ </V2>
-
-  - name: P11 Wait for pods to be running....
-    k8s_facts:
-      kind: Pod
-      api_version: v1
-      namespace: '{{ operator_namespace }}'
-      label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
-    register: server_pods
-
-  - name: P12 Update resource state
-    operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: "Starting Servers"
-
-  when: resource_state.resources[0].status.state == "Building" and resource_kind == "pod"
- 
-########### <VM block>
-# VM remains scale agnostic for now
-###########
-- block:
-
-  - name: V11 Start Server(s)
-    k8s:
-      definition: "{{ lookup('template', 'server_vm.yml.j2') | from_yaml }}"
-    register: servers
-    with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
-
-  - name: V12 Wait for vms to be running....
-    k8s_facts:
-      kind: VirtualMachineInstance
-      api_version: kubevirt.io/v1alpha3
-      namespace: '{{ operator_namespace }}'
-      label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
-    register: server_vms
-
-  - name: V13 Update resource state
-    operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: "Starting Servers"
-
-  when: resource_state.resources[0].status.state == "Building" and resource_kind == "vm"
-
-########### </VM vlock>
-
-########### <POD> mode
-- block:
-
-  - name: P13 Get server pods
-    k8s_facts:
-      kind: Pod
-      api_version: v1
-      namespace: '{{ operator_namespace }}'
-      label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
-    register: server_pods
-
-  - name: P14 Update resource state
-    operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: "Starting Clients"
-    when: "num_server_pods|int  == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
-    #when: "workload_args.pair|default('1')|int == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
+  - include_tasks: wait_set_done.yml
+    when: resource_state.resources[0].status.state == "Set Running"
 
 
-  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "pod"
+  - include_tasks: next_set.yml
+    when: resource_state.resources[0].status.state == "Run Next Set"
+    # will loop back to "Client Running" state, or FALLTHRU to "Running" state below and finish
 
-######## </POD>
-#
-######## <VM>
-- block:
+#  - include_tasks: send_client_run_signal.yml
+#    when: resource_state.resources[0].status.state == "Clients Running"
 
-  - name: V14 Wait for vms to be running....
-    k8s_facts:
-      kind: VirtualMachineInstance
-      api_version: kubevirt.io/v1alpha3
-      namespace: '{{ operator_namespace }}'
-      label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
-    register: server_vms
 
-  - name: V15 Update resource state
-    operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: "Starting Clients"
-    #when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
-    when: "num_server_pods|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and num_server_pods|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+  - include_tasks: wait_client_done.yml
+    when: resource_state.resources[0].status.state == "Running"
 
-  - name: V16 blocking client from running uperf
-    command: "redis-cli set start false"
-    with_items: "{{ server_vms.resources }}"
-    #when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
-    when: "num_server_pods|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and num_server_pods|int == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+  - include_tasks: cleanup.yml
+    when: resource_state.resources[0].status.state == "Cleanup"
 
-  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "vm"
+  when:  resource_kind == "pod"
 
-#### </VM block>
 
-- block:   #HN while state is "start client" for pod
-
-  - name: A17 Get pod info
-    k8s_facts:
-      kind: Pod
-      api_version: v1
-      namespace: '{{ operator_namespace }}'
-      label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
-    register: server_pods
-
-  - name: A18 Generate uperf xml files
-    k8s:
-      definition: "{{ lookup('template', 'configmap.yml.j2') | from_yaml }}"
-
-  - block:   # Starting Clients"
-    - name: P19 Start Client(s) w/o serviceIP
-      k8s:
-        definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
-      with_items: 
-        - "{{ server_pods.resources }}"
-      when: workload_args.serviceip is defined and not workload_args.serviceip|default('false') and server_pods.resources|length > 0
-
-     #
-     # Each server annotates a "node_idx". Each peer client will
-     # derive its affinity according the 'colocate' variable.
-     #
-
-    - name: P20 Start Client(s) with serviceIP
-      k8s:
-        definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
-      with_items: 
-        - "{{ serviceip.resources }}"
-      when: workload_args.serviceip is defined and workload_args.serviceip and serviceip.resources|length > 0
-
-    when: resource_kind == "pod"
- 
-  - block:
-
-    - name: V19 Wait for vms to be running....
-      k8s_facts:
-        kind: VirtualMachineInstance
-        api_version: kubevirt.io/v1alpha3
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - type = uperf-bench-server-{{ trunc_uuid }}
-      register: server_vms
-
-    - name: V20 Generate uperf test files
-      k8s:
-        definition: "{{ lookup('template', 'configmap_script.yml.j2') | from_yaml }}"
-      with_items: "{{ server_vms.resources }}"
-
-    - name: V21 Start Client(s)
-      k8s:
-        definition: "{{ lookup('template', 'workload_vm.yml.j2') | from_yaml }}"
-      with_items: "{{ server_vms.resources }}"
-      when: server_vms.resources|length > 0
-
-    when: resource_kind == "vm"
-
-  - operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: Waiting for Clients
-
-  when: resource_state.resources[0].status.state == "Starting Clients"
 
 - block:
 
-  - block: # Pod block
-    - name: P22 Get client pod status
-      k8s_facts:
-        kind: Pod
-        api_version: v1
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - app = uperf-bench-client-{{ trunc_uuid }}
-      register: client_pods
+  - include_tasks: wait_server_ready.yml
+    when: resource_state.resources[0].status.state == "Starting Servers" 
 
-    - name: P23 Update resource state
-      operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Clients Running
-      when: "num_server_pods|int == client_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and num_server_pods|int == (client_pods | json_query('resources[].status.podIP')|length)"
-      #when: "workload_args.pair|default('1')|int == client_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (client_pods | json_query('resources[].status.podIP')|length)"
+  - include_tasks: start_client.yml
+    when: resource_state.resources[0].status.state == "Starting Clients"
 
-  - block: #V block
+  - include_tasks: wait_client_ready.yml
+    when: resource_state.resources[0].status.state == "Waiting for Clients"
 
-    - name: V22 set complete to false
-      command: "redis-cli set complete false"
+  - include_tasks: send_client_run_signal.yml
+    #when: resource_state.resources[0].status.state == "Clients Running"
+    when: resource_state.resources[0].status.state == "Clients"
 
-    - name: V23  Get count of clients ready
-      command: "redis-cli get clients-{{ trunc_uuid }}"
-      register: clients_ready_count
+  - include_tasks: wait_client_done.yml
+    when: resource_state.resources[0].status.state == "Running"
 
-    - name: V24 Update resource state
-      operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Clients Running
-      when: "workload_args.pair|default('1')|int == clients_ready_count.stdout|int"
+  - include_tasks: cleanup.yml
+    when: resource_state.resources[0].status.state == "Cleanup"
 
-  when: resource_state.resources[0].status.state == "Waiting for Clients"
+  when:  resource_kind == "vm"
 
-- block:  #ALL state = Clients running
 
-  - name: A25 Signal workload
-    command: "redis-cli set start true"
-
-  - name: A26 Update resource state
-    operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: "Running"
-
-  when: resource_state.resources[0].status.state == "Clients Running"
-
-- block:
-  - block:
-    - name: P27 Waiting for pods to complete....
-      k8s_facts:
-        kind: pod
-        api_version: v1
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - app = uperf-bench-client-{{ trunc_uuid }}
-      register: client_pods
-
-    - operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Cleanup
-          complete: false
-          #when: "workload_args.pair|default('1')|int == (client_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
-      when: "num_server_pods|int == (client_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
-    when: resource_kind == "pod"
-
-  - block:
-
-    - name: V28 get complete
-      command: "redis-cli get complete"
-      register: complete_status
-
-    - operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Cleanup
-          complete: false
-      when: complete_status.stdout == "true"
-    when: resource_kind == "vm"
-
-  when: resource_state.resources[0].status.state == "Running"
-
-- block:
-
-  - block:
-    - name: P29 Get Server Pods
-      k8s_facts:
-        kind: Pod
-        api_version: v1
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - type = uperf-bench-server-{{ trunc_uuid }}
-      register: server_pods
-
-    - name: P30 Pod names - to clean
-      set_fact:
-        clean_pods: |
-            [
-            {% for item in server_pods.resources %}
-              "{{ item['metadata']['name'] }}",
-            {% endfor %}
-            ]
-
-    - name: P31 Cleanup run
-      k8s:
-        kind: pod
-        api_version: v1
-        namespace: '{{ operator_namespace }}'
-        state: absent
-        name: "{{ item }}"
-      with_items: "{{ clean_pods }}"
-      when: cleanup
-    when: resource_kind == "pod"
-
-  - name: delete redis keys
-    command: "redis-cli del {{ item }}"
-    loop:
-      - "{{ trunc_uuid }}"
-      - "clients-{{ trunc_uuid }}"
-
-  - operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: Complete
-        complete: true
-
-  when: resource_state.resources[0].status.state == "Cleanup"

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -45,6 +45,23 @@
   register: serviceip
   when: workload_args.serviceip is defined and workload_args.serviceip
 
+### V2 vs V1
+- name: V2 Record num server (V1) pods
+  set_fact:
+      num_server_pods: "{{ workload_args.pair | default('1'|int) }}"
+  when: workload_args.max_node is not defined
+
+- name: V2 Setup eligible node (static) list - Tobe replaced by real node list builder
+  set_fact:
+      server_node_list: [ worker0 ]
+
+- name: V2 Record num server pods
+  set_fact:
+      num_server_pods: "{{ server_node_list|length * workload_args.density | default('1'|int) }}"
+  when: workload_args.max_node is defined
+
+### </ V2 vs V1>
+
 - block:
 
   - name: Create service for server pods
@@ -58,6 +75,19 @@
       definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
     register: servers
     with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
+    when: workload_args.max_node is not defined
+
+############ <V2>
+
+  - name: V2 Start Server(s) - total = eligible nodes * density
+    k8s:
+       definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
+    with_nested:
+      - "{{ server_node_list }}" 
+      - "{{ range(0, workload_args.density | default('1'|int)) | list }}"
+    when: workload_args.max_node is defined
+
+############ </V2>
 
   - name: Wait for pods to be running....
     k8s_facts:
@@ -78,7 +108,8 @@
         state: "Starting Servers"
 
   when: resource_state.resources[0].status.state == "Building" and resource_kind == "pod"
-
+ 
+########### VM block
 - block:
 
   - name: Start Server(s)
@@ -107,6 +138,8 @@
 
   when: resource_state.resources[0].status.state == "Building" and resource_kind == "vm"
 
+########### </VM vlock>
+
 - block:
 
   - name: Get server pods
@@ -126,7 +159,8 @@
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Clients"
-    when: "workload_args.pair|default('1')|int == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
+    when: "num_server_pods|int  == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
+    #when: "workload_args.pair|default('1')|int == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
 
 
   when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "pod"

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -53,8 +53,7 @@
     when: resource_state.resources[0].status.state == "Waiting for Clients"
 
   - include_tasks: send_client_run_signal.yml
-    #when: resource_state.resources[0].status.state == "Clients Running"
-    when: resource_state.resources[0].status.state == "Clients"
+    when: resource_state.resources[0].status.state == "Clients Running"
 
   - include_tasks: wait_client_done.yml
     when: resource_state.resources[0].status.state == "Running"

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Get current state
+- name: A1 Get current state
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
@@ -18,7 +18,7 @@
       complete: false
   when: resource_state.resources[0].status.state is not defined
 
-- name: Get current state - If it has changed
+- name: A3 Get current state - If it has changed
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
@@ -26,7 +26,7 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
-- name: Capture operator information
+- name: A4 Capture operator information
   k8s_facts:
     kind: Pod
     api_version: v1
@@ -35,7 +35,7 @@
       - name = benchmark-operator
   register: bo
 
-- name: Capture ServiceIP
+- name: A5 Capture ServiceIP
   k8s_facts:
     kind: Service
     api_version: v1
@@ -46,31 +46,35 @@
   when: workload_args.serviceip is defined and workload_args.serviceip
 
 ### V2 vs V1
-- name: V2 Record num server (V1) pods
+- name: A6 Record num server (V1) pods
   set_fact:
-      num_server_pods: "{{ workload_args.pair | default('1'|int) }}"
+      num_server_pods: "{{ workload_args.pair | default('1')|int }}"
   when: workload_args.max_node is not defined
 
-- name: V2 Setup eligible node (static) list - Tobe replaced by real node list builder
+- name: A7 V2 Setup eligible node (static) list - Tobe replaced by real node list builder
   set_fact:
-      server_node_list: [ worker0 ]
+      server_node_list: [ worker0, worker2 ]
 
-- name: V2 Record num server pods
+- name: A8 V2 Record num server pods
   set_fact:
-      num_server_pods: "{{ server_node_list|length * workload_args.density | default('1'|int) }}"
+      num_server_pods: "{{ server_node_list|length * workload_args.density | default('1')|int }}"
   when: workload_args.max_node is defined
+
+- name: A8_1 show num_server_pods
+  debug:
+      var: num_server_pods
 
 ### </ V2 vs V1>
 
 - block:
 
-  - name: Create service for server pods
+  - name: P8 Create service for server pods
     k8s:
       definition: "{{ lookup('template', 'service.yml.j2') | from_yaml }}"
     with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
     when: workload_args.serviceip is defined and workload_args.serviceip
 
-  - name: Start Server(s)
+  - name: P9 Start Server(s)
     k8s:
       definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
     register: servers
@@ -79,7 +83,7 @@
 
 ############ <V2>
 
-  - name: V2 Start Server(s) - total = eligible nodes * density
+  - name: P10 V2 Start Server(s) - total = eligible nodes * density
     k8s:
        definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
     with_nested:
@@ -89,7 +93,7 @@
 
 ############ </V2>
 
-  - name: Wait for pods to be running....
+  - name: P11 Wait for pods to be running....
     k8s_facts:
       kind: Pod
       api_version: v1
@@ -98,7 +102,7 @@
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_pods
 
-  - name: Update resource state
+  - name: P12 Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
@@ -109,16 +113,16 @@
 
   when: resource_state.resources[0].status.state == "Building" and resource_kind == "pod"
  
-########### VM block
+########### <VM block>
 - block:
 
-  - name: Start Server(s)
+  - name: V11 Start Server(s)
     k8s:
       definition: "{{ lookup('template', 'server_vm.yml.j2') | from_yaml }}"
     register: servers
     with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
 
-  - name: Wait for vms to be running....
+  - name: V12 Wait for vms to be running....
     k8s_facts:
       kind: VirtualMachineInstance
       api_version: kubevirt.io/v1alpha3
@@ -127,7 +131,7 @@
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_vms
 
-  - name: Update resource state
+  - name: V13 Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
@@ -140,9 +144,10 @@
 
 ########### </VM vlock>
 
+########### <POD>
 - block:
 
-  - name: Get server pods
+  - name: P13 Get server pods
     k8s_facts:
       kind: Pod
       api_version: v1
@@ -151,7 +156,7 @@
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_pods
 
-  - name: Update resource state
+  - name: P14 Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
@@ -165,9 +170,11 @@
 
   when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "pod"
 
+######## </POD>
+######## <VM>
 - block:
 
-  - name: Wait for vms to be running....
+  - name: V14 Wait for vms to be running....
     k8s_facts:
       kind: VirtualMachineInstance
       api_version: kubevirt.io/v1alpha3
@@ -176,7 +183,7 @@
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_vms
 
-  - name: Update resource state
+  - name: V15 Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
@@ -184,18 +191,22 @@
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Clients"
-    when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+    #when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+    when: "num_server_pods|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and num_server_pods|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
 
-  - name: blocking client from running uperf
+  - name: V16 blocking client from running uperf
     command: "redis-cli set start false"
     with_items: "{{ server_vms.resources }}"
-    when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+    #when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+    when: "num_server_pods|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and num_server_pods|int == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
 
   when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "vm"
 
-- block:
+#### </VM block>
 
-  - name: Get pod info
+- block:   #HN while state is "start client"
+
+  - name: A17 Get pod info
     k8s_facts:
       kind: Pod
       api_version: v1
@@ -204,28 +215,28 @@
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_pods
 
-  - name: Generate uperf xml files
+  - name: A18 Generate uperf xml files
     k8s:
       definition: "{{ lookup('template', 'configmap.yml.j2') | from_yaml }}"
 
   - block:
-    - name: Start Client(s)
+    - name: P19 Start Client(s)
       k8s:
         definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
       with_items: "{{ server_pods.resources }}"
       when: workload_args.serviceip is defined and not workload_args.serviceip|default('false') and server_pods.resources|length > 0
 
-    - name: Start Client(s) - ServiceIP
+    - name: P20 Start Client(s) - ServiceIP
       k8s:
         definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
       with_items: "{{ serviceip.resources }}"
       when: workload_args.serviceip is defined and workload_args.serviceip and serviceip.resources|length > 0
 
     when: resource_kind == "pod"
-
+ 
   - block:
 
-    - name: Wait for vms to be running....
+    - name: V19 Wait for vms to be running....
       k8s_facts:
         kind: VirtualMachineInstance
         api_version: kubevirt.io/v1alpha3
@@ -234,12 +245,12 @@
           - type = uperf-bench-server-{{ trunc_uuid }}
       register: server_vms
 
-    - name: Generate uperf test files
+    - name: V20 Generate uperf test files
       k8s:
         definition: "{{ lookup('template', 'configmap_script.yml.j2') | from_yaml }}"
       with_items: "{{ server_vms.resources }}"
 
-    - name: Start Client(s)
+    - name: V21 Start Client(s)
       k8s:
         definition: "{{ lookup('template', 'workload_vm.yml.j2') | from_yaml }}"
       with_items: "{{ server_vms.resources }}"
@@ -259,8 +270,8 @@
 
 - block:
 
-  - block:
-    - name: Get client pod status
+  - block: #P block
+    - name: P22 Get client pod status
       k8s_facts:
         kind: Pod
         api_version: v1
@@ -269,7 +280,7 @@
           - app = uperf-bench-client-{{ trunc_uuid }}
       register: client_pods
 
-    - name: Update resource state
+    - name: P23 Update resource state
       operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
@@ -277,20 +288,19 @@
         namespace: "{{ operator_namespace }}"
         status:
           state: Clients Running
-      when: "workload_args.pair|default('1')|int == client_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (client_pods | json_query('resources[].status.podIP')|length)"
+      when: "num_server_pods|int == client_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and num_server_pods|int == (client_pods | json_query('resources[].status.podIP')|length)"
+      #when: "workload_args.pair|default('1')|int == client_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (client_pods | json_query('resources[].status.podIP')|length)"
 
-    when: resource_kind == "pod"
+  - block: #V block
 
-  - block:
-
-    - name: set complete to false
+    - name: V22 set complete to false
       command: "redis-cli set complete false"
 
-    - name: Get count of clients ready
+    - name: V23  Get count of clients ready
       command: "redis-cli get clients-{{ trunc_uuid }}"
       register: clients_ready_count
 
-    - name: Update resource state
+    - name: V24 Update resource state
       operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
@@ -300,16 +310,21 @@
           state: Clients Running
       when: "workload_args.pair|default('1')|int == clients_ready_count.stdout|int"
 
+    - name: V14 debug state
+      debug: 
+        msg: "HN ater V24 {{ resource_state.resources[0].status.state }}"
+
     when: resource_kind == "vm"
+
 
   when: resource_state.resources[0].status.state == "Waiting for Clients"
 
-- block:
+- block:  #ALL state = Clients running
 
-  - name: Signal workload
+  - name: A25 Signal workload
     command: "redis-cli set start true"
 
-  - name: Update resource state
+  - name: A26 Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
@@ -322,7 +337,7 @@
 
 - block:
   - block:
-    - name: Waiting for pods to complete....
+    - name: P27 Waiting for pods to complete....
       k8s_facts:
         kind: pod
         api_version: v1
@@ -339,12 +354,13 @@
         status:
           state: Cleanup
           complete: false
-      when: "workload_args.pair|default('1')|int == (client_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
+          #when: "workload_args.pair|default('1')|int == (client_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
+      when: "num_server_pods|int == (client_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
     when: resource_kind == "pod"
 
   - block:
 
-    - name: get complete
+    - name: V28 get complete
       command: "redis-cli get complete"
       register: complete_status
 
@@ -364,7 +380,7 @@
 - block:
 
   - block:
-    - name: Get Server Pods
+    - name: P29 Get Server Pods
       k8s_facts:
         kind: Pod
         api_version: v1
@@ -373,7 +389,7 @@
           - type = uperf-bench-server-{{ trunc_uuid }}
       register: server_pods
 
-    - name: Pod names - to clean
+    - name: P30 Pod names - to clean
       set_fact:
         clean_pods: |
             [
@@ -382,7 +398,7 @@
             {% endfor %}
             ]
 
-    - name: Cleanup run
+    - name: P31 Cleanup run
       k8s:
         kind: pod
         api_version: v1

--- a/roles/uperf/tasks/next_set.yml
+++ b/roles/uperf/tasks/next_set.yml
@@ -61,7 +61,7 @@
     # All done
     #
     - name: Unpause pods to complete
-      command: "redis-cli set start done"
+      command: "redis-cli set start-{{trunc_uuid}} done"
 
     - name: Change state to proceed to exit
       operator_sdk.util.k8s_status:
@@ -79,10 +79,10 @@
     # More round(s) to run.
     #
     - name: Send redis restart signal
-      command: "redis-cli set start restart"
+      command: "redis-cli set start-{{trunc_uuid}} restart"
 
     - name: Reset redis num_completion
-      command: "redis-cli set num_completion 0"
+      command: "redis-cli set num_completion-{{trunc_uuid}} 0"
 
     - name: Change state to run next round
       operator_sdk.util.k8s_status:

--- a/roles/uperf/tasks/next_set.yml
+++ b/roles/uperf/tasks/next_set.yml
@@ -8,31 +8,17 @@
 # continues where it left off.
 #
 - block:
-  - name: debug 
-    command: "redis-cli set task next_set"
   - name:
     set_fact:
         all_run_done: False
 
-  - name: read previous pod_idx
-    command: "redis-cli get pod_idx"
-    register: redis_pod_idx
-
   - name: Increment pod_idx
     set_fact:
-        pod_idx: "{{redis_pod_idx.stdout|int + 1}}"
+        pod_idx: "{{resource_state.resources[0].status.pod_idx|int +1 }}"
 
-  - name: read pod_hi_idx 
-    command: "redis-cli get pod_hi_idx"
-    register: redis_pod_hi_idx
-
-  - name: Read prev node_idx
-    command: "redis-cli get node_idx"
-    register: redis_node_idx
-
-  - name: node_idx
+  - name: Read previous node_idx
     set_fact:
-       node_idx: "{{redis_node_idx.stdout|int}}"
+       node_idx: "{{resource_state.resources[0].status.node_idx|int}}"
 
   - block: 
     #
@@ -42,28 +28,20 @@
       set_fact:
         node_idx: "{{node_idx|int + 1}}"
 
-    - name: Read node_hi_idx
-      command: "redis-cli get node_hi_idx"
-      register: redis_node_hi_idx
-
     - name: Check node loop for ending condition
       set_fact:
         all_run_done: True
-      when: "node_idx|int > redis_node_hi_idx.stdout|int"
+      when: "node_idx|int > resource_state.resources[0].status.node_hi_idx|int"
 
     #
     # Reset pod_idx AFTER node_idx tasks above, else cond change
     # causes it to skip node_idx tasks
     #
-    - name: read pod_low_idx
-      command: "redis-cli get pod_low_idx"
-      register: redis_pod_low_idx
-  
     - name: Reset pod_idx to pod_low_idx
       set_fact:
-        pod_idx: "{{redis_pod_low_idx.stdout|int}}"
+        pod_idx: "{{resource_state.resources[0].status.pod_low_idx}}"
 
-    when: "pod_idx|int > redis_pod_hi_idx.stdout|int"
+    when: "pod_idx|int > resource_state.resources[0].status.pod_hi_idx|int"
 
   - block:
     # 
@@ -93,7 +71,7 @@
     - name: Reset redis num_completion
       command: "redis-cli set num_completion 0"
 
-    # New node_idx value on new node loop ONLY. But we are lazy, just write every time.
+    # New node_idx value on new node loop ONLY. But we simply write every time.
     - name: Set next run node_idx
       command: "redis-cli set node_idx {{node_idx}}"
 
@@ -108,6 +86,8 @@
           namespace: "{{ operator_namespace }}"
           status:
             state: Clients Running
+            pod_idx: "{{pod_idx}}"
+            node_idx: "{{node_idx}}"
 
     when: all_run_done == False
 

--- a/roles/uperf/tasks/next_set.yml
+++ b/roles/uperf/tasks/next_set.yml
@@ -1,6 +1,6 @@
 ---
 #
-# This module logically implements RE-ENTRANT double for loops
+# This module logically implements RE-ENTRANT nested for loops
 #   with_items:
 #     range (node_low_idx, node_hi_idx)
 #     range (pod_low_idx, pod_hi_idx)
@@ -8,25 +8,36 @@
 # continues where it left off.
 #
 - block:
-  - name:
+  - name: Read previous node_idx and pod_idx
     set_fact:
         all_run_done: False
+        inc: "{{workload_args.step_size|default('add1')}}"
+        amount: 0
+        pod_idx: "{{resource_state.resources[0].status.pod_idx|int}}"
+        node_idx: "{{resource_state.resources[0].status.node_idx|int}}"
+
+  - name: Extract add amount
+    set_fact:
+      amount: "{{ inc | regex_replace('[^0-9]', '') }}"
+      inc: add
+    when: "'add' in inc"
 
   - name: Increment pod_idx
     set_fact:
-        pod_idx: "{{resource_state.resources[0].status.pod_idx|int +1 }}"
-
-  - name: Read previous node_idx
-    set_fact:
-       node_idx: "{{resource_state.resources[0].status.node_idx|int}}"
-
+        pod_idx: "{%-if inc=='add' -%}{{pod_idx|int+amount|int}} 
+                  {%-elif inc=='log2' -%}{{(pod_idx|int*2)+1}} 
+                  {%-else -%}{{pod_idx|int+1}} 
+                  {% endif %}"
   - block: 
     #
     # This block starts a new node loop
     #
     - name: Increment node_idx
       set_fact:
-        node_idx: "{{node_idx|int + 1}}"
+        node_idx: "{%- if inc=='add' -%}{{node_idx|int+amount|int}} 
+                   {%- elif inc=='log2' -%}{{(node_idx|int *2)+1}} 
+                   {%- else -%}{{node_idx|int+1}} 
+                   {% endif %}"
 
     - name: Check node loop for ending condition
       set_fact:

--- a/roles/uperf/tasks/next_set.yml
+++ b/roles/uperf/tasks/next_set.yml
@@ -68,7 +68,7 @@
           name: "{{ meta.name }}"
           namespace: "{{ operator_namespace }}"
           status:
-            state: Set Running
+            state: Running
 
     when: all_run_done == True
 
@@ -81,13 +81,6 @@
 
     - name: Reset redis num_completion
       command: "redis-cli set num_completion 0"
-
-    # New node_idx value on new node loop ONLY. But we simply write every time.
-    - name: Set next run node_idx
-      command: "redis-cli set node_idx {{node_idx}}"
-
-    - name: Set next run pod_idx
-      command: "redis-cli set pod_idx {{pod_idx}}"
 
     - name: Change state to run next round
       operator_sdk.util.k8s_status:

--- a/roles/uperf/tasks/next_set.yml
+++ b/roles/uperf/tasks/next_set.yml
@@ -1,9 +1,11 @@
 ---
 #
-# This module logically implements RE-ENTRANT nested for loops
+# This module logically implements an RE-ENTRANT nested "for" loops;
+#   <do something>  
 #   with_items:
 #     range (node_low_idx, node_hi_idx)
 #     range (pod_low_idx, pod_hi_idx)
+#
 # Each iteration executes one item, and each re-entrance
 # continues where it left off.
 #
@@ -95,5 +97,8 @@
 
     when: all_run_done == False
 
-  when: resource_state.resources[0].status.state == "Run Next Set"
+  when: resource_kind == "pod"
 
+#
+# No <VM> block - Scale mode support is N/A
+#

--- a/roles/uperf/tasks/next_set.yml
+++ b/roles/uperf/tasks/next_set.yml
@@ -1,0 +1,59 @@
+---
+
+- block:
+  - name: debug 
+    command: "redis-cli set task next_set"
+
+  - name: read last group_node_count
+    command: "redis-cli get group_node_count"
+    register: redis_out
+
+  - name: Compute next run group size
+    set_fact:
+        group_node_count: "{{redis_out.stdout|int + 1}}"
+
+  - block:
+    # 
+    # We have passed max_node - All done
+    #
+    - name: Unpause pods to complete
+      command: "redis-cli set start done"
+
+    - name: Change state to proceed to exit
+      operator_sdk.util.k8s_status:
+          api_version: ripsaw.cloudbulldozer.io/v1alpha1
+          kind: Benchmark
+          name: "{{ meta.name }}"
+          namespace: "{{ operator_namespace }}"
+          status:
+            state: Set Running
+
+    when: "group_node_count|int > workload_args.max_node|int"
+
+  - block:
+    # 
+    # More round(s) to run.
+    #
+
+    - name: Send redis restart signal
+      command: "redis-cli set start restart"
+
+    - name: Reset redis num_completion
+      command: "redis-cli set num_completion 0"
+
+    - name: Set next run group_node_count
+      command: "redis-cli set group_node_count {{group_node_count}}"
+
+    - name: Change state to run next round
+      operator_sdk.util.k8s_status:
+          api_version: ripsaw.cloudbulldozer.io/v1alpha1
+          kind: Benchmark
+          name: "{{ meta.name }}"
+          namespace: "{{ operator_namespace }}"
+          status:
+            state: Clients Running
+
+    when: "group_node_count|int <= workload_args.max_node|int"
+
+  when: resource_state.resources[0].status.state == "Run Next Set"
+

--- a/roles/uperf/tasks/next_set.yml
+++ b/roles/uperf/tasks/next_set.yml
@@ -1,20 +1,73 @@
 ---
-
+#
+# This module logically implements RE-ENTRANT double for loops
+#   with_items:
+#     range (node_low_idx, node_hi_idx)
+#     range (pod_low_idx, pod_hi_idx)
+# Each iteration executes one item, and each re-entrance
+# continues where it left off.
+#
 - block:
   - name: debug 
     command: "redis-cli set task next_set"
-
-  - name: read last group_node_count
-    command: "redis-cli get group_node_count"
-    register: redis_out
-
-  - name: Compute next run group size
+  - name:
     set_fact:
-        group_node_count: "{{redis_out.stdout|int + 1}}"
+        all_run_done: False
+
+  - name: read previous pod_idx
+    command: "redis-cli get pod_idx"
+    register: redis_pod_idx
+
+  - name: Increment pod_idx
+    set_fact:
+        pod_idx: "{{redis_pod_idx.stdout|int + 1}}"
+
+  - name: read pod_hi_idx 
+    command: "redis-cli get pod_hi_idx"
+    register: redis_pod_hi_idx
+
+  - name: Read prev node_idx
+    command: "redis-cli get node_idx"
+    register: redis_node_idx
+
+  - name: node_idx
+    set_fact:
+       node_idx: "{{redis_node_idx.stdout|int}}"
+
+  - block: 
+    #
+    # This block starts a new node loop
+    #
+    - name: Increment node_idx
+      set_fact:
+        node_idx: "{{node_idx|int + 1}}"
+
+    - name: Read node_hi_idx
+      command: "redis-cli get node_hi_idx"
+      register: redis_node_hi_idx
+
+    - name: Check node loop for ending condition
+      set_fact:
+        all_run_done: True
+      when: "node_idx|int > redis_node_hi_idx.stdout|int"
+
+    #
+    # Reset pod_idx AFTER node_idx tasks above, else cond change
+    # causes it to skip node_idx tasks
+    #
+    - name: read pod_low_idx
+      command: "redis-cli get pod_low_idx"
+      register: redis_pod_low_idx
+  
+    - name: Reset pod_idx to pod_low_idx
+      set_fact:
+        pod_idx: "{{redis_pod_low_idx.stdout|int}}"
+
+    when: "pod_idx|int > redis_pod_hi_idx.stdout|int"
 
   - block:
     # 
-    # We have passed max_node - All done
+    # All done
     #
     - name: Unpause pods to complete
       command: "redis-cli set start done"
@@ -28,21 +81,24 @@
           status:
             state: Set Running
 
-    when: "group_node_count|int > workload_args.max_node|int"
+    when: all_run_done == True
 
   - block:
     # 
     # More round(s) to run.
     #
-
     - name: Send redis restart signal
       command: "redis-cli set start restart"
 
     - name: Reset redis num_completion
       command: "redis-cli set num_completion 0"
 
-    - name: Set next run group_node_count
-      command: "redis-cli set group_node_count {{group_node_count}}"
+    # New node_idx value on new node loop ONLY. But we are lazy, just write every time.
+    - name: Set next run node_idx
+      command: "redis-cli set node_idx {{node_idx}}"
+
+    - name: Set next run pod_idx
+      command: "redis-cli set pod_idx {{pod_idx}}"
 
     - name: Change state to run next round
       operator_sdk.util.k8s_status:
@@ -53,7 +109,7 @@
           status:
             state: Clients Running
 
-    when: "group_node_count|int <= workload_args.max_node|int"
+    when: all_run_done == False
 
   when: resource_state.resources[0].status.state == "Run Next Set"
 

--- a/roles/uperf/tasks/run_a_set.yml
+++ b/roles/uperf/tasks/run_a_set.yml
@@ -3,9 +3,9 @@
 - block:
   #
   # Entry Condition: 
-  #    1. A previous task has set 'node_idx' in redis
+  #    1. A previous task has set 'node_idx' and 'pod_idx' in redis
   #    2. All cliest are polling for 'start' to run its workoad
-  # Output: Clients with idx <= node_idx will run
+  # Output: Clients with node_idx <= redis node_idx && pod_idx <= redis pod_ix
   #
 
   - name: Signal group to run

--- a/roles/uperf/tasks/run_a_set.yml
+++ b/roles/uperf/tasks/run_a_set.yml
@@ -3,9 +3,9 @@
 - block:
   #
   # Entry Condition: 
-  #    1. A previous task has set 'group_node_count' in redis
+  #    1. A previous task has set 'node_idx' in redis
   #    2. All cliest are polling for 'start' to run its workoad
-  # Output: Clients with idx <= group_node_count will run
+  # Output: Clients with idx <= node_idx will run
   #
 
   - name: Signal group to run

--- a/roles/uperf/tasks/run_a_set.yml
+++ b/roles/uperf/tasks/run_a_set.yml
@@ -9,7 +9,7 @@
   #
 
   - name: Signal group to run
-    command: "redis-cli set start true "
+    command: "redis-cli set start true-{{resource_state.resources[0].status.node_idx|int}}-{{resource_state.resources[0].status.pod_idx|int}}"
 
   - name: Update state to "Set Running"
     operator_sdk.util.k8s_status:

--- a/roles/uperf/tasks/run_a_set.yml
+++ b/roles/uperf/tasks/run_a_set.yml
@@ -9,7 +9,7 @@
   #
 
   - name: Signal group to run
-    command: "redis-cli set start true-{{resource_state.resources[0].status.node_idx|int}}-{{resource_state.resources[0].status.pod_idx|int}}"
+    command: "redis-cli set start-{{trunc_uuid}} true-{{resource_state.resources[0].status.node_idx|int}}-{{resource_state.resources[0].status.pod_idx|int}}"
 
   - name: Update state to "Set Running"
     operator_sdk.util.k8s_status:

--- a/roles/uperf/tasks/run_a_set.yml
+++ b/roles/uperf/tasks/run_a_set.yml
@@ -5,7 +5,7 @@
   # Entry Condition: 
   #    1. A previous task has set 'node_idx' and 'pod_idx' in benchmark ctx
   #    2. All cliest are polling redis for 'start-node_idx-pod_idx' to start
-  # Output: Clients with node_idx <= redis node_idx && pod_idx <= redis pod_ix
+  # Output: Clients with node_idx <= redis node_idx && pod_idx <= redis pod_ix will run
   #
 
   - name: Signal group to run
@@ -19,6 +19,8 @@
       namespace: "{{ operator_namespace }}"
       status:
         state: Set Running
+  when: resource_kind == "pod"
 
-  when: resource_state.resources[0].status.state == "Clients Running"
-
+#
+# No <VM> kind - It has not been adapted to Scale mode
+#

--- a/roles/uperf/tasks/run_a_set.yml
+++ b/roles/uperf/tasks/run_a_set.yml
@@ -1,0 +1,27 @@
+---
+
+- block:
+  #
+  # Entry Condition: 
+  #    1. A previous task has set 'group_node_count' in redis
+  #    2. All cliest are polling for 'start' to run its workoad
+  # Output: Clients with idx <= group_node_count will run
+  #
+
+  - name: Signal group to run
+    command: "redis-cli set start true "
+
+  - name: Update state to "Set Running"
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Set Running
+
+  - name: debug 2
+    command: "redis-cli set state Set_Running"
+
+  when: resource_state.resources[0].status.state == "Clients Running"
+

--- a/roles/uperf/tasks/run_a_set.yml
+++ b/roles/uperf/tasks/run_a_set.yml
@@ -3,8 +3,8 @@
 - block:
   #
   # Entry Condition: 
-  #    1. A previous task has set 'node_idx' and 'pod_idx' in redis
-  #    2. All cliest are polling for 'start' to run its workoad
+  #    1. A previous task has set 'node_idx' and 'pod_idx' in benchmark ctx
+  #    2. All cliest are polling redis for 'start-node_idx-pod_idx' to start
   # Output: Clients with node_idx <= redis node_idx && pod_idx <= redis pod_ix
   #
 
@@ -19,9 +19,6 @@
       namespace: "{{ operator_namespace }}"
       status:
         state: Set Running
-
-  - name: debug 2
-    command: "redis-cli set state Set_Running"
 
   when: resource_state.resources[0].status.state == "Clients Running"
 

--- a/roles/uperf/tasks/send_client_run_signal.yml
+++ b/roles/uperf/tasks/send_client_run_signal.yml
@@ -1,0 +1,18 @@
+---
+
+- block:
+
+  - name: A25 Signal workload
+    command: "redis-cli set start true"
+
+  - name: A26 Update resource state
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Running"
+
+  when: resource_state.resources[0].status.state == "Clients Running"
+

--- a/roles/uperf/tasks/send_client_run_signal.yml
+++ b/roles/uperf/tasks/send_client_run_signal.yml
@@ -1,8 +1,8 @@
 ---
-
+# This module is invoked by VM-kind only
 - block:
 
-  - name: A25 Signal workload
+  - name: Signal workload
     command: "redis-cli set start true"
 
   - name: A26 Update resource state

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -51,8 +51,8 @@
   
   - name: Isolate Worker Role Hostnames
     set_fact:
-      worker_node_list: "{{ node_list | json_query('resources[].metadata.name') | list }}"
-  
+      worker_node_list: "{{ node_list | json_query('resources[].metadata.labels.\"kubernetes.io/hostname\"') | list }}"
+ 
   - name: List Nodes Labeled with {{ workload_args.exclude_label }}
     k8s_info:
       api_version: v1

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -161,7 +161,7 @@
     api_version: v1
     namespace: '{{ operator_namespace }}'
     label_selectors:
-      - type = uperf-bench-server-{{ trunc_uuid }}
+      - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
   register: serviceip
   when: workload_args.serviceip is defined and workload_args.serviceip
 

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -123,14 +123,27 @@
     with_items:
       - '{{workload_args.pin_server}}'
       - '{{workload_args.pin_client}}'
+  #
+  # In 'Pin' mode, 'pair' specifies number of pairs (classic behavior), If 'pair' 
+  # is undefined use 'density_range' (new bahavior with "Scale" enhancement)
+  #
+  - name: Init "Pin" mode indices using 'pair'
+    set_fact:
+        pod_low_idx: "{{ workload_args.pair | default('1')|int - 1 }}"
+        pod_hi_idx: "{{ workload_args.pair | default('1')|int - 1 }}"
+        # node indices are used as client pod 'start' parameter.
+        node_low_idx: "0"
+        node_hi_idx: "0"
+    when: workload_args.pair is defined
 
-  - name: Init "Pin" mode node and pod indices
+  - name: Init "Pin" mode indices using 'density_range'
     set_fact:
         pod_low_idx: "{{ workload_args.density_range[0] | default('1')|int - 1 }}"
         pod_hi_idx: "{{ workload_args.density_range[1] | default('1')|int - 1 }}"
         # node indices are used as client pod 'start' parameter.
         node_low_idx: "0"
         node_hi_idx: "0"
+    when: workload_args.pair is not defined
 
   - name: Record num Pin server pods using new worker_node_list
     set_fact:

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -67,13 +67,6 @@
 # Compute node and pod limits using CR params while taking into account 
 # of the actual number of nodes available in the system
 #
-- name: init node idx
-  set_fact:
-       node_idx: "{{ workload_args.min_node | default('0')|int }}"
-    #
-    # TBD HN range check, colocate and other checks
-    #
-
 - name: init pod low idx
   set_fact:
       pod_low_idx: "{{ workload_args.density_range[0]|int | default('1')|int - 1 }}"
@@ -102,20 +95,20 @@
 - name: A6 Record num server (V1) pods using workload_args.pair - TBD
   set_fact:
       num_server_pods: "{{ workload_args.pair | default('1')|int }}"
-  when: workload_args.max_node is not defined
+  when: workload_args.node_range is not defined
 
   #- name: A7 V2 scale run -  Setup eligible node (static) list - Tobe replaced by real node list builder
   #  set_fact:
   #      worker_node_list: "{{workload_args.node_list[0]}}"
-  #  when: workload_args.max_node is not defined
+  #  when: workload_args.node_range is not defined
   #
   #- name: A7 V1 non-scale Setup eligible node (static) list - Tobe replaced by real node list builder
   #  set_fact:
   #      worker_node_list: "{{workload_args.node_list}}"
-  #  when: workload_args.max_node is defined
+  #  when: workload_args.node_range is defined
 
 - name: A8 V2 Record num server pods using new worker_node_list
   set_fact:
       num_server_pods: "{{ (node_hi_idx|int+1) * (pod_hi_idx|int+1) }}"
-  when: workload_args.max_node is defined
+  when: workload_args.node_range is defined
 

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -50,8 +50,8 @@
 
 - name: Exlude unhealthy nodes i.e. low diskspace 
   set_fact:
-      worker_node_list: "{{ worker_node_list | reject('search', workload_args.exluded_node) | list }}"
-  when: workload_args.exluded_node is defined
+      worker_node_list: "{{ worker_node_list | difference(workload_args.excluded_node[0]) }}"
+  when: workload_args.excluded_node is defined
 
 - name: A5 Capture ServiceIP
   k8s_facts:

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -48,10 +48,23 @@
   set_fact:
     worker_node_list: "{{ node_list | json_query('resources[].metadata.name') | list }}"
 
-- name: Exclude unhealthy nodes i.e. low diskspace 
+- name: List Nodes Labeled with {{ workload_args.exclude_label }}
+  k8s_info:
+    api_version: v1
+    kind: Node
+    label_selectors:
+      - '{{ item }}'
+  with_items: "{{ workload_args.exclude_labels }}"
+  register: exclude_node_list
+
+- name: Isolate Worker Role Hostnames for label  {{ workload_args.exclude_label }}
   set_fact:
-      worker_node_list: "{{ worker_node_list | difference(workload_args.excluded_node[0]) }}"
-  when: workload_args.excluded_node is defined and workload_args.excluded_node|length > 0
+    worker_node_exclude_list: "{{ exclude_node_list | json_query('results[].resources[].metadata.name') }}"
+
+- name: Exclude labelled nodes
+  set_fact:
+      worker_node_list: "{{ worker_node_list | difference(worker_node_exclude_list) }}"
+  when: workload_args.exclude_labels is defined and workload_args.exclude_labels | length > 0
 
 - name: A5 Capture ServiceIP
   k8s_facts:

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -67,7 +67,7 @@
     set_fact:
       worker_node_exclude_list: "{{ exclude_node_list | json_query('results[].resources[].metadata.name') }}"
   
-  - name: Exclude labelled nodes
+  - name: Exclude labeled nodes
     set_fact:
         worker_node_list: "{{ worker_node_list | difference(worker_node_exclude_list) }}"
     when: workload_args.exclude_labels is defined and workload_args.exclude_labels | length > 0
@@ -81,20 +81,33 @@
         pod_hi_idx: "{{ workload_args.density_range[1] | default('1')|int - 1 }}"
         node_low_idx: "{{ workload_args.node_range[0] | default('1')|int - 1 }}"
         node_hi_idx: "{{ workload_args.node_range[1]  | default('1')|int - 1 }}"
-  
+    #
+    # Next sanity check and massage the indices if necessary.
+    # We shall complete gracefully and not iterate wildly.
+    #
   - name: Adjust node_hi_idx if cluster has less nodes
     set_fact:
         node_hi_idx: "{{ worker_node_list|length| default('0')|int -1 }}"
     when: "node_hi_idx|int >= worker_node_list|length| default('0')|int "
+
+  - name: Adjust node_low_idx if necessary 
+    set_fact:
+        node_low_idx: "{{node_hi_idx|int}}"
+    when: "node_low_idx|int > node_hi_idx|int"
+
+  - name: Adjust pod_low_idx if necessary
+    set_fact:
+        pod_low_idx: "{{pod_hi_idx|int}}"
+    when: "pod_low_idx|int > pod_hi_idx|int"
 
   - name: Record num server pods using new worker_node_list
     # in Scale mode, num server pods = num_node * number_pod
     set_fact:
       num_server_pods: "{{ (node_hi_idx|int+1) * (pod_hi_idx|int+1) }}"
  
-      #
-      # End scle mode
-      #
+    #
+    # End scale mode
+    #
   when: workload_args.pin | default(False) == False
 
 - block:
@@ -119,7 +132,7 @@
         node_low_idx: "0"
         node_hi_idx: "0"
 
-  - name: A8 V2 Record num Pin server pods using new worker_node_list
+  - name: Record num Pin server pods using new worker_node_list
     set_fact:
       # in Pin mode, num server pods = number of pods 
       num_server_pods: "{{ pod_hi_idx|int +1 }}"

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -45,8 +45,12 @@
   no_log: True
 
 - name: Isolate Worker Role Hostnames
-  register:
+  set_fact:
     worker_node_list: "{{ node_list | json_query('resources[].metadata.name') | list }}"
+
+- name: Exlude unhealthy nodes i.e. low diskspace 
+  set_fact:
+      worker_node_list: "{{ worker_node_list | reject('search', workload_args.exluded_node) | list }}"
 
 - name: A5 Capture ServiceIP
   k8s_facts:

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -51,6 +51,7 @@
 - name: Exlude unhealthy nodes i.e. low diskspace 
   set_fact:
       worker_node_list: "{{ worker_node_list | reject('search', workload_args.exluded_node) | list }}"
+  when: workload_args.exluded_node is defined
 
 - name: A5 Capture ServiceIP
   k8s_facts:

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -1,0 +1,71 @@
+---
+
+- name: A1 Get current state
+  k8s_facts:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: '{{ meta.name }}'
+    namespace: '{{ operator_namespace }}'
+  register: resource_state
+
+- operator_sdk.util.k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      state: Building
+      complete: false
+  when: resource_state.resources[0].status.state is not defined
+
+- name: A3 Get current state - If it has changed
+  k8s_facts:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: '{{ meta.name }}'
+    namespace: '{{ operator_namespace }}'
+  register: resource_state
+
+- name: A4 Capture operator information
+  k8s_facts:
+    kind: Pod
+    api_version: v1
+    namespace: '{{ operator_namespace }}'
+    label_selectors:
+      - name = benchmark-operator
+  register: bo
+
+- name: A5 Capture ServiceIP
+  k8s_facts:
+    kind: Service
+    api_version: v1
+    namespace: '{{ operator_namespace }}'
+    label_selectors:
+      - type = uperf-bench-server-{{ trunc_uuid }}
+  register: serviceip
+  when: workload_args.serviceip is defined and workload_args.serviceip
+
+#
+# "pin" mode exists prior to "scale" mode. If "pin: true", we will
+# do the old way using pin_server and pin_client
+#
+- name: A6 Record num server (V1) pods using workload_args.pair - TBD
+  set_fact:
+      num_server_pods: "{{ workload_args.pair | default('1')|int }}"
+  when: workload_args.max_node is not defined
+
+- name: A7 V2 scale run -  Setup eligible node (static) list - Tobe replaced by real node list builder
+  set_fact:
+      worker_node_list: "{{workload_args.node_list[0]}}"
+  when: workload_args.max_node is not defined
+
+- name: A7 V1 non-scale Setup eligible node (static) list - Tobe replaced by real node list builder
+  set_fact:
+      worker_node_list: "{{workload_args.node_list}}"
+  when: workload_args.max_node is defined
+
+- name: A8 V2 Record num server pods using new worker_node_list
+  set_fact:
+      num_server_pods: "{{ worker_node_list|length * workload_args.density | default('1')|int }}"
+  when: workload_args.max_node is defined
+

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: A1 Get current state
+- name: Get current state
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
@@ -18,7 +18,7 @@
       complete: false
   when: resource_state.resources[0].status.state is not defined
 
-- name: A3 Get current state - If it has changed
+- name: Get current state - If it has changed
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
@@ -26,7 +26,7 @@
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
-- name: A4 Capture operator information
+- name: Capture operator information
   k8s_facts:
     kind: Pod
     api_version: v1
@@ -34,40 +34,102 @@
     label_selectors:
       - name = benchmark-operator
   register: bo
+  
+- block:
+    #
+    # This block is for scale mode where client and server pods are spreaded
+    # across all eligible nodes
+    #
+  - name: List Nodes Labeled as Workers
+    k8s_info:
+      api_version: v1
+      kind: Node
+      label_selectors:
+        - "node-role.kubernetes.io/worker="
+    register: node_list
+    no_log: True
+  
+  - name: Isolate Worker Role Hostnames
+    set_fact:
+      worker_node_list: "{{ node_list | json_query('resources[].metadata.name') | list }}"
+  
+  - name: List Nodes Labeled with {{ workload_args.exclude_label }}
+    k8s_info:
+      api_version: v1
+      kind: Node
+      label_selectors:
+        - '{{ item }}'
+    with_items: "{{ workload_args.exclude_labels }}"
+    register: exclude_node_list
+    when: workload_args.exclude_labels is defined and workload_args.exclude_labels | length > 0
+  
+  - name: Isolate Worker Role Hostnames for label  {{ workload_args.exclude_label }}
+    set_fact:
+      worker_node_exclude_list: "{{ exclude_node_list | json_query('results[].resources[].metadata.name') }}"
+  
+  - name: Exclude labelled nodes
+    set_fact:
+        worker_node_list: "{{ worker_node_list | difference(worker_node_exclude_list) }}"
+    when: workload_args.exclude_labels is defined and workload_args.exclude_labels | length > 0
+    #
+    # Compute node and pod limits using CR params while taking into account 
+    # of the actual number of nodes available in the system
+    #
+  - name: init pod and node low/hi idx
+    set_fact:
+        pod_low_idx: "{{ workload_args.density_range[0] | default('1')|int - 1 }}"
+        pod_hi_idx: "{{ workload_args.density_range[1] | default('1')|int - 1 }}"
+        node_low_idx: "{{ workload_args.node_range[0] | default('1')|int - 1 }}"
+        node_hi_idx: "{{ workload_args.node_range[1]  | default('1')|int - 1 }}"
+  
+  - name: Adjust node_hi_idx if cluster has less nodes
+    set_fact:
+        node_hi_idx: "{{ worker_node_list|length| default('0')|int -1 }}"
+    when: "node_hi_idx|int >= worker_node_list|length| default('0')|int "
 
-- name: List Nodes Labeled as Workers
-  k8s_info:
-    api_version: v1
-    kind: Node
-    label_selectors:
-      - "node-role.kubernetes.io/worker="
-  register: node_list
-  no_log: True
+  - name: Record num server pods using new worker_node_list
+    # in Scale mode, num server pods = num_node * number_pod
+    set_fact:
+      num_server_pods: "{{ (node_hi_idx|int+1) * (pod_hi_idx|int+1) }}"
+ 
+      #
+      # End scle mode
+      #
+  when: workload_args.pin | default(False) == False
 
-- name: Isolate Worker Role Hostnames
-  set_fact:
-    worker_node_list: "{{ node_list | json_query('resources[].metadata.name') | list }}"
+- block:
+    #
+    # This block is for the "pin" mode where the server and the client node
+    # are specified by pin_server and pin_client variables.
+    
+  - name: Add "Pin" server and client node to worker list. 
+    # The add order is significant as we will enumerate the server pods on
+    # the first node in the list, and client pods on the second node.
+    set_fact: 
+        worker_node_list: "{{worker_node_list + [item]}}"
+    with_items:
+      - '{{workload_args.pin_server}}'
+      - '{{workload_args.pin_client}}'
 
-- name: List Nodes Labeled with {{ workload_args.exclude_label }}
-  k8s_info:
-    api_version: v1
-    kind: Node
-    label_selectors:
-      - '{{ item }}'
-  with_items: "{{ workload_args.exclude_labels }}"
-  register: exclude_node_list
-  when: workload_args.exclude_labels is defined and workload_args.exclude_labels | length > 0
+  - name: Init "Pin" mode node and pod indices
+    set_fact:
+        pod_low_idx: "{{ workload_args.density_range[0] | default('1')|int - 1 }}"
+        pod_hi_idx: "{{ workload_args.density_range[1] | default('1')|int - 1 }}"
+        # node indices are used as client pod 'start' parameter.
+        node_low_idx: "0"
+        node_hi_idx: "0"
 
-- name: Isolate Worker Role Hostnames for label  {{ workload_args.exclude_label }}
-  set_fact:
-    worker_node_exclude_list: "{{ exclude_node_list | json_query('results[].resources[].metadata.name') }}"
+  - name: A8 V2 Record num Pin server pods using new worker_node_list
+    set_fact:
+      # in Pin mode, num server pods = number of pods 
+      num_server_pods: "{{ pod_hi_idx|int +1 }}"
 
-- name: Exclude labelled nodes
-  set_fact:
-      worker_node_list: "{{ worker_node_list | difference(worker_node_exclude_list) }}"
-  when: workload_args.exclude_labels is defined and workload_args.exclude_labels | length > 0
-
-- name: A5 Capture ServiceIP
+    #
+    # End pin mode where pin_client and pin_server are specified
+    #
+  when: workload_args.pin | default(False) == True
+  
+- name: Capture ServiceIP
   k8s_facts:
     kind: Service
     api_version: v1
@@ -76,57 +138,4 @@
       - type = uperf-bench-server-{{ trunc_uuid }}
   register: serviceip
   when: workload_args.serviceip is defined and workload_args.serviceip
-
-#
-# Compute node and pod limits using CR params while taking into account 
-# of the actual number of nodes available in the system
-#
-- name: init pod low idx
-  set_fact:
-      pod_low_idx: "{{ workload_args.density_range[0]|int | default('1')|int - 1 }}"
-  when: workload_args.density_range is defined
-
-- name: init pod hi idx
-  set_fact:
-      pod_hi_idx: "{{ workload_args.density_range[1]|int | default('1')|int - 1 }}"
-  when: workload_args.density_range is defined
-
-- name: init node low idx
-  set_fact:
-      node_low_idx: "{{ workload_args.node_range[0]|int | default('1')|int - 1 }}"
-  when: workload_args.node_range is defined
-
-- name: init node hi idx
-  set_fact:
-      node_hi_idx: "{{ workload_args.node_range[1]|int | default('1')|int - 1 }}"
-  when: workload_args.node_range is defined
-
-- name: Adjust node_hi_idx if cluster has less nodes
-  set_fact:
-      node_hi_idx: "{{ worker_node_list|length| default('0')|int -1 }}"
-  when: "node_hi_idx|int >= worker_node_list|length| default('0')|int "
-
-#
-# "pin" mode exists prior to "scale" mode. If "pin: true", we will
-# do the old way using pin_server and pin_client
-#
-- name: A6 Record num server (V1) pods using workload_args.pair - TBD
-  set_fact:
-      num_server_pods: "{{ workload_args.pair | default('1')|int }}"
-  when: workload_args.node_range is not defined
-
-  #- name: A7 V2 scale run -  Setup eligible node (static) list - Tobe replaced by real node list builder
-  #  set_fact:
-  #      worker_node_list: "{{workload_args.node_list[0]}}"
-  #  when: workload_args.node_range is not defined
-  #
-  #- name: A7 V1 non-scale Setup eligible node (static) list - Tobe replaced by real node list builder
-  #  set_fact:
-  #      worker_node_list: "{{workload_args.node_list}}"
-  #  when: workload_args.node_range is defined
-
-- name: A8 V2 Record num server pods using new worker_node_list
-  set_fact:
-      num_server_pods: "{{ (node_hi_idx|int+1) * (pod_hi_idx|int+1) }}"
-  when: workload_args.node_range is defined
 

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -56,6 +56,7 @@
       - '{{ item }}'
   with_items: "{{ workload_args.exclude_labels }}"
   register: exclude_node_list
+  when: workload_args.exclude_labels is defined and workload_args.exclude_labels | length > 0
 
 - name: Isolate Worker Role Hostnames for label  {{ workload_args.exclude_label }}
   set_fact:

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -70,18 +70,22 @@
 - name: init pod low idx
   set_fact:
       pod_low_idx: "{{ workload_args.density_range[0]|int | default('1')|int - 1 }}"
+  when: workload_args.density_range is defined
 
 - name: init pod hi idx
   set_fact:
       pod_hi_idx: "{{ workload_args.density_range[1]|int | default('1')|int - 1 }}"
+  when: workload_args.density_range is defined
 
 - name: init node low idx
   set_fact:
       node_low_idx: "{{ workload_args.node_range[0]|int | default('1')|int - 1 }}"
+  when: workload_args.node_range is defined
 
 - name: init node hi idx
   set_fact:
       node_hi_idx: "{{ workload_args.node_range[1]|int | default('1')|int - 1 }}"
+  when: workload_args.node_range is defined
 
 - name: Adjust node_hi_idx if cluster has less nodes
   set_fact:

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -51,7 +51,7 @@
 - name: Exclude unhealthy nodes i.e. low diskspace 
   set_fact:
       worker_node_list: "{{ worker_node_list | difference(workload_args.excluded_node[0]) }}"
-  when: workload_args.excluded_node is defined
+  when: workload_args.excluded_node is defined and workload_args.excluded_node|length > 0
 
 - name: A5 Capture ServiceIP
   k8s_facts:

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -35,6 +35,19 @@
       - name = benchmark-operator
   register: bo
 
+- name: List Nodes Labeled as Workers
+  k8s_info:
+    api_version: v1
+    kind: Node
+    label_selectors:
+      - "node-role.kubernetes.io/worker="
+  register: node_list
+  no_log: True
+
+- name: Isolate Worker Role Hostnames
+  register:
+    worker_node_list: "{{ node_list | json_query('resources[].metadata.name') | list }}"
+
 - name: A5 Capture ServiceIP
   k8s_facts:
     kind: Service
@@ -54,15 +67,15 @@
       num_server_pods: "{{ workload_args.pair | default('1')|int }}"
   when: workload_args.max_node is not defined
 
-- name: A7 V2 scale run -  Setup eligible node (static) list - Tobe replaced by real node list builder
-  set_fact:
-      worker_node_list: "{{workload_args.node_list[0]}}"
-  when: workload_args.max_node is not defined
-
-- name: A7 V1 non-scale Setup eligible node (static) list - Tobe replaced by real node list builder
-  set_fact:
-      worker_node_list: "{{workload_args.node_list}}"
-  when: workload_args.max_node is defined
+  #- name: A7 V2 scale run -  Setup eligible node (static) list - Tobe replaced by real node list builder
+  #  set_fact:
+  #      worker_node_list: "{{workload_args.node_list[0]}}"
+  #  when: workload_args.max_node is not defined
+  #
+  #- name: A7 V1 non-scale Setup eligible node (static) list - Tobe replaced by real node list builder
+  #  set_fact:
+  #      worker_node_list: "{{workload_args.node_list}}"
+  #  when: workload_args.max_node is defined
 
 - name: A8 V2 Record num server pods using new worker_node_list
   set_fact:

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -48,7 +48,7 @@
   set_fact:
     worker_node_list: "{{ node_list | json_query('resources[].metadata.name') | list }}"
 
-- name: Exlude unhealthy nodes i.e. low diskspace 
+- name: Exclude unhealthy nodes i.e. low diskspace 
   set_fact:
       worker_node_list: "{{ worker_node_list | difference(workload_args.excluded_node[0]) }}"
   when: workload_args.excluded_node is defined
@@ -62,6 +62,38 @@
       - type = uperf-bench-server-{{ trunc_uuid }}
   register: serviceip
   when: workload_args.serviceip is defined and workload_args.serviceip
+
+#
+# Compute node and pod limits using CR params while taking into account 
+# of the actual number of nodes available in the system
+#
+- name: init node idx
+  set_fact:
+       node_idx: "{{ workload_args.min_node | default('0')|int }}"
+    #
+    # TBD HN range check, colocate and other checks
+    #
+
+- name: init pod low idx
+  set_fact:
+      pod_low_idx: "{{ workload_args.density_range[0]|int | default('1')|int - 1 }}"
+
+- name: init pod hi idx
+  set_fact:
+      pod_hi_idx: "{{ workload_args.density_range[1]|int | default('1')|int - 1 }}"
+
+- name: init node low idx
+  set_fact:
+      node_low_idx: "{{ workload_args.node_range[0]|int | default('1')|int - 1 }}"
+
+- name: init node hi idx
+  set_fact:
+      node_hi_idx: "{{ workload_args.node_range[1]|int | default('1')|int - 1 }}"
+
+- name: Adjust node_hi_idx if cluster has less nodes
+  set_fact:
+      node_hi_idx: "{{ worker_node_list|length| default('0')|int -1 }}"
+  when: "node_hi_idx|int >= worker_node_list|length| default('0')|int "
 
 #
 # "pin" mode exists prior to "scale" mode. If "pin: true", we will
@@ -84,6 +116,6 @@
 
 - name: A8 V2 Record num server pods using new worker_node_list
   set_fact:
-      num_server_pods: "{{ worker_node_list|length * workload_args.density | default('1')|int }}"
+      num_server_pods: "{{ (node_hi_idx|int+1) * (pod_hi_idx|int+1) }}"
   when: workload_args.max_node is defined
 

--- a/roles/uperf/tasks/start_client.yml
+++ b/roles/uperf/tasks/start_client.yml
@@ -40,8 +40,6 @@
  
 ### <VM> kind 
   - block:
-    - name: debug 
-      command: "redis-cli set state Starting_Clients"
 
     - name: V19 Wait for vms to be running....
       k8s_facts:

--- a/roles/uperf/tasks/start_client.yml
+++ b/roles/uperf/tasks/start_client.yml
@@ -1,0 +1,76 @@
+---
+
+- block:
+
+### <POD> kind 
+  - name: A17 Get pod info
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_pods
+
+  - name: A18 Generate uperf xml files
+    k8s:
+      definition: "{{ lookup('template', 'configmap.yml.j2') | from_yaml }}"
+
+  - block:   # Starting Clients"
+    - name: P19 Start Client(s) w/o serviceIP
+      k8s:
+        definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
+      with_items: 
+        - "{{ server_pods.resources }}"
+      when: workload_args.serviceip is defined and not workload_args.serviceip|default('false') and server_pods.resources|length > 0
+
+     #
+     # Each server annotates a "node_idx". Each peer client will
+     # derive its affinity according the 'colocate' variable.
+     #
+
+    - name: P20 Start Client(s) with serviceIP
+      k8s:
+        definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
+      with_items: 
+        - "{{ serviceip.resources }}"
+      when: workload_args.serviceip is defined and workload_args.serviceip and serviceip.resources|length > 0
+
+    when: resource_kind == "pod"
+ 
+### <VM> kind 
+  - block:
+
+    - name: V19 Wait for vms to be running....
+      k8s_facts:
+        kind: VirtualMachineInstance
+        api_version: kubevirt.io/v1alpha3
+        namespace: '{{ operator_namespace }}'
+        label_selectors:
+          - type = uperf-bench-server-{{ trunc_uuid }}
+      register: server_vms
+
+
+    - name: V20 Generate uperf test files
+      k8s:
+        definition: "{{ lookup('template', 'configmap_script.yml.j2') | from_yaml }}"
+      with_items: "{{ server_vms.resources }}"
+
+    - name: V21 Start Client(s)
+      k8s:
+        definition: "{{ lookup('template', 'workload_vm.yml.j2') | from_yaml }}"
+      with_items: "{{ server_vms.resources }}"
+      when: server_vms.resources|length > 0
+
+    when: resource_kind == "vm"
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Waiting for Clients
+
+  when: resource_state.resources[0].status.state == "Starting Clients"
+

--- a/roles/uperf/tasks/start_client.yml
+++ b/roles/uperf/tasks/start_client.yml
@@ -20,7 +20,7 @@
       definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
     vars: 
       resource_item: "{{ server_pods.resources }}"
-    when: workload_args.serviceip is defined and not workload_args.serviceip|default('false') and server_pods.resources|length > 0
+    when: workload_args.serviceip|default(False) == False and server_pods.resources|length > 0
 
    #
    # Each server annotates a "node_idx". Each peer client will
@@ -32,7 +32,7 @@
       definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
     vars: 
       resource_item: "{{ serviceip.resources }}"
-    when: workload_args.serviceip is defined and workload_args.serviceip and serviceip.resources|length > 0
+    when: workload_args.serviceip|default(False) == True and serviceip.resources|length > 0
 
   when: resource_kind == "pod"
  

--- a/roles/uperf/tasks/start_client.yml
+++ b/roles/uperf/tasks/start_client.yml
@@ -20,8 +20,8 @@
     - name: P19 Start Client(s) w/o serviceIP
       k8s:
         definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
-      with_items: 
-        - "{{ server_pods.resources }}"
+      vars: 
+        resource_item: "{{ server_pods.resources }}"
       when: workload_args.serviceip is defined and not workload_args.serviceip|default('false') and server_pods.resources|length > 0
 
      #
@@ -32,8 +32,8 @@
     - name: P20 Start Client(s) with serviceIP
       k8s:
         definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
-      with_items: 
-        - "{{ serviceip.resources }}"
+      vars: 
+        resource_item: "{{ serviceip.resources }}"
       when: workload_args.serviceip is defined and workload_args.serviceip and serviceip.resources|length > 0
 
     when: resource_kind == "pod"

--- a/roles/uperf/tasks/start_client.yml
+++ b/roles/uperf/tasks/start_client.yml
@@ -1,76 +1,73 @@
 ---
 
-- block:
+- name: Get pod info
+  k8s_facts:
+    kind: Pod
+    api_version: v1
+    namespace: '{{ operator_namespace }}'
+    label_selectors:
+      - type = uperf-bench-server-{{ trunc_uuid }}
+  register: server_pods
 
-### <POD> kind 
-  - name: A17 Get pod info
+- name: Generate uperf xml files
+  k8s:
+    definition: "{{ lookup('template', 'configmap.yml.j2') | from_yaml }}"
+
+- block:
+  ### <POD> kind 
+  - name: Start Client(s) w/o serviceIP
+    k8s:
+      definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
+    vars: 
+      resource_item: "{{ server_pods.resources }}"
+    when: workload_args.serviceip is defined and not workload_args.serviceip|default('false') and server_pods.resources|length > 0
+
+   #
+   # Each server annotates a "node_idx". Each peer client will
+   # derive its affinity according the 'colocate' variable.
+   #
+
+  - name: Start Client(s) with serviceIP
+    k8s:
+      definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
+    vars: 
+      resource_item: "{{ serviceip.resources }}"
+    when: workload_args.serviceip is defined and workload_args.serviceip and serviceip.resources|length > 0
+
+  when: resource_kind == "pod"
+ 
+- block:
+  ### <VM> kind 
+
+  - name: Wait for vms to be running....
     k8s_facts:
-      kind: Pod
-      api_version: v1
+      kind: VirtualMachineInstance
+      api_version: kubevirt.io/v1alpha3
       namespace: '{{ operator_namespace }}'
       label_selectors:
         - type = uperf-bench-server-{{ trunc_uuid }}
-    register: server_pods
+    register: server_vms
 
-  - name: A18 Generate uperf xml files
+
+  - name: Generate uperf test files
     k8s:
-      definition: "{{ lookup('template', 'configmap.yml.j2') | from_yaml }}"
+      definition: "{{ lookup('template', 'configmap_script.yml.j2') | from_yaml }}"
+    with_items: "{{ server_vms.resources }}"
 
-  - block:   # Starting Clients"
-    - name: P19 Start Client(s) w/o serviceIP
-      k8s:
-        definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
-      vars: 
-        resource_item: "{{ server_pods.resources }}"
-      when: workload_args.serviceip is defined and not workload_args.serviceip|default('false') and server_pods.resources|length > 0
+  - name: Start Client(s)
+    k8s:
+      definition: "{{ lookup('template', 'workload_vm.yml.j2') | from_yaml }}"
+    with_items: "{{ server_vms.resources }}"
+    when: server_vms.resources|length > 0
 
-     #
-     # Each server annotates a "node_idx". Each peer client will
-     # derive its affinity according the 'colocate' variable.
-     #
+  when: resource_kind == "vm"
 
-    - name: P20 Start Client(s) with serviceIP
-      k8s:
-        definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
-      vars: 
-        resource_item: "{{ serviceip.resources }}"
-      when: workload_args.serviceip is defined and workload_args.serviceip and serviceip.resources|length > 0
+- operator_sdk.util.k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      state: Waiting for Clients
 
-    when: resource_kind == "pod"
- 
-### <VM> kind 
-  - block:
-
-    - name: V19 Wait for vms to be running....
-      k8s_facts:
-        kind: VirtualMachineInstance
-        api_version: kubevirt.io/v1alpha3
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - type = uperf-bench-server-{{ trunc_uuid }}
-      register: server_vms
-
-
-    - name: V20 Generate uperf test files
-      k8s:
-        definition: "{{ lookup('template', 'configmap_script.yml.j2') | from_yaml }}"
-      with_items: "{{ server_vms.resources }}"
-
-    - name: V21 Start Client(s)
-      k8s:
-        definition: "{{ lookup('template', 'workload_vm.yml.j2') | from_yaml }}"
-      with_items: "{{ server_vms.resources }}"
-      when: server_vms.resources|length > 0
-
-    when: resource_kind == "vm"
-
-  - operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: Waiting for Clients
-
-  when: resource_state.resources[0].status.state == "Starting Clients"
 

--- a/roles/uperf/tasks/start_client.yml
+++ b/roles/uperf/tasks/start_client.yml
@@ -40,6 +40,8 @@
  
 ### <VM> kind 
   - block:
+    - name: debug 
+      command: "redis-cli set state Starting_Clients"
 
     - name: V19 Wait for vms to be running....
       k8s_facts:

--- a/roles/uperf/tasks/start_client.yml
+++ b/roles/uperf/tasks/start_client.yml
@@ -6,7 +6,7 @@
     api_version: v1
     namespace: '{{ operator_namespace }}'
     label_selectors:
-      - type = uperf-bench-server-{{ trunc_uuid }}
+      - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
   register: server_pods
 
 - name: Generate uperf xml files
@@ -45,7 +45,7 @@
       api_version: kubevirt.io/v1alpha3
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
+        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_vms
 
 

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -4,21 +4,9 @@
   # Start servers
   #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 - block:
-  - name: init group node count
-    set_fact:
-       group_node_count: "{{ workload_args.min_node | default('1')|int }}"
-    #
-    # TBD HN range check, colocate and other checks
-    #
 
-  - name: init redis
-    command: "redis-cli set group_mark 0"
-  - name: init redis
-    command: "redis-cli set start 0"
-  - name: init redis
-    command: "redis-cli set num_completion 0"
-  - name: init redis
-    command: "redis-cli set group_node_count {{ group_node_count }}"
+  - include_tasks: init.yml
+
 
   - name: P8 Create service for server pods
     k8s:
@@ -39,8 +27,11 @@
     k8s:
        definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
     with_nested:
-      - "{{ range(0, worker_node_list|length| default('0'|int)) | list }}"
-      - "{{ range(0, workload_args.density | default('1'|int)) | list }}"
+      - "{{ range(0, node_hi_idx|int +1) | list }}"
+      - "{{ range(0, pod_hi_idx|int  +1) | list }}"
+
+     #- "{{ range(0, worker_node_list|length| default('0'|int)) | list }}"
+     #- "{{ range(0, workload_args.density | default('1'|int)) | list }}"
     #
     # Each server annotates a "node_idx" which will allow its peer client
     # to derive its affinity according the 'colocate' variable

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -30,7 +30,7 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
+        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_pods
 
   - name: Update resource state
@@ -58,7 +58,7 @@
       api_version: kubevirt.io/v1alpha3
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
+        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_vms
 
   - name: Update resource state

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -18,7 +18,8 @@
     k8s:
       definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
     register: servers
-    with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
+    vars:
+      pod_sequence: "{{ workload_args.pair | default('1')|int }}"
     when: workload_args.node_range is not defined
 
 ############ <V2>
@@ -26,9 +27,9 @@
   - name: P10 V2 Start Server(s) - total = eligible nodes * density
     k8s:
        definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
-    with_nested:
-      - "{{ range(0, node_hi_idx|int +1) | list }}"
-      - "{{ range(0, pod_hi_idx|int  +1) | list }}"
+    vars:
+      pod_sequence: "{{ pod_hi_idx|int +1 }}"
+      node_sequence: "{{ node_hi_idx|int +1 }}"
     when: workload_args.node_range is defined
     #
     # Each server annotates a "node_idx" which will allow its peer client

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -6,7 +6,7 @@
 - block:
   - name: init group node count
     set_fact:
-       group_node_count: "{{ workload_args.min_node | default('2')|int }}"
+       group_node_count: "{{ workload_args.min_node | default('1')|int }}"
     #
     # TBD HN range check, colocate and other checks
     #

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -29,7 +29,7 @@
     with_nested:
       - "{{ range(0, node_hi_idx|int +1) | list }}"
       - "{{ range(0, pod_hi_idx|int  +1) | list }}"
-
+    when: workload_args.node_range is defined
     #
     # Each server annotates a "node_idx" which will allow its peer client
     # to derive its affinity according the 'colocate' variable

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -1,13 +1,16 @@
 ---
 
 - block:
-
+  ### <POD> kind
   - include_tasks: init.yml
 
   - name: Create service for server pods
     k8s:
       definition: "{{ lookup('template', 'service.yml.j2') | from_yaml }}"
-    with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
+    vars:
+      pod_sequence: "{{ pod_hi_idx|int +1 }}"
+      node_sequence: "{{ node_hi_idx|int +1 }}"
+
     when: workload_args.serviceip is defined and workload_args.serviceip
 
   - name: Start Server(s) - total = eligible nodes * density
@@ -39,20 +42,17 @@
       status:
         state: "Starting Servers"
 
-  when: resource_state.resources[0].status.state == "Building" and resource_kind == "pod"
+  when: resource_kind == "pod"
  
-########### <VM block>
-# VM remains scale agnostic for now
-###########
 - block:
-
-  - name: V11 Start Server(s)
+  ### <VM} kind remains as-is w/o "scale" mode
+  - name: Start Server(s)
     k8s:
       definition: "{{ lookup('template', 'server_vm.yml.j2') | from_yaml }}"
     register: servers
     with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
 
-  - name: V12 Wait for vms to be running....
+  - name: Wait for vms to be running....
     k8s_facts:
       kind: VirtualMachineInstance
       api_version: kubevirt.io/v1alpha3
@@ -61,7 +61,7 @@
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_vms
 
-  - name: V13 Update resource state
+  - name: Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
@@ -70,8 +70,5 @@
       status:
         state: "Starting Servers"
 
-  when: resource_state.resources[0].status.state == "Building" and resource_kind == "vm"
-
-########### </VM vlock>
-
+  when: resource_kind == "vm"
 

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -1,44 +1,27 @@
 ---
 
-  #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-  # Start servers
-  #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 - block:
 
   - include_tasks: init.yml
 
-
-  - name: P8 Create service for server pods
+  - name: Create service for server pods
     k8s:
       definition: "{{ lookup('template', 'service.yml.j2') | from_yaml }}"
     with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
     when: workload_args.serviceip is defined and workload_args.serviceip
 
-  - name: P9 Start Server(s)
-    k8s:
-      definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
-    register: servers
-    vars:
-      pod_sequence: "{{ workload_args.pair | default('1')|int }}"
-    when: workload_args.node_range is not defined
-
-############ <V2>
-
-  - name: P10 V2 Start Server(s) - total = eligible nodes * density
+  - name: Start Server(s) - total = eligible nodes * density
     k8s:
        definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
     vars:
       pod_sequence: "{{ pod_hi_idx|int +1 }}"
       node_sequence: "{{ node_hi_idx|int +1 }}"
-    when: workload_args.node_range is defined
+
     #
     # Each server annotates a "node_idx" which will allow its peer client
     # to derive its affinity according the 'colocate' variable
     #
-
-############ </V2>
-
-  - name: P11 Wait for pods to be running....
+  - name: Wait for pods to be running....
     k8s_facts:
       kind: Pod
       api_version: v1
@@ -47,7 +30,7 @@
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_pods
 
-  - name: P12 Update resource state
+  - name: Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -19,7 +19,7 @@
       definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
     register: servers
     with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
-    when: workload_args.max_node is not defined
+    when: workload_args.node_range is not defined
 
 ############ <V2>
 
@@ -30,8 +30,6 @@
       - "{{ range(0, node_hi_idx|int +1) | list }}"
       - "{{ range(0, pod_hi_idx|int  +1) | list }}"
 
-     #- "{{ range(0, worker_node_list|length| default('0'|int)) | list }}"
-     #- "{{ range(0, workload_args.density | default('1'|int)) | list }}"
     #
     # Each server annotates a "node_idx" which will allow its peer client
     # to derive its affinity according the 'colocate' variable

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -1,0 +1,104 @@
+---
+
+  #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+  # Start servers
+  #@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+- block:
+  - name: init group node count
+    set_fact:
+       group_node_count: "{{ workload_args.min_node | default('2')|int }}"
+    #
+    # TBD HN range check, colocate and other checks
+    #
+
+  - name: init redis
+    command: "redis-cli set group_mark 0"
+  - name: init redis
+    command: "redis-cli set start 0"
+  - name: init redis
+    command: "redis-cli set num_completion 0"
+  - name: init redis
+    command: "redis-cli set group_node_count {{ group_node_count }}"
+
+  - name: P8 Create service for server pods
+    k8s:
+      definition: "{{ lookup('template', 'service.yml.j2') | from_yaml }}"
+    with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
+    when: workload_args.serviceip is defined and workload_args.serviceip
+
+  - name: P9 Start Server(s)
+    k8s:
+      definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
+    register: servers
+    with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
+    when: workload_args.max_node is not defined
+
+############ <V2>
+
+  - name: P10 V2 Start Server(s) - total = eligible nodes * density
+    k8s:
+       definition: "{{ lookup('template', 'server.yml.j2') | from_yaml }}"
+    with_nested:
+      - "{{ range(0, worker_node_list|length| default('0'|int)) | list }}"
+      - "{{ range(0, workload_args.density | default('1'|int)) | list }}"
+    #
+    # Each server annotates a "node_idx" which will allow its peer client
+    # to derive its affinity according the 'colocate' variable
+    #
+
+############ </V2>
+
+  - name: P11 Wait for pods to be running....
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_pods
+
+  - name: P12 Update resource state
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Servers"
+
+  when: resource_state.resources[0].status.state == "Building" and resource_kind == "pod"
+ 
+########### <VM block>
+# VM remains scale agnostic for now
+###########
+- block:
+
+  - name: V11 Start Server(s)
+    k8s:
+      definition: "{{ lookup('template', 'server_vm.yml.j2') | from_yaml }}"
+    register: servers
+    with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
+
+  - name: V12 Wait for vms to be running....
+    k8s_facts:
+      kind: VirtualMachineInstance
+      api_version: kubevirt.io/v1alpha3
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_vms
+
+  - name: V13 Update resource state
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Servers"
+
+  when: resource_state.resources[0].status.state == "Building" and resource_kind == "vm"
+
+########### </VM vlock>
+
+

--- a/roles/uperf/tasks/wait_client_done.yml
+++ b/roles/uperf/tasks/wait_client_done.yml
@@ -1,6 +1,9 @@
 ---
 
 - block:
+  - name: debug 
+    command: "redis-cli set task Running"
+
 #### <POD> kind
   - block:
     - name: P27 Waiting for pods to complete....

--- a/roles/uperf/tasks/wait_client_done.yml
+++ b/roles/uperf/tasks/wait_client_done.yml
@@ -1,8 +1,6 @@
 ---
 
 - block:
-  - name: debug 
-    command: "redis-cli set task Running"
 
 #### <POD> kind
   - block:

--- a/roles/uperf/tasks/wait_client_done.yml
+++ b/roles/uperf/tasks/wait_client_done.yml
@@ -1,0 +1,45 @@
+---
+
+- block:
+#### <POD> kind
+  - block:
+    - name: P27 Waiting for pods to complete....
+      k8s_facts:
+        kind: pod
+        api_version: v1
+        namespace: '{{ operator_namespace }}'
+        label_selectors:
+          - app = uperf-bench-client-{{ trunc_uuid }}
+      register: client_pods
+
+    - operator_sdk.util.k8s_status:
+        api_version: ripsaw.cloudbulldozer.io/v1alpha1
+        kind: Benchmark
+        name: "{{ meta.name }}"
+        namespace: "{{ operator_namespace }}"
+        status:
+          state: Cleanup
+          complete: false
+      when: "num_server_pods|int == (client_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
+    when: resource_kind == "pod"
+
+#### <VM> kind
+  - block:
+
+    - name: V28 get complete
+      command: "redis-cli get complete"
+      register: complete_status
+
+    - operator_sdk.util.k8s_status:
+        api_version: ripsaw.cloudbulldozer.io/v1alpha1
+        kind: Benchmark
+        name: "{{ meta.name }}"
+        namespace: "{{ operator_namespace }}"
+        status:
+          state: Cleanup
+          complete: false
+      when: complete_status.stdout == "true"
+    when: resource_kind == "vm"
+
+  when: resource_state.resources[0].status.state == "Running"
+

--- a/roles/uperf/tasks/wait_client_done.yml
+++ b/roles/uperf/tasks/wait_client_done.yml
@@ -2,9 +2,9 @@
 
 - block:
 
-#### <POD> kind
+  #### <POD> kind
   - block:
-    - name: P27 Waiting for pods to complete....
+    - name: Waiting for pods to complete....
       k8s_facts:
         kind: pod
         api_version: v1
@@ -24,7 +24,7 @@
       when: "num_server_pods|int == (client_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
     when: resource_kind == "pod"
 
-#### <VM> kind
+  #### <VM> kind
   - block:
 
     - name: V28 get complete

--- a/roles/uperf/tasks/wait_client_done.yml
+++ b/roles/uperf/tasks/wait_client_done.yml
@@ -1,46 +1,40 @@
 ---
+- block:
+  ### <POD> kind
+  - name: Waiting for pods to complete....
+    k8s_facts:
+      kind: pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - app = uperf-bench-client-{{ trunc_uuid }}
+    register: client_pods
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Cleanup
+        complete: false
+    when: "num_server_pods|int == (client_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
+  when: resource_kind == "pod"
 
 - block:
+  ### <VM> kind
+  - name: get complete
+    command: "redis-cli get complete"
+    register: complete_status
 
-  #### <POD> kind
-  - block:
-    - name: Waiting for pods to complete....
-      k8s_facts:
-        kind: pod
-        api_version: v1
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - app = uperf-bench-client-{{ trunc_uuid }}
-      register: client_pods
-
-    - operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Cleanup
-          complete: false
-      when: "num_server_pods|int == (client_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
-    when: resource_kind == "pod"
-
-  #### <VM> kind
-  - block:
-
-    - name: V28 get complete
-      command: "redis-cli get complete"
-      register: complete_status
-
-    - operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Cleanup
-          complete: false
-      when: complete_status.stdout == "true"
-    when: resource_kind == "vm"
-
-  when: resource_state.resources[0].status.state == "Running"
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Cleanup
+        complete: false
+    when: complete_status.stdout == "true"
+  when: resource_kind == "vm"
 

--- a/roles/uperf/tasks/wait_client_ready.yml
+++ b/roles/uperf/tasks/wait_client_ready.yml
@@ -1,12 +1,8 @@
 ---
 - block:
-
-##### <POD> kind
-  - block: # Pod block
-    - name: debug 
-      command: "redis-cli set state Waiting_for_Clients"
-
-    - name: P22 Get client pod status
+   ##### <POD> kind
+  - block: 
+    - name: Get client pod status
       k8s_facts:
         kind: Pod
         api_version: v1
@@ -15,7 +11,7 @@
           - app = uperf-bench-client-{{ trunc_uuid }}
       register: client_pods
 
-    - name: P23 Update resource state
+    - name: Update resource state
       operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
@@ -27,8 +23,8 @@
 
     when: resource_kind == "pod"
 
-##### <VM> kind
   - block:
+    ##### <VM> kind
 
     - name: V22 set complete to false
       command: "redis-cli set complete false"

--- a/roles/uperf/tasks/wait_client_ready.yml
+++ b/roles/uperf/tasks/wait_client_ready.yml
@@ -1,49 +1,48 @@
 ---
+
+- block: 
+  ### <POD> kind
+
+  - name: Get client pod status
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - app = uperf-bench-client-{{ trunc_uuid }}
+    register: client_pods
+
+  - name: Update resource state
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Clients Running
+    when: "num_server_pods|int == client_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and num_server_pods|int == (client_pods | json_query('resources[].status.podIP')|length)"
+
+  when: resource_kind == "pod"
+
 - block:
-   ##### <POD> kind
-  - block: 
-    - name: Get client pod status
-      k8s_facts:
-        kind: Pod
-        api_version: v1
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - app = uperf-bench-client-{{ trunc_uuid }}
-      register: client_pods
+  ### <VM> kind
 
-    - name: Update resource state
-      operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Clients Running
-      when: "num_server_pods|int == client_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and num_server_pods|int == (client_pods | json_query('resources[].status.podIP')|length)"
+  - name: set complete to false
+    command: "redis-cli set complete false"
 
-    when: resource_kind == "pod"
+  - name: Get count of clients ready
+    command: "redis-cli get clients-{{ trunc_uuid }}"
+    register: clients_ready_count
 
-  - block:
-    ##### <VM> kind
+  - name: Update resource state
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Clients Running
+    when: "workload_args.pair|default('1')|int == clients_ready_count.stdout|int"
 
-    - name: V22 set complete to false
-      command: "redis-cli set complete false"
-
-    - name: Get count of clients ready
-      command: "redis-cli get clients-{{ trunc_uuid }}"
-      register: clients_ready_count
-
-    - name: V24 Update resource state
-      operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Clients Running
-      when: "workload_args.pair|default('1')|int == clients_ready_count.stdout|int"
-
-    when: resource_kind == "vm"
-
-  when: resource_state.resources[0].status.state == "Waiting for Clients"
+  when: resource_kind == "vm"
 

--- a/roles/uperf/tasks/wait_client_ready.yml
+++ b/roles/uperf/tasks/wait_client_ready.yml
@@ -33,14 +33,9 @@
     - name: V22 set complete to false
       command: "redis-cli set complete false"
 
-    - name: V23 Get client vm status
-      k8s_facts:
-        kind: VirtualMachineInstance
-        api_version: kubevirt.io/v1alpha3
-        namespace: '{{ operator_namespace }}'
-        label_selectors:
-          - app = uperf-bench-client-{{ trunc_uuid }}
-      register: client_vms
+    - name: Get count of clients ready
+      command: "redis-cli get clients-{{ trunc_uuid }}"
+      register: clients_ready_count
 
     - name: V24 Update resource state
       operator_sdk.util.k8s_status:
@@ -50,7 +45,7 @@
         namespace: "{{ operator_namespace }}"
         status:
           state: Clients Running
-      when: "workload_args.pair|default('1')|int == client_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (client_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+      when: "workload_args.pair|default('1')|int == clients_ready_count.stdout|int"
 
     when: resource_kind == "vm"
 

--- a/roles/uperf/tasks/wait_client_ready.yml
+++ b/roles/uperf/tasks/wait_client_ready.yml
@@ -3,6 +3,9 @@
 
 ##### <POD> kind
   - block: # Pod block
+    - name: debug 
+      command: "redis-cli set state Waiting_for_Clients"
+
     - name: P22 Get client pod status
       k8s_facts:
         kind: Pod

--- a/roles/uperf/tasks/wait_client_ready.yml
+++ b/roles/uperf/tasks/wait_client_ready.yml
@@ -1,0 +1,55 @@
+---
+- block:
+
+##### <POD> kind
+  - block: # Pod block
+    - name: P22 Get client pod status
+      k8s_facts:
+        kind: Pod
+        api_version: v1
+        namespace: '{{ operator_namespace }}'
+        label_selectors:
+          - app = uperf-bench-client-{{ trunc_uuid }}
+      register: client_pods
+
+    - name: P23 Update resource state
+      operator_sdk.util.k8s_status:
+        api_version: ripsaw.cloudbulldozer.io/v1alpha1
+        kind: Benchmark
+        name: "{{ meta.name }}"
+        namespace: "{{ operator_namespace }}"
+        status:
+          state: Clients Running
+      when: "num_server_pods|int == client_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and num_server_pods|int == (client_pods | json_query('resources[].status.podIP')|length)"
+
+    when: resource_kind == "pod"
+
+##### <VM> kind
+  - block:
+
+    - name: V22 set complete to false
+      command: "redis-cli set complete false"
+
+    - name: V23 Get client vm status
+      k8s_facts:
+        kind: VirtualMachineInstance
+        api_version: kubevirt.io/v1alpha3
+        namespace: '{{ operator_namespace }}'
+        label_selectors:
+          - app = uperf-bench-client-{{ trunc_uuid }}
+      register: client_vms
+
+    - name: V24 Update resource state
+      operator_sdk.util.k8s_status:
+        api_version: ripsaw.cloudbulldozer.io/v1alpha1
+        kind: Benchmark
+        name: "{{ meta.name }}"
+        namespace: "{{ operator_namespace }}"
+        status:
+          state: Clients Running
+      when: "workload_args.pair|default('1')|int == client_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (client_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+
+    when: resource_kind == "vm"
+
+  when: resource_state.resources[0].status.state == "Waiting for Clients"
+

--- a/roles/uperf/tasks/wait_server_ready.yml
+++ b/roles/uperf/tasks/wait_server_ready.yml
@@ -1,9 +1,6 @@
 ---
-########### <POD> kind
 - block:
-
-  - name: debug 
-    command: "redis-cli set state Starting_Servers"
+   ########### <POD> kind
 
   - name: P13 Get server pods
     k8s_facts:
@@ -14,11 +11,7 @@
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_pods
 
-  - name: debug
-    debug:
-        msg: "{{ num_server_pods }}"
-
-  - name: P14 Update resource state
+  - name: Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
@@ -30,8 +23,8 @@
 
   when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "pod"
 
-######## <VM> kind
 - block:
+  ######## <VM> kind
 
   - name: V14 Wait for vms to be running....
     k8s_facts:

--- a/roles/uperf/tasks/wait_server_ready.yml
+++ b/roles/uperf/tasks/wait_server_ready.yml
@@ -1,8 +1,8 @@
 ---
 - block:
-   ########### <POD> kind
+  ### <POD> kind
 
-  - name: P13 Get server pods
+  - name: Get server pods
     k8s_facts:
       kind: Pod
       api_version: v1
@@ -19,14 +19,14 @@
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Clients"
-    when: "num_server_pods|int  == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
+    when: "num_server_pods|int == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
 
-  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "pod"
+  when: resource_kind == "pod"
 
 - block:
-  ######## <VM> kind
+  ### <VM> kind
 
-  - name: V14 Wait for vms to be running....
+  - name: Wait for vms to be running....
     k8s_facts:
       kind: VirtualMachineInstance
       api_version: kubevirt.io/v1alpha3
@@ -35,7 +35,7 @@
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_vms
 
-  - name: V15 Update resource state
+  - name: Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
@@ -45,11 +45,11 @@
         state: "Starting Clients"
     when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
 
-  - name: V16 blocking client from running uperf
+  - name: blocking client from running uperf
     command: "redis-cli set start false"
     with_items: "{{ server_vms.resources }}"
     when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
 
-  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "vm" 
+  when: resource_kind == "vm" 
 
 

--- a/roles/uperf/tasks/wait_server_ready.yml
+++ b/roles/uperf/tasks/wait_server_ready.yml
@@ -53,10 +53,10 @@
     when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
 
   - name: V16 blocking client from running uperf
-    command: "redis-cli set {{ trunc_uuid }} false"
+    command: "redis-cli set start false"
     with_items: "{{ server_vms.resources }}"
     when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
 
-  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "vm" and workload_args.pair|default('1')|int|int == 1
+  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "vm" 
 
 

--- a/roles/uperf/tasks/wait_server_ready.yml
+++ b/roles/uperf/tasks/wait_server_ready.yml
@@ -8,7 +8,7 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
+        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_pods
 
   - name: Update resource state
@@ -32,7 +32,7 @@
       api_version: kubevirt.io/v1alpha3
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = uperf-bench-server-{{ trunc_uuid }}
+        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_vms
 
   - name: Update resource state

--- a/roles/uperf/tasks/wait_server_ready.yml
+++ b/roles/uperf/tasks/wait_server_ready.yml
@@ -2,6 +2,9 @@
 ########### <POD> kind
 - block:
 
+  - name: debug 
+    command: "redis-cli set state Starting_Servers"
+
   - name: P13 Get server pods
     k8s_facts:
       kind: Pod
@@ -10,6 +13,10 @@
       label_selectors:
         - type = uperf-bench-server-{{ trunc_uuid }}
     register: server_pods
+
+  - name: debug
+    debug:
+        msg: "{{ num_server_pods }}"
 
   - name: P14 Update resource state
     operator_sdk.util.k8s_status:

--- a/roles/uperf/tasks/wait_server_ready.yml
+++ b/roles/uperf/tasks/wait_server_ready.yml
@@ -1,0 +1,55 @@
+---
+########### <POD> kind
+- block:
+
+  - name: P13 Get server pods
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_pods
+
+  - name: P14 Update resource state
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Clients"
+    when: "num_server_pods|int  == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
+
+  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "pod"
+
+######## <VM> kind
+- block:
+
+  - name: V14 Wait for vms to be running....
+    k8s_facts:
+      kind: VirtualMachineInstance
+      api_version: kubevirt.io/v1alpha3
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - type = uperf-bench-server-{{ trunc_uuid }}
+    register: server_vms
+
+  - name: V15 Update resource state
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Clients"
+    when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+
+  - name: V16 blocking client from running uperf
+    command: "redis-cli set {{ trunc_uuid }} false"
+    with_items: "{{ server_vms.resources }}"
+    when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
+
+  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "vm" and workload_args.pair|default('1')|int|int == 1
+
+

--- a/roles/uperf/tasks/wait_set_done.yml
+++ b/roles/uperf/tasks/wait_set_done.yml
@@ -4,7 +4,7 @@
   - block:
     ### <POD> kind
     - name: read pod completion count
-      command: "redis-cli get num_completion"
+      command: "redis-cli get num_completion-{{trunc_uuid}}"
       register: num_completion
 
     - operator_sdk.util.k8s_status:

--- a/roles/uperf/tasks/wait_set_done.yml
+++ b/roles/uperf/tasks/wait_set_done.yml
@@ -2,10 +2,6 @@
 
 - block:
   - block:
-
-    - name: debug
-      command: "redis-cli set state Set_Running"
-
     - name: read pod completion count
       command: "redis-cli get num_completion"
       register: num_completion

--- a/roles/uperf/tasks/wait_set_done.yml
+++ b/roles/uperf/tasks/wait_set_done.yml
@@ -2,6 +2,7 @@
 
 - block:
   - block:
+    ### <POD> kind
     - name: read pod completion count
       command: "redis-cli get num_completion"
       register: num_completion
@@ -18,5 +19,10 @@
 
     when: resource_kind == "pod"
 
-  when: resource_state.resources[0].status.state == "Set Running"
+    ### no <VM> kind block - Run a "set" is not yet supported
 
+  when: resource_kind == "pod"
+
+#
+# No <VM> kind block - It has not been adapted to scale mode yet.
+#

--- a/roles/uperf/tasks/wait_set_done.yml
+++ b/roles/uperf/tasks/wait_set_done.yml
@@ -1,0 +1,31 @@
+---
+
+- block:
+  - block:
+
+    - name: debug
+      command: "redis-cli set task wait_set_done"
+
+    - name: read pod completion count
+      command: "redis-cli get num_completion"
+      register: num_completion
+
+    - name: read group_node_count
+      command: "redis-cli get group_node_count"
+      register: group_node_count
+
+    - name: debug
+      command: "redis-cli set read_num_completion {{ num_completion.stdout }}"
+
+    - operator_sdk.util.k8s_status:
+        api_version: ripsaw.cloudbulldozer.io/v1alpha1
+        kind: Benchmark
+        name: "{{ meta.name }}"
+        namespace: "{{ operator_namespace }}"
+        status:
+          state: Run Next Set
+      when: "num_completion.stdout|int == group_node_count.stdout|int * workload_args.density|default('1')|int"
+    when: resource_kind == "pod"
+
+  when: resource_state.resources[0].status.state == "Set Running"
+

--- a/roles/uperf/tasks/wait_set_done.yml
+++ b/roles/uperf/tasks/wait_set_done.yml
@@ -10,9 +10,13 @@
       command: "redis-cli get num_completion"
       register: num_completion
 
-    - name: read group_node_count
-      command: "redis-cli get group_node_count"
-      register: group_node_count
+    - name: read node_idx
+      command: "redis-cli get node_idx"
+      register: node_idx
+
+    - name: read pod_idx
+      command: "redis-cli get pod_idx"
+      register: pod_idx
 
     - name: debug
       command: "redis-cli set read_num_completion {{ num_completion.stdout }}"
@@ -24,7 +28,8 @@
         namespace: "{{ operator_namespace }}"
         status:
           state: Run Next Set
-      when: "num_completion.stdout|int == group_node_count.stdout|int * workload_args.density|default('1')|int"
+      when: "num_completion.stdout|int == ((node_idx.stdout|int+1) * (pod_idx.stdout|int +1))"
+      #when: "num_completion.stdout|int == node_idx.stdout|int * workload_args.density|default('1')|int"
     when: resource_kind == "pod"
 
   when: resource_state.resources[0].status.state == "Set Running"

--- a/roles/uperf/tasks/wait_set_done.yml
+++ b/roles/uperf/tasks/wait_set_done.yml
@@ -10,14 +10,20 @@
       command: "redis-cli get num_completion"
       register: num_completion
 
-    - operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Run Next Set
+    - block:
+      - operator_sdk.util.k8s_status:
+          api_version: ripsaw.cloudbulldozer.io/v1alpha1
+          kind: Benchmark
+          name: "{{ meta.name }}"
+          namespace: "{{ operator_namespace }}"
+          status:
+            state: Run Next Set
+
+      - name: Change redis state to force idle client pods to outside their main loop
+        command: "redis-cli set start 0"
+        
       when: "num_completion.stdout|int == ((resource_state.resources[0].status.node_idx|int +1) * (resource_state.resources[0].status.pod_idx|int +1))"
+
     when: resource_kind == "pod"
 
   when: resource_state.resources[0].status.state == "Set Running"

--- a/roles/uperf/tasks/wait_set_done.yml
+++ b/roles/uperf/tasks/wait_set_done.yml
@@ -10,17 +10,13 @@
       command: "redis-cli get num_completion"
       register: num_completion
 
-    - block:
-      - operator_sdk.util.k8s_status:
+    - operator_sdk.util.k8s_status:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
           kind: Benchmark
           name: "{{ meta.name }}"
           namespace: "{{ operator_namespace }}"
           status:
             state: Run Next Set
-
-      - name: Change redis state to force idle client pods to outside their main loop
-        command: "redis-cli set start 0"
         
       when: "num_completion.stdout|int == ((resource_state.resources[0].status.node_idx|int +1) * (resource_state.resources[0].status.pod_idx|int +1))"
 

--- a/roles/uperf/tasks/wait_set_done.yml
+++ b/roles/uperf/tasks/wait_set_done.yml
@@ -4,22 +4,11 @@
   - block:
 
     - name: debug
-      command: "redis-cli set task wait_set_done"
+      command: "redis-cli set state Set_Running"
 
     - name: read pod completion count
       command: "redis-cli get num_completion"
       register: num_completion
-
-    - name: read node_idx
-      command: "redis-cli get node_idx"
-      register: node_idx
-
-    - name: read pod_idx
-      command: "redis-cli get pod_idx"
-      register: pod_idx
-
-    - name: debug
-      command: "redis-cli set read_num_completion {{ num_completion.stdout }}"
 
     - operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
@@ -28,8 +17,7 @@
         namespace: "{{ operator_namespace }}"
         status:
           state: Run Next Set
-      when: "num_completion.stdout|int == ((node_idx.stdout|int+1) * (pod_idx.stdout|int +1))"
-      #when: "num_completion.stdout|int == node_idx.stdout|int * workload_args.density|default('1')|int"
+      when: "num_completion.stdout|int == ((resource_state.resources[0].status.node_idx|int +1) * (resource_state.resources[0].status.pod_idx|int +1))"
     when: resource_kind == "pod"
 
   when: resource_state.resources[0].status.state == "Set Running"

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -15,7 +15,7 @@ items:
       template:
         metadata:
           labels:
-            app: uperf-bench-server-{{ item  }}-{{ trunc_uuid }}
+            app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(32,true,'') }}-{{ item  }}-{{ trunc_uuid }}
             type: uperf-bench-server-{{ trunc_uuid }}
           annotations:
 {% if workload_args.multus.enabled is sameas true %}

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -6,7 +6,7 @@ metadata:
 {% if workload_args.max_node is not defined %}
   name: 'uperf-server-{{ item }}-{{ trunc_uuid }}'
 {% else %}
-  name: 'uperf-server-{{ item[0] }}-{{ item[1] }}-{{ trunc_uuid }}'
+  name: 'uperf-server-{{worker_node_list[ item[0]] }}-{{ item[1] }}-{{ trunc_uuid }}'
 {% endif %}
 
   namespace: "{{ operator_namespace }}"
@@ -20,14 +20,16 @@ spec:
 {% if workload_args.max_node is not defined %}
         app: uperf-bench-server-{{item}}-{{ trunc_uuid }}
 {% else %}
-        app: uperf-bench-server-{{ item[0] }}-{{ item[1]  }}-{{ trunc_uuid }}
+        #app: uperf-bench-server-{{ item[0] }}-{{ item[1]  }}-{{ trunc_uuid }}
+        app: uperf-bench-server-{{ worker_node_list[item[0]] }}-{{ item[1]  }}-{{ trunc_uuid }}
 {% endif %}
 
         type: uperf-bench-server-{{ trunc_uuid }}
-{% if workload_args.multus.enabled is sameas true %}
       annotations:
+{% if workload_args.multus.enabled is sameas true %}
         k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.server}}
 {% endif %}
+        node_idx: '{{ item[0] }}'
     spec:
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
@@ -56,7 +58,8 @@ spec:
 #
 {% if workload_args.max_node is defined %}
       nodeSelector:
-        kubernetes.io/hostname: '{{ item[0] }}'
+        #kubernetes.io/hostname: '{{ item[0] }}'
+        kubernetes.io/hostname: '{{ worker_node_list[item[0]] }}'
 {% endif %}
 
 {% if workload_args.serviceip is sameas true %}

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -3,7 +3,7 @@ kind: Job
 apiVersion: batch/v1
 metadata:
 
-{% if workload_args.max_node is not defined %}
+{% if workload_args.node_range is not defined %}
   name: 'uperf-server-{{ item }}-{{ trunc_uuid }}'
 {% else %}
   name: 'uperf-server-{{worker_node_list[ item[0]] }}-{{ item[1] }}-{{ trunc_uuid }}'
@@ -17,7 +17,7 @@ spec:
     metadata:
       labels:
 
-{% if workload_args.max_node is not defined %}
+{% if workload_args.node_range is not defined %}
         app: uperf-bench-server-{{item}}-{{ trunc_uuid }}
 {% else %}
         #app: uperf-bench-server-{{ item[0] }}-{{ item[1]  }}-{{ trunc_uuid }}
@@ -57,7 +57,7 @@ spec:
 # 
 # V2 pin server pod to node
 #
-{% if workload_args.max_node is defined %}
+{% if workload_args.node_range is defined %}
       nodeSelector:
         #kubernetes.io/hostname: '{{ item[0] }}'
         kubernetes.io/hostname: '{{ worker_node_list[item[0]] }}'

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -15,7 +15,6 @@ items:
       template:
         metadata:
           labels:
-            #app: uperf-bench-server-{{ node_idx_item }}-{{ item  }}-{{ trunc_uuid }}
             app: uperf-bench-server-{{ worker_node_list[node_idx_item] }}-{{ item  }}-{{ trunc_uuid }}
             type: uperf-bench-server-{{ trunc_uuid }}
           annotations:
@@ -46,12 +45,7 @@ items:
           nodeSelector:
             kubernetes.io/hostname: '{{ workload_args.pin_server }}'
 {% endif %}
-
-# 
-# V2 pin server pod to node
-#
           nodeSelector:
-            #kubernetes.io/hostname: '{{ node_idx_item }}'
             kubernetes.io/hostname: '{{ worker_node_list[node_idx_item] }}'
 
 {% if workload_args.serviceip is sameas true %}

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -15,7 +15,7 @@ items:
       template:
         metadata:
           labels:
-            app: uperf-bench-server-{{ worker_node_list[node_idx_item] }}-{{ item  }}-{{ trunc_uuid }}
+            app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(16,true,'') }}-{{ item  }}-{{ trunc_uuid }}
             type: uperf-bench-server-{{ trunc_uuid }}
           annotations:
 {% if workload_args.multus.enabled is sameas true %}

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -1,72 +1,89 @@
 ---
-kind: Job
-apiVersion: batch/v1
-metadata:
-
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+{% macro job_template(item, node_idx_item='') %}
+  - kind: Job
+    apiVersion: batch/v1
+    metadata:    
 {% if workload_args.node_range is not defined %}
-  name: 'uperf-server-{{ item }}-{{ trunc_uuid }}'
+      name: 'uperf-server-{{ item }}-{{ trunc_uuid }}'
 {% else %}
-  name: 'uperf-server-{{worker_node_list[ item[0]] }}-{{ item[1] }}-{{ trunc_uuid }}'
+      name: 'uperf-server-{{worker_node_list[ node_idx_item ] }}-{{ item }}-{{ trunc_uuid }}'
 {% endif %}
-
-  namespace: "{{ operator_namespace }}"
-spec:
-  ttlSecondsAfterFinished: 600
-  backoffLimit: 0
-  template:
-    metadata:
-      labels:
-
-{% if workload_args.node_range is not defined %}
-        app: uperf-bench-server-{{item}}-{{ trunc_uuid }}
-{% else %}
-        #app: uperf-bench-server-{{ item[0] }}-{{ item[1]  }}-{{ trunc_uuid }}
-        app: uperf-bench-server-{{ worker_node_list[item[0]] }}-{{ item[1]  }}-{{ trunc_uuid }}
-{% endif %}
-
-        type: uperf-bench-server-{{ trunc_uuid }}
-      annotations:
-{% if workload_args.multus.enabled is sameas true %}
-        k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.server}}
-{% endif %}
-        node_idx: '{{ item[0] }}'
-        pod_idx: '{{ item[1] }}'
+      namespace: "{{ operator_namespace }}"
     spec:
+      ttlSecondsAfterFinished: 600
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+{% if workload_args.node_range is not defined %}
+            app: uperf-bench-server-{{item}}-{{ trunc_uuid }}
+{% else %}
+            #app: uperf-bench-server-{{ node_idx_item }}-{{ item  }}-{{ trunc_uuid }}
+            app: uperf-bench-server-{{ worker_node_list[node_idx_item] }}-{{ item  }}-{{ trunc_uuid }}
+{% endif %}
+            type: uperf-bench-server-{{ trunc_uuid }}
+          annotations:
+{% if workload_args.multus.enabled is sameas true %}
+            k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.server}}
+{% endif %}
+{% if workload_args.node_range is defined %}
+            node_idx: '{{ node_idx_item }}'
+            pod_idx: '{{ item }}'
+{% endif %}
+        spec:
 {% if workload_args.runtime_class is defined %}
-      runtimeClassName: "{{ workload_args.runtime_class }}"
+          runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}
 {% if workload_args.hostnetwork is sameas true %}
-      hostNetwork: true
-      serviceAccountName: benchmark-operator
+          hostNetwork: true
+          serviceAccountName: benchmark-operator
 {% endif %}
-      containers:
-      - name: benchmark
-        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/uperf:latest') }}
+          containers:
+          - name: benchmark
+            image: {{ workload_args.image | default('quay.io/cloud-bulldozer/uperf:latest') }}
 {% if workload_args.server_resources is defined %}
-        resources: {{ workload_args.server_resources | to_json }}
+            resources: {{ workload_args.server_resources | to_json }}
 {% endif %}
-        imagePullPolicy: Always
-        command: ["/bin/sh","-c"]
-        args: ["uperf -s -v -P 20000"]
-      restartPolicy: OnFailure
+            imagePullPolicy: Always
+            command: ["/bin/sh","-c"]
+            args: ["uperf -s -v -P 20000"]
+          restartPolicy: OnFailure
 {% if workload_args.pin is sameas true %}
-      nodeSelector:
-        kubernetes.io/hostname: '{{ workload_args.pin_server }}'
+          nodeSelector:
+            kubernetes.io/hostname: '{{ workload_args.pin_server }}'
 {% endif %}
 
 # 
 # V2 pin server pod to node
 #
 {% if workload_args.node_range is defined %}
-      nodeSelector:
-        #kubernetes.io/hostname: '{{ item[0] }}'
-        kubernetes.io/hostname: '{{ worker_node_list[item[0]] }}'
+          nodeSelector:
+            #kubernetes.io/hostname: '{{ node_idx_item }}'
+            kubernetes.io/hostname: '{{ worker_node_list[node_idx_item] }}'
 {% endif %}
 
 {% if workload_args.serviceip is sameas true %}
-      securityContext:
-        sysctls:
-        - name: net.ipv4.ip_local_port_range
-          value: 20000 20011
+          securityContext:
+            sysctls:
+            - name: net.ipv4.ip_local_port_range
+              value: 20000 20011
 {% endif %}
-{% include "metadata.yml.j2" %}
+{% macro metadata() %}{% include "metadata.yml.j2" %}{% endmacro %}
+    {{ metadata()|indent }}
+{% endmacro %}
+{% if workload_args.node_range is not defined %}
+{% for item in range(pod_sequence|int)  %}
+{{ job_template(item) }}
+{% endfor %}
+{% else %}
+{% for node_idx_item in range(node_sequence|int)  %}
+{% for item in range(pod_sequence|int)  %}
+{{ job_template(item,node_idx_item) }}
+{% endfor %}
+{% endfor %}
+{% endif %}
+

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -7,11 +7,7 @@ items:
   - kind: Job
     apiVersion: batch/v1
     metadata:    
-{% if workload_args.node_range is not defined %}
-      name: 'uperf-server-{{ item }}-{{ trunc_uuid }}'
-{% else %}
       name: 'uperf-server-{{worker_node_list[ node_idx_item ] }}-{{ item }}-{{ trunc_uuid }}'
-{% endif %}
       namespace: "{{ operator_namespace }}"
     spec:
       ttlSecondsAfterFinished: 600
@@ -19,21 +15,15 @@ items:
       template:
         metadata:
           labels:
-{% if workload_args.node_range is not defined %}
-            app: uperf-bench-server-{{item}}-{{ trunc_uuid }}
-{% else %}
             #app: uperf-bench-server-{{ node_idx_item }}-{{ item  }}-{{ trunc_uuid }}
             app: uperf-bench-server-{{ worker_node_list[node_idx_item] }}-{{ item  }}-{{ trunc_uuid }}
-{% endif %}
             type: uperf-bench-server-{{ trunc_uuid }}
           annotations:
 {% if workload_args.multus.enabled is sameas true %}
             k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.server}}
 {% endif %}
-{% if workload_args.node_range is defined %}
             node_idx: '{{ node_idx_item }}'
             pod_idx: '{{ item }}'
-{% endif %}
         spec:
 {% if workload_args.runtime_class is defined %}
           runtimeClassName: "{{ workload_args.runtime_class }}"
@@ -60,11 +50,9 @@ items:
 # 
 # V2 pin server pod to node
 #
-{% if workload_args.node_range is defined %}
           nodeSelector:
             #kubernetes.io/hostname: '{{ node_idx_item }}'
             kubernetes.io/hostname: '{{ worker_node_list[node_idx_item] }}'
-{% endif %}
 
 {% if workload_args.serviceip is sameas true %}
           securityContext:
@@ -75,15 +63,9 @@ items:
 {% macro metadata() %}{% include "metadata.yml.j2" %}{% endmacro %}
     {{ metadata()|indent }}
 {% endmacro %}
-{% if workload_args.node_range is not defined %}
-{% for item in range(pod_sequence|int)  %}
-{{ job_template(item) }}
-{% endfor %}
-{% else %}
 {% for node_idx_item in range(node_sequence|int)  %}
 {% for item in range(pod_sequence|int)  %}
 {{ job_template(item,node_idx_item) }}
 {% endfor %}
 {% endfor %}
-{% endif %}
 

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -15,7 +15,7 @@ items:
       template:
         metadata:
           labels:
-            app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(32,true,'') }}-{{ item  }}-{{ trunc_uuid }}
+            app: uperf-bench-server-{{ item  }}-{{ trunc_uuid }}
             type: uperf-bench-server-{{ trunc_uuid }}
           annotations:
 {% if workload_args.multus.enabled is sameas true %}

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -30,6 +30,7 @@ spec:
         k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.server}}
 {% endif %}
         node_idx: '{{ item[0] }}'
+        pod_idx: '{{ item[1] }}'
     spec:
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -16,7 +16,7 @@ items:
         metadata:
           labels:
             app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(32,true,'') }}-{{ item  }}-{{ trunc_uuid }}
-            type: uperf-bench-server-{{ trunc_uuid }}
+            type: {{ meta.name }}-bench-server-{{ trunc_uuid }}
           annotations:
 {% if workload_args.multus.enabled is sameas true %}
             k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.server}}

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -50,6 +50,15 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: '{{ workload_args.pin_server }}'
 {% endif %}
+
+# 
+# V2 pin server pod to node
+#
+{% if workload_args.max_node is defined %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ item[0] }}'
+{% endif %}
+
 {% if workload_args.serviceip is sameas true %}
       securityContext:
         sysctls:

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -7,7 +7,7 @@ items:
   - kind: Job
     apiVersion: batch/v1
     metadata:    
-      name: 'uperf-server-{{worker_node_list[ node_idx_item ] }}-{{ item }}-{{ trunc_uuid }}'
+      name: 'uperf-server-{{worker_node_list[ node_idx_item ] | truncate(32,true,'') }}-{{ item }}-{{ trunc_uuid }}'
       namespace: "{{ operator_namespace }}"
     spec:
       ttlSecondsAfterFinished: 600
@@ -15,7 +15,7 @@ items:
       template:
         metadata:
           labels:
-            app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(16,true,'') }}-{{ item  }}-{{ trunc_uuid }}
+            app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(32,true,'') }}-{{ item  }}-{{ trunc_uuid }}
             type: uperf-bench-server-{{ trunc_uuid }}
           annotations:
 {% if workload_args.multus.enabled is sameas true %}

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -2,7 +2,13 @@
 kind: Job
 apiVersion: batch/v1
 metadata:
+
+{% if workload_args.max_node is not defined %}
   name: 'uperf-server-{{ item }}-{{ trunc_uuid }}'
+{% else %}
+  name: 'uperf-server-{{ item[0] }}-{{ item[1] }}-{{ trunc_uuid }}'
+{% endif %}
+
   namespace: "{{ operator_namespace }}"
 spec:
   ttlSecondsAfterFinished: 600
@@ -10,7 +16,13 @@ spec:
   template:
     metadata:
       labels:
+
+{% if workload_args.max_node is not defined %}
         app: uperf-bench-server-{{item}}-{{ trunc_uuid }}
+{% else %}
+        app: uperf-bench-server-{{ item[0] }}-{{ item[1]  }}-{{ trunc_uuid }}
+{% endif %}
+
         type: uperf-bench-server-{{ trunc_uuid }}
 {% if workload_args.multus.enabled is sameas true %}
       annotations:

--- a/roles/uperf/templates/server_vm.yml.j2
+++ b/roles/uperf/templates/server_vm.yml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: '{{ operator_namespace }}'
   labels:
     app : uperf-bench-server-{{ item }}-{{ trunc_uuid }}
-    type : uperf-bench-server-{{ trunc_uuid }}
+    type : {{ meta.name }}-bench-server-{{ trunc_uuid }}
 spec:
   domain:
     cpu:

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -1,27 +1,46 @@
 ---
-kind: Service
 apiVersion: v1
-metadata:
-  name: uperf-service-{{ item }}-{{ trunc_uuid }}
-  namespace: '{{ operator_namespace }}'
-  labels:
-    app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
-    type: uperf-bench-server-{{ trunc_uuid }}
-spec:
-  selector:
-    app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
-  ports:
-  - name: uperf
-    port: 20000
-    targetPort: 20000
-    protocol: TCP
+kind: List
+metadata: {}
+items:
+{% macro job_template(item, node_idx_item='') %}
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      #name: uperf-service-{{ item }}-{{ trunc_uuid }}
+      name:  uperf-service-{{worker_node_list[ node_idx_item ] }}-{{ item }}-{{ trunc_uuid }}
+
+      namespace: '{{ operator_namespace }}'
+      labels:
+        #app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
+        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] }}-{{ item }}-{{ trunc_uuid }}
+        type: uperf-bench-server-{{ trunc_uuid }}
+      annotations:
+            node_idx: '{{ node_idx_item }}'
+            pod_idx: '{{ item }}'
+    spec:
+      selector:
+        #app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
+        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] }}-{{ item }}-{{ trunc_uuid }}
+      ports:
+      - name: uperf
+        port: 20000
+        targetPort: 20000
+        protocol: TCP
 {% for num in range(20001,20012,1) %}
-  - name: uperf-control-tcp-{{num}}
-    port: {{num}}
-    targetPort: {{num}}
-    protocol: TCP
-  - name: uperf-control-udp-{{num}}
-    port: {{num}}
-    targetPort: {{num}}
-    protocol: UDP
+      - name: uperf-control-tcp-{{num}}
+        port: {{num}}
+        targetPort: {{num}}
+        protocol: TCP
+      - name: uperf-control-udp-{{num}}
+        port: {{num}}
+        targetPort: {{num}}
+        protocol: UDP
 {% endfor %}
+{% endmacro %}
+{% for node_idx_item in range(node_sequence|int)  %}
+{% for item in range(pod_sequence|int)  %}
+{{ job_template(item,node_idx_item) }}
+{% endfor %}
+{% endfor %}
+

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -8,12 +8,12 @@ items:
     apiVersion: v1
     metadata:
       #name: uperf-service-{{ item }}-{{ trunc_uuid }}
-      name:  uperf-service-{{worker_node_list[ node_idx_item ] }}-{{ item }}-{{ trunc_uuid }}
+      name:  uperf-service-{{worker_node_list[ node_idx_item ] | truncate(32,true,'') }}-{{ item }}-{{ trunc_uuid }}
 
       namespace: '{{ operator_namespace }}'
       labels:
         #app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
-        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(16,true,'') }}-{{ item }}-{{ trunc_uuid }}
+        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(32,true,'') }}-{{ item }}-{{ trunc_uuid }}
         type: uperf-bench-server-{{ trunc_uuid }}
       annotations:
             node_idx: '{{ node_idx_item }}'
@@ -21,7 +21,7 @@ items:
     spec:
       selector:
         #app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
-        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(16,true,'')}}-{{ item }}-{{ trunc_uuid }}
+        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(32,true,'')}}-{{ item }}-{{ trunc_uuid }}
       ports:
       - name: uperf
         port: 20000

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -7,12 +7,10 @@ items:
   - kind: Service
     apiVersion: v1
     metadata:
-      #name: uperf-service-{{ item }}-{{ trunc_uuid }}
       name:  uperf-service-{{worker_node_list[ node_idx_item ] | truncate(32,true,'') }}-{{ item }}-{{ trunc_uuid }}
 
       namespace: '{{ operator_namespace }}'
       labels:
-        #app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
         app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(32,true,'') }}-{{ item }}-{{ trunc_uuid }}
         type: uperf-bench-server-{{ trunc_uuid }}
       annotations:
@@ -20,7 +18,6 @@ items:
             pod_idx: '{{ item }}'
     spec:
       selector:
-        #app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
         app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(32,true,'')}}-{{ item }}-{{ trunc_uuid }}
       ports:
       - name: uperf

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -11,7 +11,7 @@ items:
       namespace: '{{ operator_namespace }}'
       labels:
         app: uperf-bench-server-{{ worker_node_list[ node_idx_item ] | truncate(32,true,'')}}-{{ item }}-{{ trunc_uuid }}
-        type: uperf-bench-server-{{ trunc_uuid }}
+        type: {{ meta.name }}-bench-server-{{ trunc_uuid }}
       annotations:
         node_idx: '{{ node_idx_item }}'
         pod_idx: '{{ item }}'

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -13,7 +13,7 @@ items:
       namespace: '{{ operator_namespace }}'
       labels:
         #app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
-        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] }}-{{ item }}-{{ trunc_uuid }}
+        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(16,true,'') }}-{{ item }}-{{ trunc_uuid }}
         type: uperf-bench-server-{{ trunc_uuid }}
       annotations:
             node_idx: '{{ node_idx_item }}'
@@ -21,7 +21,7 @@ items:
     spec:
       selector:
         #app: uperf-bench-server-{{ item }}-{{ trunc_uuid }}
-        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] }}-{{ item }}-{{ trunc_uuid }}
+        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(16,true,'')}}-{{ item }}-{{ trunc_uuid }}
       ports:
       - name: uperf
         port: 20000

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -7,18 +7,17 @@ items:
   - kind: Service
     apiVersion: v1
     metadata:
-      name:  uperf-service-{{worker_node_list[ node_idx_item ] | truncate(32,true,'') }}-{{ item }}-{{ trunc_uuid }}
-
+      name:  uperf-service-{{ worker_node_list[ node_idx_item ] | truncate(32,true,'') }}-{{ item }}-{{ trunc_uuid }}
       namespace: '{{ operator_namespace }}'
       labels:
-        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(32,true,'') }}-{{ item }}-{{ trunc_uuid }}
+        app: uperf-bench-server-{{ worker_node_list[ node_idx_item ] | truncate(32,true,'')}}-{{ item }}-{{ trunc_uuid }}
         type: uperf-bench-server-{{ trunc_uuid }}
       annotations:
-            node_idx: '{{ node_idx_item }}'
-            pod_idx: '{{ item }}'
+        node_idx: '{{ node_idx_item }}'
+        pod_idx: '{{ item }}'
     spec:
       selector:
-        app:  uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(32,true,'')}}-{{ item }}-{{ trunc_uuid }}
+        app: uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(32,true,'')}}-{{ item }}-{{ trunc_uuid }}
       ports:
       - name: uperf
         port: 20000
@@ -40,4 +39,3 @@ items:
 {{ job_template(item,node_idx_item) }}
 {% endfor %}
 {% endfor %}
-

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -19,7 +19,7 @@ items:
           labels:
             app: uperf-bench-client-{{ trunc_uuid }}
             clientfor: {{ item.metadata.labels.app }}
-            type: uperf-bench-client-{{ trunc_uuid }}
+            type: {{ meta.name }}-bench-client-{{ trunc_uuid }}
 {% if workload_args.multus.enabled is sameas true %}
           annotations:
             k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.client }}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -46,7 +46,7 @@ items:
                   topologyKey: kubernetes.io/hostname
           containers:
           - name: benchmark
-            image: {{ workload_args.image | default('quay.io/cloud-bulldozer/uperf:latest') }}
+            image: {{ workload_args.image | default('quay.io/lblyth/lblyth-uperf:latest') }}
             env:
               - name: uuid
                 value: "{{ uuid }}"
@@ -88,11 +88,11 @@ items:
             args:
 {% if workload_args.serviceip is sameas true %}
               - "export serviceip=true;
-                export h={{item.spec.clusterIP}};
+              export h={{item.spec.clusterIP}};
 {% else %}
 {% if workload_args.multus.client is defined %}
               - "export multus_client={{workload_args.multus.client}};
-                export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
+              export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
 {% else %}
               - "export h={{item.status.podIP}};
 {% endif %}
@@ -103,8 +103,17 @@ items:
 {% if workload_args.step_size is defined %}
                  export stepsize={{ workload_args.step_size }};
 {% endif %}
+{% if workload_args.step_size is defined %}
+                export stepsize={{ workload_args.step_size }};
+{% endif %}
+{% if workload_args.node_range is defined %}
+                export node_range={{ workload_args.node_range[0] }}_{{ workload_args.node_range[1] }};
+{% endif %}
+{% if workload_args.density_range is defined %}
+                export density_range={{ workload_args.density_range[0] }}_{{ workload_args.density_range[1] }};
+{% endif %}
 {% if workload_args.networkpolicy is defined %}
-                 export networkpolicy={{workload_args.networkpolicy}};
+                export networkpolicy={{workload_args.networkpolicy}};
 {% endif %}
                  export hostnet={{workload_args.hostnetwork}};
                  export my_node_idx={{ (item['metadata']['annotations']['node_idx'] | from_json) }};
@@ -126,8 +135,8 @@ items:
                        if [[ $my_node_idx -gt $node_limit || $my_pod_idx -gt $pod_limit ]]; then
                              sleep 0.5; continue;
                        fi;
-    
-                       /bin/echo 'UPERF-run-context: num_node=' $((node_limit+1)) 'density=' $((pod_limit+1)) 'my_node_idx=' $my_node_idx 'my_pod_idx=' $my_pod_idx;
+
+                       echo "UPERF-run-context num_node=" $((node_limit+1)) "density=" $((pod_limit+1)) "my_node_idx=" $my_node_idx "my_pod_idx=" $my_pod_idx;
                        node_count=$((node_limit+1));
                        pod_count=$((pod_limit+1));
 
@@ -169,7 +178,7 @@ items:
                        if [[ $state =~ 'restart' ]]; then
                           sleep 0.5; continue;
                        fi;
-    
+
                    elif [[ $state =~ 'done' ]]; then
                        break;
                    else

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -3,9 +3,9 @@ kind: Job
 apiVersion: batch/v1
 metadata:
 {% if workload_args.serviceip is sameas true %}
-  name: 'uperf-client-{{item[0].spec.clusterIP}}-{{ trunc_uuid }}'
+  name: 'uperf-client-{{item.spec.clusterIP}}-{{ trunc_uuid }}'
 {% else %}
-  name: 'uperf-client-{{item[0].status.podIP}}-{{ trunc_uuid }}'
+  name: 'uperf-client-{{item.status.podIP}}-{{ trunc_uuid }}'
 {% endif %}
   namespace: '{{ operator_namespace }}'
 spec:
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: uperf-bench-client-{{ trunc_uuid }}
-        clientfor: {{ item[0].metadata.labels.app }}
+        clientfor: {{ item.metadata.labels.app }}
         type: uperf-bench-client-{{ trunc_uuid }}
 {% if workload_args.multus.enabled is sameas true %}
       annotations:
@@ -37,7 +37,7 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - {{ item[0].metadata.labels.app }}
+                  - {{ item.metadata.labels.app }}
               topologyKey: kubernetes.io/hostname
       containers:
       - name: benchmark
@@ -83,13 +83,13 @@ spec:
         args:
 {% if workload_args.serviceip is sameas true %}
           - "export serviceip=true;
-            export h={{item[0].spec.clusterIP}};
+            export h={{item.spec.clusterIP}};
 {% else %}
 {% if workload_args.multus.client is defined %}
           - "export multus_client={{workload_args.multus.client}};
-            export h={{ (item[0]['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
+            export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
 {% else %}
-          - "export h={{item[0].status.podIP}};
+          - "export h={{item.status.podIP}};
 {% endif %}
 {% endif %}
 {% if workload_args.networkpolicy is defined %}
@@ -138,14 +138,23 @@ spec:
           configMap:
             name: uperf-test-{{ trunc_uuid }}
       restartPolicy: OnFailure
+{% if workload_args.max_node is defined %}
+{% if workload_args.colocate is sameas true %}
+      nodeSelector:
+        # client node same as server node
+        kubernetes.io/hostname: "{{ worker_node_list[item['metadata']['annotations']['node_idx'] | from_json] }}"
+{% else %}
+      nodeSelector:
+        # skew client node one position left in the woker_node_list
+        kubernetes.io/hostname: "{{ worker_node_list[ (1+(item['metadata']['annotations']['node_idx'] | from_json)) % (worker_node_list|length)] }}"
+{% endif %}
+
+{% else  %}
 {% if workload_args.pin is sameas true %}
       nodeSelector:
         kubernetes.io/hostname: '{{ workload_args.pin_client }}'
 {% endif %}
-
-{% if workload_args.max_node is defined %}
-      nodeSelector:
-        kubernetes.io/hostname: '{{ item[1] }}'
+   
 {% endif %}
 
 

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -3,9 +3,9 @@ kind: Job
 apiVersion: batch/v1
 metadata:
 {% if workload_args.serviceip is sameas true %}
-  name: 'uperf-client-{{item.spec.clusterIP}}-{{ trunc_uuid }}'
+  name: 'uperf-client-{{item[0].spec.clusterIP}}-{{ trunc_uuid }}'
 {% else %}
-  name: 'uperf-client-{{item.status.podIP}}-{{ trunc_uuid }}'
+  name: 'uperf-client-{{item[0].status.podIP}}-{{ trunc_uuid }}'
 {% endif %}
   namespace: '{{ operator_namespace }}'
 spec:
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: uperf-bench-client-{{ trunc_uuid }}
-        clientfor: {{ item.metadata.labels.app }}
+        clientfor: {{ item[0].metadata.labels.app }}
         type: uperf-bench-client-{{ trunc_uuid }}
 {% if workload_args.multus.enabled is sameas true %}
       annotations:
@@ -37,7 +37,7 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - {{ item.metadata.labels.app }}
+                  - {{ item[0].metadata.labels.app }}
               topologyKey: kubernetes.io/hostname
       containers:
       - name: benchmark
@@ -83,13 +83,13 @@ spec:
         args:
 {% if workload_args.serviceip is sameas true %}
           - "export serviceip=true;
-            export h={{item.spec.clusterIP}};
+            export h={{item[0].spec.clusterIP}};
 {% else %}
 {% if workload_args.multus.client is defined %}
           - "export multus_client={{workload_args.multus.client}};
-            export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
+            export h={{ (item[0]['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
 {% else %}
-          - "export h={{item.status.podIP}};
+          - "export h={{item[0].status.podIP}};
 {% endif %}
 {% endif %}
 {% if workload_args.networkpolicy is defined %}
@@ -142,4 +142,11 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: '{{ workload_args.pin_client }}'
 {% endif %}
+
+{% if workload_args.max_node is defined %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ item[1] }}'
+{% endif %}
+
+
 {% include "metadata.yml.j2" %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -1,124 +1,129 @@
 ---
-kind: Job
-apiVersion: batch/v1
-metadata:
-{% if workload_args.serviceip is sameas true %}
-  name: 'uperf-client-{{item.spec.clusterIP}}-{{ trunc_uuid }}'
-{% else %}
-  name: 'uperf-client-{{item.status.podIP}}-{{ trunc_uuid }}'
-{% endif %}
-  namespace: '{{ operator_namespace }}'
-spec:
-  template:
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+{% for item in resource_item %}
+  - kind: Job
+    apiVersion: batch/v1
     metadata:
-      labels:
-        app: uperf-bench-client-{{ trunc_uuid }}
-        clientfor: {{ item.metadata.labels.app }}
-        type: uperf-bench-client-{{ trunc_uuid }}
-{% if workload_args.multus.enabled is sameas true %}
-      annotations:
-        k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.client }}
+{% if workload_args.serviceip is sameas true %}
+      name: 'uperf-client-{{item.spec.clusterIP}}-{{ trunc_uuid }}'
+{% else %}
+      name: 'uperf-client-{{item.status.podIP}}-{{ trunc_uuid }}'
 {% endif %}
+      namespace: '{{ operator_namespace }}'
     spec:
+      template:
+        metadata:
+          labels:
+            app: uperf-bench-client-{{ trunc_uuid }}
+            clientfor: {{ item.metadata.labels.app }}
+            type: uperf-bench-client-{{ trunc_uuid }}
+{% if workload_args.multus.enabled is sameas true %}
+          annotations:
+            k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.client }}
+{% endif %}
+        spec:
 {% if workload_args.runtime_class is defined %}
-      runtimeClassName: "{{ workload_args.runtime_class }}"
+          runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}
 {% if workload_args.hostnetwork is sameas true %}
-      hostNetwork: true
-      serviceAccountName: benchmark-operator
+          hostNetwork: true
+          serviceAccountName: benchmark-operator
 {% endif %}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - {{ item.metadata.labels.app }}
-              topologyKey: kubernetes.io/hostname
-      containers:
-      - name: benchmark
-        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/uperf:latest') }}
-        env:
-          - name: uuid
-            value: "{{ uuid }}"
-          - name: test_user
-            value: "{{ test_user | default("ripsaw") }}"
-          - name: clustername
-            value: "{{ clustername }}"
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                      - {{ item.metadata.labels.app }}
+                  topologyKey: kubernetes.io/hostname
+          containers:
+          - name: benchmark
+            image: {{ workload_args.image | default('quay.io/cloud-bulldozer/uperf:latest') }}
+            env:
+              - name: uuid
+                value: "{{ uuid }}"
+              - name: test_user
+                value: "{{ test_user | default("ripsaw") }}"
+              - name: clustername
+                value: "{{ clustername }}"
 {% if elasticsearch is defined %}
-          - name: es
-            value: "{{ elasticsearch.url }}"
-          - name: es_index
-            value: "{{ elasticsearch.index_name | default("ripsaw-uperf") }}"
-          - name: parallel
-            value: "{{ elasticsearch.parallel | default(false) }}"
-          - name: es_verify_cert
-            value: "{{ elasticsearch.verify_cert | default(true) }}"
+              - name: es
+                value: "{{ elasticsearch.url }}"
+              - name: es_index
+                value: "{{ elasticsearch.index_name | default("ripsaw-uperf") }}"
+              - name: parallel
+                value: "{{ elasticsearch.parallel | default(false) }}"
+              - name: es_verify_cert
+                value: "{{ elasticsearch.verify_cert | default(true) }}"
 {% endif %}
 {% if prometheus is defined %}
-          - name: prom_es
-            value: "{{ prometheus.es_url }}"
-          - name: prom_parallel
-            value: "{{ prometheus.es_parallel | default(false) }}"
-          - name: prom_token
-            value: "{{ prometheus.prom_token | default() }}"
-          - name: prom_url
-            value: "{{ prometheus.prom_url | default() }}"
+              - name: prom_es
+                value: "{{ prometheus.es_url }}"
+              - name: prom_parallel
+                value: "{{ prometheus.es_parallel | default(false) }}"
+              - name: prom_token
+                value: "{{ prometheus.prom_token | default() }}"
+              - name: prom_url
+                value: "{{ prometheus.prom_url | default() }}"
 {% endif %}
-          - name: client_node
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: server_node
-            value: "{{ uperf.pin_server|default("unknown") }}"
+              - name: client_node
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+              - name: server_node
+                value: "{{ uperf.pin_server|default("unknown") }}"
 {% if workload_args.client_resources is defined %}
-        resources: {{ workload_args.client_resources | to_json }}
+            resources: {{ workload_args.client_resources | to_json }}
 {% endif %}
-        imagePullPolicy: Always
-        command: ["/bin/sh", "-c"]
-        args:
+            imagePullPolicy: Always
+            command: ["/bin/sh", "-c"]
+            args:
 {% if workload_args.serviceip is sameas true %}
-          - "export serviceip=true;
-            export h={{item.spec.clusterIP}};
+              - "export serviceip=true;
+                export h={{item.spec.clusterIP}};
 {% else %}
 {% if workload_args.multus.client is defined %}
-          - "export multus_client={{workload_args.multus.client}};
-            export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
+              - "export multus_client={{workload_args.multus.client}};
+                export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
 {% else %}
-          - "export h={{item.status.podIP}};
+              - "export h={{item.status.podIP}};
 {% endif %}
 {% endif %}
 {% if workload_args.networkpolicy is defined %}
-             export networkpolicy={{workload_args.networkpolicy}};
+                 export networkpolicy={{workload_args.networkpolicy}};
 {% endif %}
-             export hostnet={{workload_args.hostnetwork}};
-             export my_node_idx={{ (item['metadata']['annotations']['node_idx'] | from_json) }};
-             export my_pod_idx={{ (item['metadata']['annotations']['pod_idx'] | from_json) }};
-             export ips=$(hostname -I);
-             export num_pairs={{workload_args.pair}};
-             export node_count=0
-             export pod_count=0
-             node_limit=0;
-             pod_limit=0;
-             STR='';
-             while true; do
-               STR=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
-               state=$(echo $STR | cut -f1 -d-);
-               if [[ $state =~ 'true' ]]; then
-                   node_limit=$(echo $STR | cut -f2 -d-);
-                   pod_limit=$(echo $STR | cut -f3 -d-);
-                   echo 'state=' $state 'node=' $node_limit 'pod=' $pod_limit;
-                   if [[ $my_node_idx -gt $node_limit || $my_pod_idx -gt $pod_limit ]]; then
-                         continue;
-                   fi;
-
-                   /bin/echo 'UPERF-run-context: num_node=' $((node_limit+1)) 'density=' $((pod_limit+1)) 'my_node_idx=' $my_node_idx 'my_pod_idx=' $my_pod_idx;
-                   node_count=$((node_limit+1));
-                   pod_count=$((pod_limit+1));
+                 export hostnet={{workload_args.hostnetwork}};
+                 export my_node_idx={{ (item['metadata']['annotations']['node_idx'] | from_json) }};
+                 export my_pod_idx={{ (item['metadata']['annotations']['pod_idx'] | from_json) }};
+                 export ips=$(hostname -I);
+                 export num_pairs={{workload_args.pair}};
+                 export node_count=0
+                 export pod_count=0
+                 node_limit=0;
+                 pod_limit=0;
+                 STR='';
+                 while true; do
+                   STR=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
+                   state=$(echo $STR | cut -f1 -d-);
+                   if [[ $state =~ 'true' ]]; then
+                       node_limit=$(echo $STR | cut -f2 -d-);
+                       pod_limit=$(echo $STR | cut -f3 -d-);
+                       echo 'state=' $state 'node=' $node_limit 'pod=' $pod_limit;
+                       if [[ $my_node_idx -gt $node_limit || $my_pod_idx -gt $pod_limit ]]; then
+                             continue;
+                       fi;
+    
+                       /bin/echo 'UPERF-run-context: num_node=' $((node_limit+1)) 'density=' $((pod_limit+1)) 'my_node_idx=' $my_node_idx 'my_pod_idx=' $my_pod_idx;
+                       node_count=$((node_limit+1));
+                       pod_count=$((pod_limit+1));
 
 {% for test in workload_args.test_types %}
 {% for proto in workload_args.protos %}
@@ -131,72 +136,73 @@ spec:
 {% set rsize = size %}
 {% endif %}
 {% for nthr in workload_args.nthrs %}
-                 cat /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}};
-                 run_snafu --tool uperf -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}} -s {{workload_args.samples}} --resourcetype {{resource_kind}} -u {{ uuid }} --user {{test_user | default("ripsaw")}} \
+                     cat /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}};
+                     run_snafu --tool uperf -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}} -s {{workload_args.samples}} --resourcetype {{resource_kind}} -u {{ uuid }} --user {{test_user | default("ripsaw")}} \
 {% if workload_args.run_id is defined %}
-                 --run-id {{workload_args.run_id}} \
+                     --run-id {{workload_args.run_id}} \
 {% endif %}
 {% if workload_args.debug is defined and workload_args.debug %}
-                 -v \
+                     -v \
 {% endif %}
                  ;
 {% endfor %}
 {% endfor %}
 {% endfor %}
 {% endfor %}
-                   redis-cli -h {{bo.resources[0].status.podIP}} incr num_completion;
-                   while true; do
-                       state=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
+                       redis-cli -h {{bo.resources[0].status.podIP}} incr num_completion;
+                       while true; do
+                           state=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
+                           if [[ $state =~ 'restart' ]]; then
+                              break;
+                           elif [[ $state =~ 'done' ]]; then
+                              break;
+                           else
+                             continue;
+                           fi;
+                       done;
                        if [[ $state =~ 'restart' ]]; then
-                          break;
-                       elif [[ $state =~ 'done' ]]; then
-                          break;
-                       else
-                         continue;
+                          continue;
                        fi;
-                   done;
-                   if [[ $state =~ 'restart' ]]; then
-                      continue;
+    
+                   elif [[ $state =~ 'done' ]]; then
+                       break;
+                   else
+                     continue;
                    fi;
-
-               elif [[ $state =~ 'done' ]]; then
                    break;
-               else
-                 continue;
-               fi;
-               break;
-             done;
+                 done;
 {% if workload_args.node_range is not defined %}
-             redis-cli -h {{bo.resources[0].status.podIP}} set start false"
+                 redis-cli -h {{bo.resources[0].status.podIP}} set start false"
 {% else %}
-            "
+                "
 {% endif %}
-        volumeMounts:
-          - name: config-volume
-            mountPath: "/tmp/uperf-test"
-      volumes:
-        - name: config-volume
-          configMap:
-            name: uperf-test-{{ trunc_uuid }}
-      restartPolicy: OnFailure
+            volumeMounts:
+              - name: config-volume
+                mountPath: "/tmp/uperf-test"
+          volumes:
+            - name: config-volume
+              configMap:
+                name: uperf-test-{{ trunc_uuid }}
+          restartPolicy: OnFailure
 {% if workload_args.node_range is defined %}
 {% if workload_args.colocate is sameas true %}
-      nodeSelector:
-        # client node same as server node
-        kubernetes.io/hostname: "{{ worker_node_list[item['metadata']['annotations']['node_idx'] | from_json] }}"
+          nodeSelector:
+            # client node same as server node
+            kubernetes.io/hostname: "{{ worker_node_list[item['metadata']['annotations']['node_idx'] | from_json] }}"
 {% else %}
-      nodeSelector:
-        # skew client node one position left in the woker_node_list
-        kubernetes.io/hostname: "{{ worker_node_list[ (1+(item['metadata']['annotations']['node_idx'] | from_json)) % (worker_node_list|length)] }}"
+          nodeSelector:
+            # skew client node one position left in the woker_node_list
+            kubernetes.io/hostname: "{{ worker_node_list[ (1+(item['metadata']['annotations']['node_idx'] | from_json)) % (worker_node_list|length)] }}"
 {% endif %}
 
 {% else  %}
 {% if workload_args.pin is sameas true %}
-      nodeSelector:
-        kubernetes.io/hostname: '{{ workload_args.pin_client }}'
+          nodeSelector:
+            kubernetes.io/hostname: '{{ workload_args.pin_client }}'
 {% endif %}
    
 {% endif %}
 
-
-{% include "metadata.yml.j2" %}
+{% macro metadata() %}{% include "metadata.yml.j2" %}{% endmacro %}
+    {{ metadata()|indent }}
+{% endfor %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -117,8 +117,8 @@ items:
                  export my_pod_idx={{ (item['metadata']['annotations']['pod_idx'] | from_json) }};
                  export ips=$(hostname -I);
                  export num_pairs={{workload_args.pair}};
-                 export node_count=0
-                 export pod_count=0
+                 export node_count=0;
+                 export pod_count=0;
                  node_limit=0;
                  pod_limit=0;
                  STR='';
@@ -128,7 +128,6 @@ items:
                    if [[ $state =~ 'true' ]]; then
                        node_limit=$(echo $STR | cut -f2 -d-);
                        pod_limit=$(echo $STR | cut -f3 -d-);
-                       echo 'state=' $state 'node=' $node_limit 'pod=' $pod_limit;
                        if [[ $my_node_idx -gt $node_limit || $my_pod_idx -gt $pod_limit ]]; then
                              sleep 0.5; continue;
                        fi;

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -88,11 +88,11 @@ items:
             args:
 {% if workload_args.serviceip is sameas true %}
               - "export serviceip=true;
-              export h={{item.spec.clusterIP}};
+                 export h={{item.spec.clusterIP}};
 {% else %}
 {% if workload_args.multus.client is defined %}
               - "export multus_client={{workload_args.multus.client}};
-              export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
+                 export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
 {% else %}
               - "export h={{item.status.podIP}};
 {% endif %}
@@ -101,16 +101,16 @@ items:
                  export colocate={{ workload_args.colocate}};
 {% endif %}
 {% if workload_args.step_size is defined %}
-                export stepsize={{ workload_args.step_size }};
+                 export stepsize={{ workload_args.step_size }};
 {% endif %}
 {% if workload_args.node_range is defined %}
-                export node_range='{{ workload_args.node_range[0] }}_{{ workload_args.node_range[1] }}';
+                 export node_range='{{ workload_args.node_range[0] }}_{{ workload_args.node_range[1] }}';
 {% endif %}
 {% if workload_args.density_range is defined %}
-                export density_range='{{ workload_args.density_range[0] }}_{{ workload_args.density_range[1] }}';
+                 export density_range='{{ workload_args.density_range[0] }}_{{ workload_args.density_range[1] }}';
 {% endif %}
 {% if workload_args.networkpolicy is defined %}
-                export networkpolicy={{workload_args.networkpolicy}};
+                 export networkpolicy={{workload_args.networkpolicy}};
 {% endif %}
                  export hostnet={{workload_args.hostnetwork}};
                  export my_node_idx={{ (item['metadata']['annotations']['node_idx'] | from_json) }};
@@ -199,7 +199,7 @@ items:
             kubernetes.io/hostname: "{{ worker_node_list[item['metadata']['annotations']['node_idx'] | from_json] }}"
 {% else %}
           nodeSelector:
-            # skew client node one position left in the woker_node_list
+            # skew client node one position to the right in the worker_node_list
             kubernetes.io/hostname: "{{ worker_node_list[ (1+(item['metadata']['annotations']['node_idx'] | from_json)) % (worker_node_list|length)] }}"
 {% endif %}
 

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -96,18 +96,22 @@ spec:
              export networkpolicy={{workload_args.networkpolicy}};
 {% endif %}
              export hostnet={{workload_args.hostnetwork}};
-             mynode={{ (item['metadata']['annotations']['node_idx'] | from_json) }};
+             my_node_idx={{ (item['metadata']['annotations']['node_idx'] | from_json) }};
+             my_pod_idx={{ (item['metadata']['annotations']['pod_idx'] | from_json) }};
              export ips=$(hostname -I);
              export num_pairs={{workload_args.pair}};
              node_limit=0;
+             pod_limit=0;
              while true; do
                state=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
                if [[ $state =~ 'true' ]]; then
-                   node_limit=$(redis-cli -h {{bo.resources[0].status.podIP}} get group_node_count);
-                   if [[ $node_limit -le $mynode ]]; then
+                   node_limit=$(redis-cli -h {{bo.resources[0].status.podIP}} get node_idx);
+                   pod_limit=$(redis-cli -h {{bo.resources[0].status.podIP}} get pod_idx);
+                   if [[ $my_node_idx -gt $node_limit || $my_pod_idx -gt $pod_limit ]]; then
                          continue;
                    fi;
 
+                   /bin/echo 'UPERF scale config: num_node=' $node_limit+1' density= {{ pod_idx }}';
 
 {% for test in workload_args.test_types %}
 {% for proto in workload_args.protos %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -98,10 +98,10 @@ items:
 {% endif %}
 {% endif %}
 {% if (workload_args.colocate is defined) %}
-              - export colocate={{ workload_args.colocate}};
+                 export colocate={{ workload_args.colocate}};
 {% endif %}
 {% if workload_args.step_size is defined %}
-              - export stepsize={{ workload_args.step_size }};
+                 export stepsize={{ workload_args.step_size }};
 {% endif %}
 {% if workload_args.networkpolicy is defined %}
                  export networkpolicy={{workload_args.networkpolicy}};

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -97,6 +97,12 @@ items:
               - "export h={{item.status.podIP}};
 {% endif %}
 {% endif %}
+{% if (workload_args.colocate is defined) %}
+              - export colocate={{ workload_args.colocate}};
+{% endif %}
+{% if workload_args.step_size is defined %}
+              - export stepsize={{ workload_args.step_size }};
+{% endif %}
 {% if workload_args.networkpolicy is defined %}
                  export networkpolicy={{workload_args.networkpolicy}};
 {% endif %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -46,7 +46,7 @@ items:
                   topologyKey: kubernetes.io/hostname
           containers:
           - name: benchmark
-            image: {{ workload_args.image | default('quay.io/lblyth/lblyth-uperf:latest') }}
+            image: {{ workload_args.image | default('quay.io/cloud-bulldozer/uperf:latest') }}
             env:
               - name: uuid
                 value: "{{ uuid }}"
@@ -116,7 +116,7 @@ items:
                  export my_node_idx={{ (item['metadata']['annotations']['node_idx'] | from_json) }};
                  export my_pod_idx={{ (item['metadata']['annotations']['pod_idx'] | from_json) }};
                  export ips=$(hostname -I);
-                 export num_pairs={{workload_args.pair}};
+                 export num_pairs=1
                  export node_count=0;
                  export pod_count=0;
                  node_limit=0;
@@ -135,6 +135,7 @@ items:
                        echo 'UPERF-run-context num_node=' $((node_limit+1)) 'density=' $((pod_limit+1)) 'my_node_idx=' $my_node_idx 'my_pod_idx=' $my_pod_idx;
                        node_count=$((node_limit+1));
                        pod_count=$((pod_limit+1));
+                       num_pairs=$((pod_limit+1));
 
 {% for test in workload_args.test_types %}
 {% for proto in workload_args.protos %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -96,10 +96,12 @@ spec:
              export networkpolicy={{workload_args.networkpolicy}};
 {% endif %}
              export hostnet={{workload_args.hostnetwork}};
-             my_node_idx={{ (item['metadata']['annotations']['node_idx'] | from_json) }};
-             my_pod_idx={{ (item['metadata']['annotations']['pod_idx'] | from_json) }};
+             export my_node_idx={{ (item['metadata']['annotations']['node_idx'] | from_json) }};
+             export my_pod_idx={{ (item['metadata']['annotations']['pod_idx'] | from_json) }};
              export ips=$(hostname -I);
              export num_pairs={{workload_args.pair}};
+             export node_count=0
+             export pod_count=0
              node_limit=0;
              pod_limit=0;
              while true; do
@@ -111,7 +113,9 @@ spec:
                          continue;
                    fi;
 
-                   /bin/echo 'UPERF scale config: num_node=' $node_limit+1' density= {{ pod_idx }}';
+                   /bin/echo 'UPERF-run-context: num_node=' $((node_limit+1)) 'density=' $((pod_limit+1)) 'my_node_idx=' $my_node_idx 'my_pod_idx=' $my_pod_idx;
+                   node_count=$((node_limit+1));
+                   pod_count=$((pod_limit+1));
 
 {% for test in workload_args.test_types %}
 {% for proto in workload_args.protos %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -104,11 +104,14 @@ spec:
              export pod_count=0
              node_limit=0;
              pod_limit=0;
+             STR='';
              while true; do
-               state=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
+               STR=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
+               state=$(echo $STR | cut -f1 -d-);
                if [[ $state =~ 'true' ]]; then
-                   node_limit=$(redis-cli -h {{bo.resources[0].status.podIP}} get node_idx);
-                   pod_limit=$(redis-cli -h {{bo.resources[0].status.podIP}} get pod_idx);
+                   node_limit=$(echo $STR | cut -f2 -d-);
+                   pod_limit=$(echo $STR | cut -f3 -d-);
+                   echo 'state=' $state 'node=' $node_limit 'pod=' $pod_limit;
                    if [[ $my_node_idx -gt $node_limit || $my_pod_idx -gt $pod_limit ]]; then
                          continue;
                    fi;
@@ -163,7 +166,11 @@ spec:
                fi;
                break;
              done;
+{% if workload_args.node_range is not defined %}
              redis-cli -h {{bo.resources[0].status.podIP}} set start false"
+{% else %}
+            "
+{% endif %}
         volumeMounts:
           - name: config-volume
             mountPath: "/tmp/uperf-test"

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -168,7 +168,7 @@ spec:
           configMap:
             name: uperf-test-{{ trunc_uuid }}
       restartPolicy: OnFailure
-{% if workload_args.max_node is defined %}
+{% if workload_args.node_range is defined %}
 {% if workload_args.colocate is sameas true %}
       nodeSelector:
         # client node same as server node

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -99,7 +99,8 @@ spec:
              export ips=$(hostname -I);
              export num_pairs={{workload_args.pair}};
              while true; do
-               if [[ $(redis-cli -h {{bo.resources[0].status.podIP}} get start) =~ 'true' ]]; then
+               state=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
+               if [[ $state =~ 'true' ]]; then
 {% for test in workload_args.test_types %}
 {% for proto in workload_args.protos %}
 {% for size in workload_args.sizes %}
@@ -124,6 +125,23 @@ spec:
 {% endfor %}
 {% endfor %}
 {% endfor %}
+                   redis-cli -h {{bo.resources[0].status.podIP}} incr num_completion;
+                   while true; do
+                       state=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
+                       if [[ $state =~ 'restart' ]]; then
+                          break;
+                       elif [[ $state =~ 'done' ]]; then
+                          break;
+                       else
+                         continue;
+                       fi;
+                   done;
+                   if [[ $state =~ 'restart' ]]; then
+                      continue;
+                   fi;
+
+               elif [[ $state =~ 'done' ]]; then
+                   break;
                else
                  continue;
                fi;

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -96,11 +96,19 @@ spec:
              export networkpolicy={{workload_args.networkpolicy}};
 {% endif %}
              export hostnet={{workload_args.hostnetwork}};
+             mynode={{ (item['metadata']['annotations']['node_idx'] | from_json) }};
              export ips=$(hostname -I);
              export num_pairs={{workload_args.pair}};
+             node_limit=0;
              while true; do
                state=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
                if [[ $state =~ 'true' ]]; then
+                   node_limit=$(redis-cli -h {{bo.resources[0].status.podIP}} get group_node_count);
+                   if [[ $node_limit -le $mynode ]]; then
+                         continue;
+                   fi;
+
+
 {% for test in workload_args.test_types %}
 {% for proto in workload_args.protos %}
 {% for size in workload_args.sizes %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -107,10 +107,10 @@ items:
                 export stepsize={{ workload_args.step_size }};
 {% endif %}
 {% if workload_args.node_range is defined %}
-                export node_range={{ workload_args.node_range[0] }}_{{ workload_args.node_range[1] }};
+                export node_range='{{ workload_args.node_range[0] }}_{{ workload_args.node_range[1] }}';
 {% endif %}
 {% if workload_args.density_range is defined %}
-                export density_range={{ workload_args.density_range[0] }}_{{ workload_args.density_range[1] }};
+                export density_range='{{ workload_args.density_range[0] }}_{{ workload_args.density_range[1] }}';
 {% endif %}
 {% if workload_args.networkpolicy is defined %}
                 export networkpolicy={{workload_args.networkpolicy}};
@@ -136,7 +136,7 @@ items:
                              sleep 0.5; continue;
                        fi;
 
-                       echo "UPERF-run-context num_node=" $((node_limit+1)) "density=" $((pod_limit+1)) "my_node_idx=" $my_node_idx "my_pod_idx=" $my_pod_idx;
+                       echo 'UPERF-run-context num_node=' $((node_limit+1)) 'density=' $((pod_limit+1)) 'my_node_idx=' $my_node_idx 'my_pod_idx=' $my_pod_idx;
                        node_count=$((node_limit+1));
                        pod_count=$((pod_limit+1));
 

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -118,7 +118,7 @@ items:
                        pod_limit=$(echo $STR | cut -f3 -d-);
                        echo 'state=' $state 'node=' $node_limit 'pod=' $pod_limit;
                        if [[ $my_node_idx -gt $node_limit || $my_pod_idx -gt $pod_limit ]]; then
-                             continue;
+                             sleep 0.5; continue;
                        fi;
     
                        /bin/echo 'UPERF-run-context: num_node=' $((node_limit+1)) 'density=' $((pod_limit+1)) 'my_node_idx=' $my_node_idx 'my_pod_idx=' $my_pod_idx;
@@ -157,17 +157,17 @@ items:
                            elif [[ $state =~ 'done' ]]; then
                               break;
                            else
-                             continue;
+                             sleep 0.5; continue;
                            fi;
                        done;
                        if [[ $state =~ 'restart' ]]; then
-                          continue;
+                          sleep 0.5; continue;
                        fi;
     
                    elif [[ $state =~ 'done' ]]; then
                        break;
                    else
-                     continue;
+                     sleep 0.5; continue;
                    fi;
                    break;
                  done;

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -123,7 +123,7 @@ items:
                  pod_limit=0;
                  STR='';
                  while true; do
-                   STR=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
+                   STR=$(redis-cli -h {{bo.resources[0].status.podIP}} get start-{{trunc_uuid}});
                    state=$(echo $STR | cut -f1 -d-);
                    if [[ $state =~ 'true' ]]; then
                        node_limit=$(echo $STR | cut -f2 -d-);
@@ -161,9 +161,9 @@ items:
 {% endfor %}
 {% endfor %}
 {% endfor %}
-                       redis-cli -h {{bo.resources[0].status.podIP}} incr num_completion;
+                       redis-cli -h {{bo.resources[0].status.podIP}} incr num_completion-{{trunc_uuid}};
                        while true; do
-                           state=$(redis-cli -h {{bo.resources[0].status.podIP}} get start);
+                           state=$(redis-cli -h {{bo.resources[0].status.podIP}} get start-{{trunc_uuid}});
                            if [[ $state =~ 'restart' ]]; then
                               break;
                            elif [[ $state =~ 'done' ]]; then

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -101,9 +101,6 @@ items:
                  export colocate={{ workload_args.colocate}};
 {% endif %}
 {% if workload_args.step_size is defined %}
-                 export stepsize={{ workload_args.step_size }};
-{% endif %}
-{% if workload_args.step_size is defined %}
                 export stepsize={{ workload_args.step_size }};
 {% endif %}
 {% if workload_args.node_range is defined %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -177,11 +177,7 @@ items:
                    fi;
                    break;
                  done;
-{% if workload_args.node_range is not defined %}
-                 redis-cli -h {{bo.resources[0].status.podIP}} set start false"
-{% else %}
                 "
-{% endif %}
             volumeMounts:
               - name: config-volume
                 mountPath: "/tmp/uperf-test"
@@ -190,7 +186,7 @@ items:
               configMap:
                 name: uperf-test-{{ trunc_uuid }}
           restartPolicy: OnFailure
-{% if workload_args.node_range is defined %}
+{% if workload_args.pin is sameas false %}
 {% if workload_args.colocate is sameas true %}
           nodeSelector:
             # client node same as server node

--- a/roles/uperf/templates/workload_vm.yml.j2
+++ b/roles/uperf/templates/workload_vm.yml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: '{{ operator_namespace }}'
   labels:
     app: uperf-bench-client-{{ trunc_uuid }}
-    type: uperf-bench-client-{{ trunc_uuid }}
+    type: {{ meta.name }}-bench-client-{{ trunc_uuid }}
 spec:
   domain:
     cpu:

--- a/roles/uperf/vars/main.yml
+++ b/roles/uperf/vars/main.yml
@@ -2,3 +2,6 @@
 # vars file for bench
 cleanup: true
 worker_node_list: []
+group_node_count: 0
+max_node_count: 0
+

--- a/roles/uperf/vars/main.yml
+++ b/roles/uperf/vars/main.yml
@@ -5,3 +5,12 @@ worker_node_list: []
 group_node_count: 0
 max_node_count: 0
 
+pod_low_idx: 1
+pod_hi_idx: 1
+node_low_idx: 1
+node_hi_idx: 1
+
+node_idx: 0
+pod_idx: 0
+
+all_run_done: false

--- a/roles/uperf/vars/main.yml
+++ b/roles/uperf/vars/main.yml
@@ -5,12 +5,12 @@ worker_node_list: []
 group_node_count: 0
 max_node_count: 0
 
-pod_low_idx: 0
-pod_hi_idx: 0
-node_low_idx: 0
-node_hi_idx: 0
+pod_low_idx: "0"
+pod_hi_idx: "0"
+node_low_idx: "0"
+node_hi_idx: "0"
 
-node_idx: 0
-pod_idx: 0
+node_idx: "0"
+pod_idx: "0"
 
 all_run_done: false

--- a/roles/uperf/vars/main.yml
+++ b/roles/uperf/vars/main.yml
@@ -2,15 +2,10 @@
 # vars file for bench
 cleanup: true
 worker_node_list: []
-group_node_count: 0
-max_node_count: 0
-
 pod_low_idx: "0"
 pod_hi_idx: "0"
 node_low_idx: "0"
 node_hi_idx: "0"
-
 node_idx: "0"
 pod_idx: "0"
-
 all_run_done: false

--- a/roles/uperf/vars/main.yml
+++ b/roles/uperf/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 # vars file for bench
 cleanup: true
+worker_node_list: []

--- a/roles/uperf/vars/main.yml
+++ b/roles/uperf/vars/main.yml
@@ -5,10 +5,10 @@ worker_node_list: []
 group_node_count: 0
 max_node_count: 0
 
-pod_low_idx: 1
-pod_hi_idx: 1
-node_low_idx: 1
-node_hi_idx: 1
+pod_low_idx: 0
+pod_hi_idx: 0
+node_low_idx: 0
+node_hi_idx: 0
 
 node_idx: 0
 pod_idx: 0

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -1,7 +1,7 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: uperf
   namespace: my-ripsaw
 spec:
   elasticsearch:

--- a/tests/test_crs/valid_uperf_networkpolicy.yaml
+++ b/tests/test_crs/valid_uperf_networkpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: uperf
   namespace: my-ripsaw
 spec:
   elasticsearch:

--- a/tests/test_crs/valid_uperf_resources.yaml
+++ b/tests/test_crs/valid_uperf_resources.yaml
@@ -1,7 +1,7 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: uperf
   namespace: my-ripsaw
 spec:
   elasticsearch:

--- a/tests/test_crs/valid_uperf_serviceip.yaml
+++ b/tests/test_crs/valid_uperf_serviceip.yaml
@@ -1,7 +1,7 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: example-benchmark
+  name: uperf
   namespace: my-ripsaw
 spec:
   elasticsearch:

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -27,8 +27,8 @@ function functional_test_uperf {
   uuid=${long_uuid:0:8}
 
   pod_count "type=uperf-bench-server-$uuid" 1 900
-  uperf_server_pod=$(get_pod "app=uperf-bench-server-0-$uuid" 300)
-  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized -l app=uperf-bench-server-0-$uuid pods --timeout=300s" "300s" $uperf_server_pod
+  uperf_server_pod=$(get_pod "type=uperf-bench-server-${uuid}" 300)
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized -l type=uperf-bench-server-${uuid} pods --timeout=300s" "300s" $uperf_server_pod
   uperf_client_pod=$(get_pod "app=uperf-bench-client-$uuid" 900)
   wait_for "kubectl wait -n my-ripsaw --for=condition=Initialized pods/$uperf_client_pod --timeout=500s" "500s" $uperf_client_pod
   wait_for "kubectl wait -n my-ripsaw --for=condition=complete -l app=uperf-bench-client-$uuid jobs --timeout=500s" "500s" $uperf_client_pod


### PR DESCRIPTION
### Summary of Changes:
This PR adds scale mode enhancement to UPERF workload for Telco-5G such as VZ's Webscale where there are up to 250 nodes at the moment.  The scale mode are realized by the following new UPERF CR options

- colocate: true/false
- density_range: [low,high]
- node_range:[ low,high]
- step_size: addN, log2
- exclude_labels: []

See uperf.md for more details.  The following preso is the project status sandbox but you could find a few useful explanations,
https://docs.google.com/presentation/d/11zCqw8K98jams8wYO24ATwpKzNYTK-xuC-gbvAddbLY/edit#slide=id.g78a1e8b739_0_913 

### Limitations:
Only support "pod' type.  "VM" type functionality remains unchanged. Future enhancement is being considered

### Scope of Changes:

1. Add ability to gather node inventory at run-time to build-up worker node list.
2. Add ability to instantiate the number of server pods according to `node_range` and `density_range`,
3. Add ability to instantiate client pod with correct affinity based on `colocate` value.
4. Add additional state to uperf workload's main state machine so that it can iterate over `node_range` and `density_range`
5. Add additional states to UPERF client workload.yml.j2 to that it can run again and again under the control of the main state machine.
6. Change serviceip, server, and client spec to list to speedup instantiation.
7. While at it, restructure the UPERF workload main.yaml to help with adding new states, isolate pod type from VM type specific code.
8. Enhance 'pin' mode to use density_range[], so pin mode now can iterate
9. remove 'pair' - now we will use 'density_range'

### Files:

- main.yml  - this was one monolithic UPERF file. Now it is just the "state machine"/main loop
- setup.yml  - contains initial setup of dynamic node list, indices representing node_range[] and density_range[]
- init.yml      - init code used mostly for creating server pods
- start_server.yml - create server pods  
- wait_server_ready.yml - wait for server pods become ready
- start_client.yml  - create client pods  
- wait_client_ready.yml  - wait for client pod becomes ready

The nest 3 files are responsible for running the loop to iterate node_range[] and density_range[]

- run_a_set.yml 
- wait_set_done.yml
- next_set.yml  

send_client_run_signal.yml  - for VM specific

The next 2 are common code to cleanup after the run>

- wait_client_done.yml  
- cleanup.yml 


### Unit-test

- PASS - test colocate, density_range, node_range, step_size
- PASS-  test pin mode
- PASS - test serviceip
- PASS - test VM mode for no regression - Need to use valid images and CR
