### PR TITLE
Add log generator workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ helm delete benchmark-operator -n my-ripsaw --purge
 | [oslat](docs/oslat.md)         | Real-Time Latency      | Yes           |  Used, default : 3second   | Not Supported          | Preview         | No |
 | [testpmd](docs/testpmd.md)         | TestPMD DPDK App      | No           |  Used   | Not Supported          | Preview         | No |
 | [Flent](docs/flent.md)         | Network Performance    | Yes           |  Used, default : 3second  | Not Supported          | Not Supported   | Yes |
+| [Log-Generator](docs/log_generator.md)         | Log Throughput to Backend    | Yes           |  Used, default : 3second  | Not Supported          | Yes  | Yes |
 
 ### Reconciliation
 

--- a/docs/log_generator.md
+++ b/docs/log_generator.md
@@ -1,0 +1,106 @@
+# Log Generator
+
+## What does it do?
+
+The Log Generator writes messages of a set size and at a set rate to stdout. If provided
+it will also verify that all messages were recieved by the backend log aggregator.
+This data will also be indexed if Elasticsearch information is provided.
+
+*NOTE* This workload will not deploy the backend log aggregator
+
+## Variables
+
+### Required variables:
+
+`size` the size, in bytes, of the message to send
+
+`duration` how long, in minutes, messages should be sent for
+
+`messages_per_second` the number of messages per second (mutually exclusive with messages_per_minute)
+
+`messages_per_minute` the number of messages per minute (mutually exclusive with messages_per_second)
+
+### Optional variables:
+
+`pod-count` total number of log generator pods to launch (default: 1)
+
+`timeout` how long, in seconds, after have been sent to allow the backend service to receive all the messages (default: 600)
+
+### Verification variables:
+
+To verify your messages have been received by the backend aggregator you must provide information for ONLY ONE of the supported
+backends: Elasticsearch or AWS CloudWatch
+
+Elasticsearch Backend:
+
+`es_url` the elasticsearch url to query for results.
+
+`es_index` the index to search for the sent messages (default: app*)
+
+`es_token` the bearer token to use to access elasticsearch if required
+
+AWS CloudWatch:
+
+`cloudwatch-log-group` the aws cloudwatch log group to query
+
+`aws_region` the region that cloudwatch is deployed to
+
+`aws_access_key` the access key to use to query cloudwatch
+
+`aws_secret_key` the secret key to use to query cloudwatch
+
+Your resource file may look like this when using an Elasticsearch Backend:
+
+```yaml
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: log-generator
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    url: "http://es-instance.com:9200"
+    index_name: log-generator
+  workload:
+    name: log_generator
+    args:
+      pod_count: 2
+      size: 512
+      messages_per_second: 10
+      duration: 1
+      es_url: "https://my-es-backend.com"
+      es_token: "sha256~myToken"
+      timeout: 600
+      label:
+        key: foo
+        value: "
+```
+
+Your resource file may look like this when using an AWS CloudWatch Backend:
+
+```yaml
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: log-generator
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    url: "http://es-instance.com:9200"
+    index_name: log-generator
+  workload:
+    name: log_generator
+    args:
+      pod_count: 10
+      size: 1024
+      messages_per_second: 100
+      duration: 10
+      cloudwatch_log_group: "my_log_group"
+      aws_region: "us-west-2"
+      aws_access_key: "myKey"
+      aws_secret_token: "myToken"
+      timeout: 800
+      label:
+        key: bar
+        value: "
+```

--- a/resources/crds/ripsaw_v1alpha1_log_generator_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_log_generator_cr.yaml
@@ -1,0 +1,38 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: log-generator
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    # Elastic search instance with full URL format. https://elastic.apps.org:9200
+    url: http://my.elasticsearch.server:80
+    index_name: log-generator
+  prometheus:
+    # Elastic search instance with full URL format. https://elastic.apps.org:9200
+    es_url: http://my.elasticsearch.server:80
+    # Prometheus bearer token
+    prom_token: PROMETHEUS_BEARER_TOKEN
+    # Prometheus URL with full URL format. https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+  workload:
+    name: log_generator
+    args:
+      # Number of log generator pods to launch
+      pod_count: 1
+      # size of message in bytes
+      size: 512
+      # number of messages per second to send
+      messages_per_second: 10
+      # duration of time to send messages in minutes
+      duration: 1
+      # url of the backend elasticsearch to be used for verification
+      es_url: "https://my_es_server"
+      # bearer token to use to access the backend elasticsearch
+      es_token: "sha256~myToken"
+      # amount of time after sending all the messages to wait for the backend to receive them all
+      timeout: 600
+      # Label of host to target
+      label:
+        key: foo
+        value: ""

