### PR TITLE
ES env var

### DIFF
--- a/roles/kube-burner/templates/kube-burner.yml.j2
+++ b/roles/kube-burner/templates/kube-burner.yml.j2
@@ -30,6 +30,9 @@ spec:
       - name: kube-burner
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/kube-burner:latest') }}
         imagePullPolicy: Always
+        env:
+        - name: prom_es
+          value: "{{ prometheus.es_url }}"
         workingDir: /tmp/kube-burner
         command: ["/bin/sh", "-c"]
         args:


### PR DESCRIPTION
Inject ES as env var. With this commit done in kube-burner https://github.com/cloud-bulldozer/kube-burner/pull/67, we can use environment variables to define the configuration. Adding prom_es  as envvar will allow us to overwrite the ElasticSearch endpoint in jobs using a remote configuration file, hence we can avoid setting ES secrets in the remote configuration file, as they can be configured with this mechanism

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>
