### PR TITLE
Add pod-density scenarios

### DIFF
--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -59,6 +59,10 @@ Each iteration of this workload creates the following objects:
   - 1 simple application deployment (hello-openshift)
   - 1 service pointing to the previous deployment
 
+- **pod-density**: Creates a single namespace with a number of Deployments equal to **job_iterations**. This workload is similar to node-density except is used to create a large number of pods spread across the cluster instead of specifically loading up each node with a given number of pods as in `node-density`.
+Each iteration of this workload creates the following object:
+  - 1 pod. (sleep)
+
 The workload type is specified by the parameter `workload` from the `args` object of the configuration. Each workload supports several configuration parameters, detailed in the [configuration section](#configuration)
 
 ## Configuration

--- a/roles/kube-burner/tasks/main.yml
+++ b/roles/kube-burner/tasks/main.yml
@@ -74,7 +74,7 @@
           configmap.yml: "{{ lookup('file', 'configmap.yml')}}"
     when: workload_args.workload == "cluster-density"
 
-  - name: Create node-density configmaps
+  - name: Create node-density or pod-density configmaps
     k8s:
       definition:
         apiVersion: v1
@@ -83,10 +83,10 @@
           name: kube-burner-config-{{ trunc_uuid }}
           namespace: "{{ operator_namespace }}"
         data:
-          config.yml: "{{ lookup('template', 'node-density.yml.j2')}}"
+          config.yml: "{{ lookup('template', 'node-pod-density.yml.j2')}}"
           metrics.yaml: "{{ lookup('file', workload_args.metrics_profile|default('metrics.yaml')) }}"
           pod.yml: "{{ lookup('file', 'pod.yml')}}"
-    when: workload_args.workload == "node-density"
+    when: workload_args.workload == "node-density" or workload_args.workload == "pod-density"
 
   - name: Create node-density-heavy configmaps
     k8s:

--- a/roles/kube-burner/templates/node-pod-density.yml.j2
+++ b/roles/kube-burner/templates/node-pod-density.yml.j2
@@ -14,12 +14,12 @@ global:
 {% endif %}
 
 jobs:
-  - name: node-density
+  - name: {{ workload_args.workload }}
     jobIterations: {{ workload_args.job_iterations }}
     qps: {{ workload_args.qps|default(5) }}
     burst: {{ workload_args.burst|default(10) }}
     namespacedIterations: false
-    namespace: node-density-{{ uuid }}
+    namespace: {{workload_args.workload}}-{{ uuid }}
     podWait: {{ workload_args.pod_wait|default(false) }}
     cleanup: {{ workload_args.cleanup|default(true) }}
     waitWhenFinished: {{ workload_args.wait_when_finished|default(true) }}


### PR DESCRIPTION
This scenarios is useful when you only care about creating a  lot of
pods in a namespace and don't care about distribution across worker nodes.
This is similar to what used to be called pod-vertical.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>