### PR TITLE
BYOWL: Suppot for any options under spec and container

### DIFF
--- a/docs/byowl.md
+++ b/docs/byowl.md
@@ -44,3 +44,11 @@ spec:
 
 This will launch the uperf container, and simply print the messages
 above into the log of the container.
+
+### A generic support:
+You can add any section under `specoptions` and `containeroptions` in `byowl` CRD, which will go under POD's `spec` and `containers` respectively as below:
+
+
+![BYOWL_DOC](https://user-images.githubusercontent.com/4022122/112431010-f31de200-8d64-11eb-9179-e6ae7eb0e2cd.png)
+
+

--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -14,12 +14,22 @@ spec:
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}
+{% if workload_args.specoptions is defined %}
+{% for label, value in  workload_args.specoptions.items() %}
+      {{ label }}: {{ value | to_json }}
+{% endfor %}
+{% endif %}
       containers:
       - name: byowl
         command: ["/bin/sh", "-c"]
         args: ["{{ workload_args.commands }}"]
         image: "{{ workload_args.image }}"
         imagePullPolicy: Always
+{% if workload_args.containeroptions is defined %}
+{% for label, value in  workload_args.containeroptions.items() %}
+        {{ label }}: {{ value | to_json }}
+{% endfor %}
+{% endif %}
       restartPolicy: OnFailure
 {% if workload_args.nodeselector is defined %}
       nodeSelector: 


### PR DESCRIPTION
# Description
Currently BYOWL does not allow to run POD in privileged mode, hostPath access, mountPath, etc properties.

Can add support for these and all possible properties in BYOWL, so that we can use BYOWL for any workload which can run in privileged mode and should have access to hostPath etc.

Currently I have hard coded these option in the roles/byowl/templates/workload.yml and building the benchmark-operator myself.

If we add all possible properties support in BYOWL, individual do not need to build the benchmark-operator themselves.


This PR for issue #533

This generic changes does not work for all the options. May be I am missing something.
Detailed discussion: https://github.com/cloud-bulldozer/benchmark-operator/issues/533#issuecomment-799143133