--- a/roles/log_generator/tasks/main.yml
+++ b/roles/log_generator/tasks/main.yml
@@ -1,0 +1,89 @@
+---
+- name: Get benchmark state
+  k8s_facts:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+  register: benchmark_state
+
+- operator_sdk.util.k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      state: "Starting Log Generator Pods"
+      complete: false
+  when: benchmark_state.resources[0].status.state is not defined
+
+- name: Get benchmark state 
+  k8s_facts:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+  register: benchmark_state
+
+- block:
+  
+  - name: Create log generator pods
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'log_generator.yml') }}"
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Building Pods"
+
+  when: benchmark_state.resources[0].status.state == "Starting Log Generator Pods"
+
+- block:
+
+  - name: Get server pods
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - app = log-generator-{{ trunc_uuid }}
+    register: log_pods
+
+  - name: Update resource state
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Log Generator Running"
+    when: "workload_args.pod_count|default('1')|int == log_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
+  
+  when: benchmark_state.resources[0].status.state == "Building Pods"
+
+- block:
+
+  - name: Get server pods
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - app = log-generator-{{ trunc_uuid }}
+    register: log_pods
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Complete
+        complete: true
+    when: "workload_args.pod_count|default('1')|int == (log_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
+
+  when: benchmark_state.resources[0].status.state == "Log Generator Running"

--- a/roles/log_generator/templates/log_generator.yml
+++ b/roles/log_generator/templates/log_generator.yml
@@ -1,0 +1,115 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: 'log-generator-{{ trunc_uuid }}'
+  namespace: '{{ operator_namespace }}'
+spec:
+  parallelism: {{ workload_args.pod_count | default(1) | int }}
+  template:
+    metadata:
+      labels:
+        app: log-generator-{{ trunc_uuid }}
+    spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
+{% if workload_args.tolerations is defined %}
+      tolerations:
+      - key: {{ workload_args.tolerations.key }}
+        value: {{ workload_args.tolerations.value }}
+        effect: {{ workload_args.tolerations.effect }}
+{% endif %}
+{% if workload_args.label is defined %}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ workload_args.label.key }}
+                operator: In
+                values:
+                - {{ workload_args.label.value }}
+{% endif %}
+      containers:
+      - image: {{ workload_args.image | default('quay.io/cloud-bulldozer/log_generator:latest') }}
+        name: log-generator
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: uuid
+            value: "{{ uuid }}"
+          - name: test_user
+            value: "{{ test_user | default("ripsaw") }}"
+          - name: clustername
+            value: "{{ clustername }}"
+{% if elasticsearch is defined %}
+          - name: es
+            value: "{{ elasticsearch.url }}"
+          - name: es_index
+            value: "{{ elasticsearch.index_name | default("log-generator") }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
+          - name: parallel
+            value: "{{ elasticsearch.parallel | default(false) }}"
+{% endif %}
+{% if prometheus is defined %}
+          - name: prom_es
+            value: "{{ prometheus.es_url }}"
+          - name: prom_parallel
+            value: "{{ prometheus.es_parallel | default(false) }}"
+          - name: prom_token
+            value: "{{ prometheus.prom_token | default() }}"
+          - name: prom_url
+            value: "{{ prometheus.prom_url | default() }}"
+{% endif %}
+        command: ["/bin/sh", "-c"]
+        args:
+          - > 
+{% if workload_args.pod_count | default(1) | int > 1 %}
+            echo "Waiting for all pods to be Ready";
+            redis-cli -h {{ bo.resources[0].status.podIP }} INCR "log-generator-{{ trunc_uuid }}" > /dev/null 2>&1;
+            pods=`redis-cli -h {{ bo.resources[0].status.podIP }} GET "log-generator-{{ trunc_uuid }}"`;
+            while [[ $pods != {{ workload_args.pod_count | int }} ]]; do
+              pods=`redis-cli -h {{ bo.resources[0].status.podIP }} GET "log-generator-{{ trunc_uuid }}"`;
+              sleep 1;
+            done;
+{% endif %}
+            run_snafu
+            --tool log_generator
+{% if workload_args.debug is defined and workload_args.debug %}
+            -v
+{% endif %}
+            -u "{{ uuid }}"
+            --size "{{ workload_args.size | default(512) }}"
+{% if workload_args.messages_per_second is defined %}
+            --messages-per-second "{{ workload_args.messages_per_second }}"
+{% endif %}
+{% if workload_args.messages_per_minute is defined %}
+            --messages-per-minue "{{ workload_args.messages_per_minute }}"
+{% endif %}
+            --duration "{{ workload_args.duration | default(10) }}"
+{% if workload_args.es_url is defined %}
+            --es-url "{{ workload_args.es_url }}"
+{% endif %}
+{% if workload_args.es_token is defined %}
+            --es-token "{{ workload_args.es_token }}"
+{% endif %}
+{% if workload_args.cloudwatch_log_group is defined %}
+            --cloudwatch-log-group "{{ workload_args.cloudwatch_log_group }}"
+            --aws-region "{{ workload_args.aws_region }}"
+            --aws-access-key "{{ workload_args.aws_access_key }}"
+            --aws-secret-key "{{ workload_args.aws_secret_key }}"
+{% endif %}
+            --pod-name ${my_pod_name}
+            --timeout "{{ workload_args.timeout | default(600) }}"
+            --pod-count {{ workload_args.pod_count | default(1) | int }}
+      imagePullPolicy: Always
+      restartPolicy: Never
+{% include "metadata.yml.j2" %}

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -28,6 +28,7 @@ function populate_test_list {
     if [[ $(echo ${item} | grep 'roles/scale_openshift') ]]; then echo "test_scale_openshift.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'roles/kube-burner') ]]; then echo "test_kubeburner.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'roles/flent') ]]; then echo "test_flent.sh" >> tests/iterate_tests; fi
