### PR TITLE
Remove runAsUser in mssql

### DIFF
--- a/tests/mssql.yaml
+++ b/tests/mssql.yaml
@@ -20,8 +20,6 @@ spec:
         app: mssql
     spec:
       terminationGracePeriodSeconds: 10
-      securityContext:
-        runAsUser: 10001
       containers:
       - name: mssql
         image: quay.io/cloud-bulldozer/mssql:latest


### PR DESCRIPTION
Should prevent using the `oc adm policy add-scc-to-group nonroot system:authenticated` workaround for mssql which seems causing other issues.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>