### PR TITLE
Adding debug workload option for snafu related jobs and enabling it for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,32 @@ spec:
       image: my.location/foo:latest
 ```
 
+## Optional debug out for benchmark-wrapper workloads
+Workloads that are triggered through [benchmark-wrapper](https://github.com/cloud-bulldozer/benchmark-wrapper)
+can optionally pass the debug flag through the workload CR.
+
+NOTE: This is not a required arguement. If omitted it will default to the default logging level of 
+the benchmark-wrapper
+
+For Example:
+
+```
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: example-benchmark
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    url: "http://my-es.foo.bar:80"
+  metadata_collection: true
+  cleanup: false
+  workload:
+    name: snafu_workload
+    args:
+      debug: true
+```
+
 ## User Provided UUID
 All benchmarks in the benchmark-operator utilize a UUID for tracking and indexing purposes. This UUID is,
 by default, generated when the workload is first started. However, if desired, a user provided UUID can

--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -17,7 +17,12 @@ spec:
       - name: cyclictest
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/cyclictest:latest') }}
         command: ["/bin/sh", "-c"]
-        args: ["run_snafu --tool cyclictest -p /tmp/cyclictest.sh -u {{ uuid }} --user {{test_user | default("ripsaw")}}"]
+        args: 
+          - run_snafu --tool cyclictest -p /tmp/cyclictest.sh -u {{ uuid }} --user {{test_user | default("ripsaw")}} \
+{% if workload_args.debug is defined and workload_args.debug %}
+            -v \
+{% endif %}
+            ;
         imagePullPolicy: Always
 {% if workload_args.nodeselector is defined %}
       nodeSelector:

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -72,7 +72,12 @@ spec:
 {% for numjobs in workload_args.numjobs %}
 {% for i in loopvar %}
 {% for job in workload_args.jobs %}
-             cat /tmp/fio/fiojob-{{job}}-{{i}}-{{numjobs}}; mkdir -p /tmp/fiod-{{uuid}}/fiojob-{{job}}-{{i}}-{{numjobs}}; run_snafu -t fio -H /tmp/host/hosts -j /tmp/fio/fiojob-{{job}}-{{i}}-{{numjobs}} -s {{workload_args.samples}} -d /tmp/fiod-{{ uuid }}/fiojob-{{job}}-{{i}}-{{numjobs}};
+             cat /tmp/fio/fiojob-{{job}}-{{i}}-{{numjobs}}; mkdir -p /tmp/fiod-{{uuid}}/fiojob-{{job}}-{{i}}-{{numjobs}};
+             run_snafu -t fio -H /tmp/host/hosts -j /tmp/fio/fiojob-{{job}}-{{i}}-{{numjobs}} -s {{workload_args.samples}} -d /tmp/fiod-{{ uuid }}/fiojob-{{job}}-{{i}}-{{numjobs}} \
+{% if workload_args.debug is defined and workload_args.debug %}
+             -v \
+{% endif %}
+             ;
 {% if workload_args.fio_json_to_log is defined and workload_args.fio_json_to_log is sameas true %}
              for fio_sample in $(seq 1 {{workload_args.samples}});
              do echo START_FIO_JSON_OUTPUT_fiod-{{uuid}}_fiojob-{{job}}-{{i}}-{{numjobs}}_SAMPLE_$fio_sample;

--- a/roles/flent/templates/workload.yml.j2
+++ b/roles/flent/templates/workload.yml.j2
@@ -69,7 +69,11 @@ spec:
              while true; do
                if [[ $(redis-cli -h {{bo.resources[0].status.podIP}} get start) =~ 'true' ]]; then
 {% for test in workload_args.test_types %}
-                 run_snafu --tool flent --ftest {{test}} -u {{ uuid }} -r $h --user {{test_user | default("ripsaw")}};
+                 run_snafu --tool flent --ftest {{test}} -u {{ uuid }} -r $h --user {{test_user | default("ripsaw")}} \
+{% if workload_args.debug is defined and workload_args.debug %}
+                 -v \
+{% endif %}
+                 ;
 {% endfor %}
                else
                  continue;

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -78,12 +78,15 @@ spec:
               cat /tmp/fs-drift/params;
               run_snafu
               --tool fs-drift
+{% if workload_args.debug is defined and workload_args.debug %}
+              -v
+{% endif %}
               --top {{fs_drift_path}}/fs_drift_test_data
               --dir ${TMPDIR}/RESULTS
 {% if workload_args.samples is defined %}
               --samples {{workload_args.samples}}
 {% endif %}
-              --yaml-input-file /tmp/fs-drift/params ;
+              --yaml-input-file /tmp/fs-drift/params;
               if [ $? = 0 ] ; then echo RUN STATUS DONE ; else echo FAIL ; exit 1 ; fi
           volumeMounts:
             - name: config-volume

--- a/roles/hammerdb/templates/db_mssql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mssql_workload.yml.j2
@@ -77,7 +77,11 @@ spec:
              export db_mssql_durability={{workload_args.db_mssql_durability}};
              export db_mssql_checkpoint={{workload_args.db_mssql_checkpoint}};
              cd /hammer;
-             run_snafu --tool hammerdb -u {{ uuid }}"
+             run_snafu --tool hammerdb -u {{ uuid }} \
+{% if workload_args.debug is defined and workload_args.debug %}
+             -v \
+{% endif %}
+             ;"
         volumeMounts:
         - name: hammerdb-workload-volume
           mountPath: "/workload"

--- a/roles/hammerdb/templates/db_mysql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mysql_workload.yml.j2
@@ -71,7 +71,11 @@ spec:
              export db_mysql_storage_engine={{workload_args.db_mysql_storage_engine}};
              export db_mysql_partition={{workload_args.db_mysql_partition}};
              cd /hammer; 
-             run_snafu --tool hammerdb -u {{ uuid }}"
+             run_snafu --tool hammerdb -u {{ uuid }}
+{% if workload_args.debug is defined and workload_args.debug %}
+             -v \
+{% endif %}
+             ;"
         volumeMounts:
         - name: hammerdb-workload-volume
           mountPath: "/workload"

--- a/roles/hammerdb/templates/db_postgres_workload.yml.j2
+++ b/roles/hammerdb/templates/db_postgres_workload.yml.j2
@@ -75,7 +75,11 @@ spec:
              export db_postgresql_oracompat={{workload_args.db_postgresql_oracompat}};
              export db_postgresql_storedprocs={{workload_args.db_postgresql_storedprocs}};
              cd /hammer; 
-             run_snafu --tool hammerdb -u {{ uuid }}"
+             run_snafu --tool hammerdb -u {{ uuid }} \
+{% if workload_args.debug is defined and workload_args.debug %}
+             -v \
+{% endif %}
+             ;"
         volumeMounts:
         - name: hammerdb-workload-volume
           mountPath: "/workload"

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -17,7 +17,12 @@ spec:
       - name: oslat
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/oslat:latest') }}
         command: ["/bin/sh", "-c"]
-        args: ["run_snafu --tool oslat -p /tmp/oslat.sh -u {{ uuid }} --user {{test_user | default("ripsaw")}}"]
+        args: 
+          - run_snafu --tool oslat -p /tmp/oslat.sh -u {{ uuid }} --user {{test_user | default("ripsaw")}} \
+{% if workload_args.debug is defined and workload_args.debug %}
+            -v \
+{% endif %}
+            ;
         imagePullPolicy: Always
 {% if workload_args.nodeselector is defined %}
       nodeSelector:

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -73,7 +73,11 @@ spec:
                      export sample_start_timestamp=$(date +%s.%3N);
                      echo \"Begin test sample $i of {{ workload_args.samples }}...\";
                      export pgbench_opts=\"$pgbench_auth -c {{ clients }} -j {{ workload_args.threads }} {% if workload_args.transactions is defined and workload_args.transactions|int > 0 %} -t {{ workload_args.transactions }} {% elif run_time|int > 0 %} -T {{ run_time }} {% endif %} -s {{ workload_args.scaling_factor }} {{ cmd_flags }} {{ item.1.db_name }}\";
-                     run_snafu --tool pgbench -r $i;
+                     run_snafu --tool pgbench -r $i \
+{% if workload_args.debug is defined and workload_args.debug %}
+                     -v \
+{% endif %}
+                     ;
                    done;
                  {% endfor %}
                  else

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -64,7 +64,11 @@ spec:
 {% endif %}
         command: ["/bin/sh", "-c"]
         args:
-          - "run_snafu --tool scale --scale {{workload_args.scale}} -u {{uuid}} --user {{test_user|default("ripsaw")}} --incluster true --poll_interval {{workload_args.poll_interval|default(5)}};
+          - "run_snafu --tool scale --scale {{workload_args.scale}} -u {{uuid}} --user {{test_user|default("ripsaw")}} --incluster true --poll_interval {{workload_args.poll_interval|default(5)}} \
+{% if workload_args.debug is defined and workload_args.debug %}
+            -v \
+{% endif %}
+            ;
             sleep {{post_sleep|default(0)}}"
       serviceAccountName: {{workload_args.serviceaccount|default("default")}}
       restartPolicy: Never

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -92,7 +92,11 @@ spec:
               --operations $arr 
               --top {{smallfile_path}}/smallfile_test_data 
               --dir /var/tmp/RESULTS 
-              --yaml-input-file /tmp/smallfile/smallfilejob ;
+              --yaml-input-file /tmp/smallfile/smallfilejob 
+{% if workload_args.debug is defined and workload_args.debug %}
+              -v
+{% endif %}
+              ;
               if [ $? = 0 ] ; then echo RUN STATUS DONE ; else exit 1 ; fi
           volumeMounts:
             - name: config-volume

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -74,7 +74,12 @@ spec:
             value: "{{ prometheus.prom_url | default() }}"
 {% endif %}
         command: ["/bin/sh", "-c"]
-        args: ["run_snafu --tool stressng -j /workload/jobfile -u {{ uuid }}"]
+        args: 
+          - run_snafu --tool stressng -j /workload/jobfile -u {{ uuid }}
+{% if workload_args.debug is defined and workload_args.debug %}
+            -v
+{% endif %}
+            ;
         volumeMounts:
         - name: stressng-workload-volume
           mountPath: "/workload"

--- a/roles/stressng/templates/stressng_workload_vm.yml.j2
+++ b/roles/stressng/templates/stressng_workload_vm.yml.j2
@@ -66,7 +66,11 @@ spec:
 {% endif %}
           - dnf install -y stress-ng redis git
           - pip3 install git+https://github.com/cloud-bulldozer/benchmark-wrapper
-          - run_snafu --tool stressng -j /tmp/stressng-test/jobfile -u {{ uuid }}
+          - run_snafu --tool stressng -j /tmp/stressng-test/jobfile -u {{ uuid }} \
+{% if workload_args.debug is defined and workload_args.debug %}
+            -v \
+{% endif %}
+            ;
     name: cloudinitdisk
   - configMap:
       name: "{{ meta.name }}-workload-{{ trunc_uuid }}"

--- a/roles/testpmd/templates/trex.yml.j2
+++ b/roles/testpmd/templates/trex.yml.j2
@@ -47,10 +47,13 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: trex
-        command: ["/bin/sh"]
+        command: ["/bin/sh", "-c"]
         args:
-        - "-c"
-        - "run_snafu --tool trex --uuid {{ trunc_uuid }} --user {{ test_user | default('snafu') }}"
+        - run_snafu --tool trex --uuid {{ trunc_uuid }} --user {{ test_user | default('snafu') }} \
+{% if workload_args.debug is defined and workload_args.debug %}
+          -v \
+{% endif %}
+          ;
         image: "{{ workload_args.image_trex | default('quay.io/cloud-bulldozer/trex:latest') }}"
         imagePullPolicy: "{{ workload_args.image_pull_policy | default('Always') }}"
         securityContext:

--- a/roles/uperf/templates/configmap_script.yml.j2
+++ b/roles/uperf/templates/configmap_script.yml.j2
@@ -42,7 +42,11 @@ data:
 {% endif %}
 {% for nthr in workload_args.nthrs %}
         cat /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}};
-        run_snafu --tool uperf -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}} -s {{workload_args.samples}} --resourcetype {{resource_kind}} -u {{ uuid }} --user {{test_user | default("ripsaw")}};
+        run_snafu --tool uperf -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}} -s {{workload_args.samples}} --resourcetype {{resource_kind}} -u {{ uuid }} --user {{test_user | default("ripsaw")}} \
+{% if workload_args.debug is defined and workload_args.debug %}
+        -v \
+{% endif %}
+        ;
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -112,11 +112,14 @@ spec:
 {% endif %}
 {% for nthr in workload_args.nthrs %}
                  cat /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}};
+                 run_snafu --tool uperf -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}} -s {{workload_args.samples}} --resourcetype {{resource_kind}} -u {{ uuid }} --user {{test_user | default("ripsaw")}} \
 {% if workload_args.run_id is defined %}
-                 run_snafu --tool uperf --run-id {{workload_args.run_id}} -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}} -s {{workload_args.samples}} --resourcetype {{resource_kind}} -u {{ uuid }} --user {{test_user | default("ripsaw")}};
-{% else %}
-                 run_snafu --tool uperf -w /tmp/uperf-test/uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}} -s {{workload_args.samples}} --resourcetype {{resource_kind}} -u {{ uuid }} --user {{test_user | default("ripsaw")}};
+                 --run-id {{workload_args.run_id}} \
 {% endif %}
+{% if workload_args.debug is defined and workload_args.debug %}
+                 -v \
+{% endif %}
+                 ;
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -75,7 +75,11 @@ spec:
             done
             sleep 0.1
             redis-cli -h {{ bo.resources[0].status.podIP }} set vegeta-{{ item }}-{{ trunc_uuid }} notready
-            run_snafu --tool vegeta --targets /tmp/vegeta/{{ t.name|replace(" ","") }} -u ${uuid} -d {{ t.duration }} --user ${test_user} -w {{ t.workers|default(1) }} -s {{ t.samples|default(1) }} {{ "--keepalive" if t.keepalive|default(false) }}
+            run_snafu --tool vegeta --targets /tmp/vegeta/{{ t.name|replace(" ","") }} -u ${uuid} -d {{ t.duration }} --user ${test_user} -w {{ t.workers|default(1) }} -s {{ t.samples|default(1) }} {{ "--keepalive" if t.keepalive|default(false) }} \
+{% if workload_args.debug is defined and workload_args.debug %}
+            -v \
+{% endif %}
+            ;
 {% endfor %}
         volumeMounts:
           - name: targets-volume

--- a/roles/ycsb/templates/ycsb_load.yaml
+++ b/roles/ycsb/templates/ycsb_load.yaml
@@ -54,7 +54,12 @@ spec:
 {% endif %}
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ['run_snafu --tool ycsb -r 1 -l -d {{ workload_args.driver }} -u {{ uuid }} --user {{ test_user | default("ripsaw") }} -w {{ ycsb_workload_load }} -x "{{ workload_args.options_load }}"']
+        args: 
+          - run_snafu --tool ycsb
+{% if workload_args.debug is defined and workload_args.debug %}
+            -v
+{% endif %}
+            -r 1 -l -d {{ workload_args.driver }} -u {{ uuid }} --user {{ test_user | default("ripsaw") }} -w {{ ycsb_workload_load }} -x "{{ workload_args.options_load }}";
         volumeMounts:
           - name: config-volume
             mountPath: "/tmp/ycsb"

--- a/roles/ycsb/templates/ycsb_run.yaml
+++ b/roles/ycsb/templates/ycsb_run.yaml
@@ -54,7 +54,12 @@ spec:
 {% endif %}
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
-        args: ['run_snafu --tool ycsb -r 1 -d {{ workload_args.driver }} -w {{ ycsb_workload }} -u {{ uuid }} --user {{ test_user | default("ripsaw") }} -x "{{ workload_args.options_run }}"']
+        args: 
+          - run_snafu --tool ycsb
+{% if workload_args.debug is defined and workload_args.debug %}
+            -v
+{% endif %}
+            -r 1 -d {{ workload_args.driver }} -w {{ ycsb_workload }} -u {{ uuid }} --user {{ test_user | default("ripsaw") }} -x "{{ workload_args.options_run }}";
         volumeMounts:
           - name: config-volume
             mountPath: "/tmp/ycsb"

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -33,6 +33,7 @@ spec:
       filesize: 10MiB
       log_sample_rate: 2000
       storagesize: 16Mi
+      debug: true
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #
 #######################################

--- a/tests/test_crs/valid_fiod_bsrange.yaml
+++ b/tests/test_crs/valid_fiod_bsrange.yaml
@@ -33,6 +33,7 @@ spec:
       filesize: 10MiB
       log_sample_rate: 2000
       storagesize: 16Mi
+      debug: true
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #
 #######################################

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -36,6 +36,7 @@ spec:
       write_ramp_time: 1
       filesize: 10MiB
       log_sample_rate: 2000
+      debug: true
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #
 #######################################

--- a/tests/test_crs/valid_flent.yaml
+++ b/tests/test_crs/valid_flent.yaml
@@ -22,3 +22,4 @@ spec:
       test_types:
         - tcp_download
       runtime: 2
+      debug: true

--- a/tests/test_crs/valid_flent_resources.yaml
+++ b/tests/test_crs/valid_flent_resources.yaml
@@ -30,3 +30,4 @@ spec:
       test_types:
         - tcp_download
       runtime: 2
+      debug: true

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -21,3 +21,4 @@ spec:
       max_file_size_kb: 4
       max_files: 1000
       duration: 15
+      debug: true

--- a/tests/test_crs/valid_fs_drift_hostpath.yaml
+++ b/tests/test_crs/valid_fs_drift_hostpath.yaml
@@ -22,3 +22,4 @@ spec:
       max_file_size_kb: 4
       max_files: 1000
       duration: 15
+      debug: true

--- a/tests/test_crs/valid_hammerdb.yaml
+++ b/tests/test_crs/valid_hammerdb.yaml
@@ -61,3 +61,4 @@ spec:
       db_postgresql_dritasnap: "false"
       db_postgresql_oracompat: "false"
       db_postgresql_storedprocs: "false"
+      debug: true

--- a/tests/test_crs/valid_pgbench.yaml
+++ b/tests/test_crs/valid_pgbench.yaml
@@ -28,3 +28,4 @@ spec:
           user: ci
           password: ci
           db_name: cidb
+      debug: true

--- a/tests/test_crs/valid_scale_down.yaml
+++ b/tests/test_crs/valid_scale_down.yaml
@@ -13,4 +13,4 @@ spec:
       scale: 0
       serviceaccount: scaler
       poll_interval: 2
-
+      debug: true

--- a/tests/test_crs/valid_scale_up.yaml
+++ b/tests/test_crs/valid_scale_up.yaml
@@ -13,4 +13,4 @@ spec:
       scale: 1
       serviceaccount: scaler
       poll_interval: 2
-
+      debug: true

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -21,3 +21,4 @@ spec:
       threads: 1
       file_size: 0
       files: 100000
+      debug: true

--- a/tests/test_crs/valid_smallfile_hostpath.yaml
+++ b/tests/test_crs/valid_smallfile_hostpath.yaml
@@ -22,3 +22,4 @@ spec:
       threads: 1
       file_size: 0
       files: 100000
+      debug: true

--- a/tests/test_crs/valid_stressng.yaml
+++ b/tests/test_crs/valid_stressng.yaml
@@ -25,4 +25,4 @@ spec:
       vm_bytes: "128M"
       # mem stressor options
       mem_stressors: "1"
-
+      debug: true

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -36,3 +36,4 @@ spec:
         - 1
         - 2
       runtime: 2
+      debug: true

--- a/tests/test_crs/valid_uperf_networkpolicy.yaml
+++ b/tests/test_crs/valid_uperf_networkpolicy.yaml
@@ -37,3 +37,4 @@ spec:
         - 1
         - 2
       runtime: 2
+      debug: true

--- a/tests/test_crs/valid_uperf_resources.yaml
+++ b/tests/test_crs/valid_uperf_resources.yaml
@@ -43,3 +43,4 @@ spec:
         - 1
         - 2
       runtime: 2
+      debug: true

--- a/tests/test_crs/valid_uperf_serviceip.yaml
+++ b/tests/test_crs/valid_uperf_serviceip.yaml
@@ -35,3 +35,4 @@ spec:
         - 1
         - 2
       runtime: 2
+      debug: true

--- a/tests/test_crs/valid_vegeta.yaml
+++ b/tests/test_crs/valid_vegeta.yaml
@@ -28,3 +28,4 @@ spec:
             - GET https://1.1.1.1
           workers: 2
           duration: 5
+      debug: true

--- a/tests/test_crs/valid_vegeta_hostnetwork.yaml
+++ b/tests/test_crs/valid_vegeta_hostnetwork.yaml
@@ -24,3 +24,4 @@ spec:
           workers: 2
           duration: 5
           keepalive: true
+      debug: true

--- a/tests/test_crs/valid_ycsb-mongo.yaml
+++ b/tests/test_crs/valid_ycsb-mongo.yaml
@@ -21,3 +21,4 @@ spec:
         - workloada
       options_load: '-p mongodb.url="mongodb://mongo-0.mongo/ycsb?"' #passed as is to ycsb when loading database
       options_run: '-p mongodb.url="mongodb://mongo-0.mongo/ycsb?" -threads 10 -target 100'
+      debug: true


### PR DESCRIPTION
# Description
snafu allows passing the -v flag to enable debug logging. This PR allows the user to set workloads.debug to true if they want to pass the debug flag to snafu. This also enables it for all pertinent CI tests