+    if [[ $(echo ${item} | grep 'roles/log_generator') ]]; then echo "test_log_generator.sh" >> tests/iterate_tests; fi
 
 
     # Check for changes in cr files
@@ -47,6 +48,7 @@ function populate_test_list {
     if [[ $(echo ${item} | grep 'valid_scale*') ]]; then echo "test_scale_openshift.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'valid_kube-burner*') ]]; then echo "test_kubeburner.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'valid_flent*') ]]; then echo "test_flent.sh" >> tests/iterate_tests; fi
+    if [[ $(echo ${item} | grep 'valid_log_generator*') ]]; then echo "test_log_generator.sh" >> tests/iterate_tests; fi
 
 
     # Check for changes in test scripts

--- a/tests/test_crs/valid_log_generator.yaml
+++ b/tests/test_crs/valid_log_generator.yaml
@@ -1,0 +1,18 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: log-generator
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    url: ES_SERVER
+    index_name: log-generator
+  workload:
+    name: log_generator
+    args:
+      pod_count: 1
+      size: 512
+      messages_per_second: 1
+      duration: 1
+      es_url: ES_SERVER
+      timeout: 600

--- a/tests/test_list
+++ b/tests/test_list
@@ -14,3 +14,4 @@ test_scale_openshift.sh
 test_stressng.sh
 test_kubeburner.sh
 test_flent.sh
+test_log_generator.sh

--- a/tests/test_log_generator.sh
+++ b/tests/test_log_generator.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -xeEo pipefail
+
+source tests/common.sh
+
+function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
+  echo "Cleaning up Log Generator Test"
+  wait_clean
+}
+
+trap error ERR
+trap finish EXIT
+
+function functional_test_log_generator {
+  wait_clean
+  apply_operator
+  test_name=$1
+  cr=$2
+  
+  echo "Performing: ${test_name}"
+  kubectl apply -f ${cr}
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
+
+  log_gen_pod=$(get_pod "app=log-generator-$uuid" 300)
+  wait_for "kubectl -n my-ripsaw wait --for=condition=Initialized -l app=log-generator-$uuid pods --timeout=300s" "300s" $log_gen_pod
+  wait_for "kubectl wait -n my-ripsaw --for=condition=complete -l app=log-generator-$uuid jobs --timeout=300s" "300s" $log_gen_pod
+
+  index="log-generator-results"
+  if check_es "${long_uuid}" "${index}"
+  then
+    echo "${test_name} test: Success"
+  else
+    echo "Failed to find data for ${test_name} in ES"
+    kubectl logs "$log_gen_pod" -n my-ripsaw
+    exit 1
+  fi
+  kubectl delete -f ${cr}
+}
+
+figlet $(basename $0)
+functional_test_log_generator "Log Generator" tests/test_crs/valid_log_generator.yaml


### PR DESCRIPTION
# Description
Adding a log generator workload that will generate X messages of Y size (in bytes) per second/minute over a duration of Z minutes. If provided it will also check the backed log aggregator to confirm it received the expected number of messages. Supported backends are elasticsearch and AWS cloudwatch.

NOTE: This requires a backend storage to be deployed if we want to create a valid ci test for this.

benchmark-wrapper PR: https://github.com/cloud-bulldozer/benchmark-wrapper/pull/254 must be merged prior to this.