### PR TITLE
System-metrics collection

### DIFF
--- a/docs/system-metrics.md
+++ b/docs/system-metrics.md
@@ -2,16 +2,18 @@
 
 Benchmark-operator is able to collect prometheus metrics from the cluster at the end of a benchmark. To do so, it creates a k8s job that uses [kube-burner](https://github.com/cloud-bulldozer/kube-burner) to collect the Prometheus metrics given by a configuration file. This system metrics collection mechanism in available for all workloads except `kube-burner` and `backpack`.
 
-This feature is disabled by default, it can be enabled by adding the following lines to the prometheus section of the benchmark's CR.
+This feature is disabled by default, it can be enabled by adding a `system_metrics` section to a benchmark CR.
 
 ```yaml
-  prometheus:
-    system_metrics_collection: true (Defaults to false)
+  system_metrics:
+    collection: true (Defaults to false)
     prom_url: <Valid prometheus endpoint, by default https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091>
-    system_metrics_index: <ES index name, defaults to system-metrics>
+    index_name: <ES index name, defaults to system-metrics>
     es_url: <valid ES endpoint>
     prom_token: <valid prometheus token, in an OpenShift environment can be obtained with oc sa get-token -n openshift-monitoring prometheus-k8s>
     metrics_profile: <valid metric profile name or URL pointing to it, by default node-metrics.yml>
+    step: <Prometheus step size, by default 30s>
+    image: <Kube-burner image, by default quay.io/cloud-bulldozer/kube-burner:latest>
 ```
 
 As stated in the example above, `metrics_profile` points to node-metrics.yml, (this file is available within the system-metrics role of this repo), however it can be configured pointing to an external URL like in the example below:
@@ -23,11 +25,8 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
-    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
-    es_url: https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443
+  system_metrics:
+    enabled: true
     prom_token: eyJhbGciOiJSUzI1NiIsImtpZCI6IlljTUxlUHBTY2hvUVJQYUlZWmV5MTE4d3VnRFpjUUh5MWZtdE9hdnlvNFUifQ.eyJpc3MiOiJrdWJlcnopeVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJvcGVuc2hpZnQtbW9uaXRvcmluZyIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJwcm9tZXRoZXVzLWs4cy10b2tlbi12NGo3YyIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJwcm9tZXRoZXVzLWs4cyIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjFkYTdkMTRkLWE2MTktNDZjYS1iZGRlLTMzOTYxOWYxMmM4MiIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpvcGVuc2hpZnQtbW9uaXRvcmluZzpwcm9tZXRoZXVzLWs4cyJ9.PJp5pD_CjMG05vVLFdxUDRWGA8C71TNyRsUcHmpMlnZLQWBwxZSDZ-Uh3y6g1O-Yz3nopeCoZLB6lugxxalcT1DhiEC9yNK53Lr6HLqaz8nWUbRPbex0913KcuSsnpeRj7tzlwQ2K3WbtIeyyHpG5vAeff07LDvHUcPsc3B_dyetGnInClBHFVEJRES6f5DbIUidtXZEfYKANJNcssly0qZMZicwvM4a_pRp6ctGB-zzR6Ac4lh3b1JLfl_5TLGuuoYEOAeJPVUF4TjemsNNJ5BlycEkVI377LKNdHf83wua5pn3ItJtKE5gdrG833203p-y0pj-UDJj2bAv0cjUQ
     metrics_profile: https://raw.githubusercontent.com/cloud-bulldozer/benchmark-operator/master/roles/kube-burner/files/metrics-aggregated.yaml
   elasticsearch:

--- a/docs/system-metrics.md
+++ b/docs/system-metrics.md
@@ -11,7 +11,7 @@ This feature is disabled by default, it can be enabled by adding the following l
     system_metrics_index: <ES index name, defaults to system-metrics>
     es_url: <valid ES endpoint>
     prom_token: <valid prometheus token, in an OpenShift environment can be obtained with oc sa get-token -n openshift-monitoring prometheus-k8s>
-    metrics_profile: <valid metric profile name or URL of it, by default it node-metrics.yml>
+    metrics_profile: <valid metric profile name or URL pointing to it, by default node-metrics.yml>
 ```
 
 As stated in the example above, `metrics_profile` points to node-metrics.yml, (this file is available within the system-metrics role of this repo), however it can be configured pointing to an external URL like in the example below:

--- a/docs/system-metrics.md
+++ b/docs/system-metrics.md
@@ -1,0 +1,58 @@
+# System-metrics collection
+
+Benchmark-operator is able to collect prometheus metrics from the cluster at the end of a benchmark. To do so, it creates a k8s job that uses [kube-burner](https://github.com/cloud-bulldozer/kube-burner) to collect the Prometheus metrics given by a configuration file.
+
+This feature is disabled by default, it can be enabled by adding the following lines to the prometheus section of the benchmark's CR.
+
+```yaml
+  prometheus:
+    system_metrics_collection: true (Defaults to false)
+    prom_url: <Valid prometheus endpoint, by default https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091>
+    system_metrics_index: <ES index name, defaults to system-metrics>
+    es_url: <valid ES endpoint>
+    prom_token: <valid prometheus token, in an OpenShift environment can be obtained with oc sa get-token -n openshift-monitoring prometheus-k8s>
+    metrics_profile: <valid metric profile name or URL of it, by default it node-metrics.yml>
+```
+
+As stated in the example above, `metrics_profile` points to node-metrics.yml, (this file is available within the system-metrics role of this repo), however it can be configured pointing to an external URL like in the example below:
+
+```yaml
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: example-benchmark
+  namespace: my-ripsaw
+spec:
+  prometheus:
+	system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443
+    prom_token: eyJhbGciOiJSUzI1NiIsImtpZCI6IlljTUxlUHBTY2hvUVJQYUlZWmV5MTE4d3VnRFpjUUh5MWZtdE9hdnlvNFUifQ.eyJpc3MiOiJrdWJlcnopeVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJvcGVuc2hpZnQtbW9uaXRvcmluZyIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJwcm9tZXRoZXVzLWs4cy10b2tlbi12NGo3YyIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJwcm9tZXRoZXVzLWs4cyIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6IjFkYTdkMTRkLWE2MTktNDZjYS1iZGRlLTMzOTYxOWYxMmM4MiIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDpvcGVuc2hpZnQtbW9uaXRvcmluZzpwcm9tZXRoZXVzLWs4cyJ9.PJp5pD_CjMG05vVLFdxUDRWGA8C71TNyRsUcHmpMlnZLQWBwxZSDZ-Uh3y6g1O-Yz3nopeCoZLB6lugxxalcT1DhiEC9yNK53Lr6HLqaz8nWUbRPbex0913KcuSsnpeRj7tzlwQ2K3WbtIeyyHpG5vAeff07LDvHUcPsc3B_dyetGnInClBHFVEJRES6f5DbIUidtXZEfYKANJNcssly0qZMZicwvM4a_pRp6ctGB-zzR6Ac4lh3b1JLfl_5TLGuuoYEOAeJPVUF4TjemsNNJ5BlycEkVI377LKNdHf83wua5pn3ItJtKE5gdrG833203p-y0pj-UDJj2bAv0cjUQ
+    metrics_profile: https://raw.githubusercontent.com/cloud-bulldozer/benchmark-operator/master/roles/kube-burner/files/metrics-aggregated.yaml
+  elasticsearch:
+    url: https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443
+    index_name: ripsaw-uperf
+  metadata:
+    collection: false
+  cleanup: false
+  workload:
+    name: uperf
+    args:
+      hostnetwork: false
+      serviceip: false
+      pin: false
+      multus:
+        enabled: false
+      samples: 1
+      pair: 1
+      test_types:
+        - stream
+      protos:
+        - tcp
+      sizes:
+        - 1024
+      nthrs:
+        - 1
+      runtime: 120
+```

--- a/docs/system-metrics.md
+++ b/docs/system-metrics.md
@@ -24,7 +24,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   prometheus:
-	system_metrics_collection: true
+    system_metrics_collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     system_metrics_index: system-metrics
     es_url: https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443

--- a/docs/system-metrics.md
+++ b/docs/system-metrics.md
@@ -1,6 +1,6 @@
 # System-metrics collection
 
-Benchmark-operator is able to collect prometheus metrics from the cluster at the end of a benchmark. To do so, it creates a k8s job that uses [kube-burner](https://github.com/cloud-bulldozer/kube-burner) to collect the Prometheus metrics given by a configuration file.
+Benchmark-operator is able to collect prometheus metrics from the cluster at the end of a benchmark. To do so, it creates a k8s job that uses [kube-burner](https://github.com/cloud-bulldozer/kube-burner) to collect the Prometheus metrics given by a configuration file. This system metrics collection mechanism in available for all workloads except `kube-burner` and `backpack`.
 
 This feature is disabled by default, it can be enabled by adding the following lines to the prometheus section of the benchmark's CR.
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -102,8 +102,5 @@
     when:
     - cr_state.resources[0].status.state is defined
     - cr_state.resources[0].status.state == "Complete"
-    - cr_state.resources[0].status.system_metrics == "Not collected"
-    - prometheus is defined
-    - prometheus.system_metrics_collection | bool
-    - prometheus.prom_url is defined
+    - system_metrics.collection | bool
     - workload.name not in ["kube-burner", "backpack"]

--- a/playbook.yml
+++ b/playbook.yml
@@ -56,12 +56,13 @@
     
     when: workload is defined and (cr_state.resources[0].status is not defined or cr_state.resources[0].status.uuid is not defined)
 
+
+  - set_fact:
+      uuid: "{{ cr_state.resources[0].status.uuid }}"
+      trunc_uuid: "{{ cr_state.resources[0].status.suuid }}"
+
   - name: Run Workload
     block:
-
-    - set_fact:
-        uuid: "{{ cr_state.resources[0].status.uuid }}"
-        trunc_uuid: "{{ cr_state.resources[0].status.suuid }}"
     
     - block:
       
@@ -93,3 +94,16 @@
       when: metadata is not defined or not metadata.collection | default('false') | bool or (cr_state.resources[0].status.metadata is defined and cr_state.resources[0].status.metadata == "Complete") or metadata.targeted | default('true') | bool
     
     when: cr_state is defined and cr_state.resources[0].status is defined and not cr_state.resources[0].status.complete|bool and (cr_state.resources[0].status.state is not defined or cr_state.resources[0].status.state != "Error")
+
+  - include_role:
+      name: system-metrics
+    vars:
+      workload_args: "{{ workload.args }}"
+    when:
+    - cr_state.resources[0].status.state is defined
+    - cr_state.resources[0].status.state == "Complete"
+    - cr_state.resources[0].status.system_metrics == "Not collected"
+    - prometheus is defined
+    - prometheus.system_metrics_collection | bool
+    - prometheus.prom_url is defined
+    - workload.name not in ["kube-burner", "backpack"]

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -45,6 +45,8 @@ spec:
                     type: string
                   prom_token:
                     type: string
+                  metrics_profile:
+                    type: string
               workload:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
@@ -135,7 +137,9 @@ spec:
                type: string
               node_idx:
                type: string
-
+              system_metrics:
+               type: string
+              default: Not collected
     additionalPrinterColumns:
     - name: Type
       type: string
@@ -153,6 +157,10 @@ spec:
       type: string
       description: If Cerberus is connected or not
       jsonPath: .status.cerberus
+    - name: System metrics
+      type: string
+      description: System metrics collect status
+      jsonPath: .status.system_metrics
     - name: UUID
       type: string
       jsonPath: .status.uuid

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -43,9 +43,8 @@ spec:
                     type: boolean
                   prom_url:
                     type: string
+                    default: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
                   prom_token:
-                    type: string
-                  metrics_profile:
                     type: string
               workload:
                 x-kubernetes-preserve-unknown-fields: true

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -43,7 +43,31 @@ spec:
                     type: boolean
                   prom_url:
                     type: string
+                  prom_token:
+                    type: string
+              system_metrics:
+                type: object
+                properties:
+                  collection:
+                    type: boolean
+                    default: false
+                  es_url:
+                    type: string
+                  index_name:
+                    type: string
+                    default: system-metrics
+                  step:
+                    type: string
+                    default: 30s
+                  metrics_profile:
+                    type: string
+                    default: node-metrics.yml
+                  prom_url:
+                    type: string
                     default: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+                  image:
+                    type: string
+                    default: quay.io/cloud-bulldozer/kube-burner:latest
                   prom_token:
                     type: string
               workload:
@@ -138,7 +162,7 @@ spec:
                type: string
               system_metrics:
                type: string
-              default: Not collected
+               default: Not collected
     additionalPrinterColumns:
     - name: Type
       type: string

--- a/roles/hammerdb/templates/db_mssql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mssql_workload.yml.j2
@@ -40,7 +40,7 @@ spec:
             value: "{{ prometheus.es_parallel | default(false) }}"
           - name: prom_token
             value: "{{ prometheus.prom_token | default() }}"
-         - name: prom_url
+          - name: prom_url
             value: "{{ prometheus.prom_url | default() }}"
 {% endif %}
         command: ["/bin/sh", "-c"]

--- a/roles/system-metrics/tasks/main.yml
+++ b/roles/system-metrics/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+
+- block:
+
+  - name: Create kube-burner configmap
+    k8s:
+      definition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: system-metrics-collector-{{ trunc_uuid }}
+          namespace: "{{ operator_namespace }}"
+        data:
+          index.yml: "{{ lookup('template', 'index.yml')}}"
+          metrics.yml: "{{ lookup('template', 'node-metrics.yml')}}"
+  
+  - name: Launching kube-burner job to index system-metrics
+    k8s:
+      definition: "{{ lookup('template', 'kube-burner.yml.j2') | from_yaml }}"
+
+  - name: Get job status
+    k8s_info:
+      kind: Job
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      name: system-metrics-collector-{{ trunc_uuid }}
+    register: job_state
+
+  - name: Set collecting state to system-metrics benchmark
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        system_metrics: Collecting
+
+  when: cr_state.resources[0].status.system_metrics == "Not collected"
+
+- name: Get job status
+  k8s_info:
+    kind: Job
+    api_version: v1
+    namespace: '{{ operator_namespace }}'
+    name: system-metrics-collector-{{ trunc_uuid }}
+  register: job_state
+
+- name: Set collected state to system-metrics benchmark
+  operator_sdk.util.k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      system_metrics: Collected
+  when: job_state.resources[0].status.succeeded is defined and (job_state.resources[0].status.succeeded | int) > 0

--- a/roles/system-metrics/templates/index.yml
+++ b/roles/system-metrics/templates/index.yml
@@ -3,7 +3,7 @@ global:
   writeToFile: false
   indexerConfig:
     enabled: true
-    esServers: ["{{ prometheus.es_url }}"]
+    esServers: ["{{ system_metrics.es_url }}"]
     insecureSkipVerify: true
-    defaultIndex: "{{ workload_args.system_metrics_index|default("system-metrics") }}"
+    defaultIndex: "{{ system_metrics.index_name }}"
     type: elastic

--- a/roles/system-metrics/templates/index.yml
+++ b/roles/system-metrics/templates/index.yml
@@ -1,0 +1,9 @@
+---
+global:
+  writeToFile: false
+  indexerConfig:
+    enabled: true
+    esServers: ["{{ prometheus.es_url }}"]
+    insecureSkipVerify: true
+    defaultIndex: "{{ workload_args.system_metrics_index|default("system-metrics") }}"
+    type: elastic

--- a/roles/system-metrics/templates/kube-burner.yml.j2
+++ b/roles/system-metrics/templates/kube-burner.yml.j2
@@ -1,0 +1,46 @@
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: system-metrics-collector-{{ trunc_uuid }}
+  namespace: {{ operator_namespace }}
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: kube-burner-benchmark-{{ trunc_uuid }}
+    spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
+      tolerations: {{ workload_args.tolerations|default([]) }}
+      restartPolicy: Never
+      containers:
+      - name: kube-burner
+        image: quay.io/cloud-bulldozer/kube-burner:latest
+        imagePullPolicy: Always
+        env:
+        - name: prom_es
+          value: "{{ prometheus.es_url }}"
+        workingDir: /tmp/kube-burner
+        command: ["/bin/sh", "-c"]
+        args:
+        - >
+          kube-burner index
+          --uuid={{ uuid }}
+          -c index.yml
+          -u {{ prometheus.prom_url|default("https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091") }}
+          -t {{ prometheus.prom_token }}
+          --start={{ (cr_state.resources[0].metadata.creationTimestamp|to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') }}
+          --end=$(date +%s)
+          -m {{ prometheus.metrics_profile|default("metrics.yml") }}
+          --step={{ workload_args.step|default("30s") }}
+        volumeMounts:
+          - name: system-metrics-collector
+            mountPath: /tmp/kube-burner
+      volumes:
+        - name: system-metrics-collector
+          configMap:
+            name: system-metrics-collector-{{ trunc_uuid }}

--- a/roles/system-metrics/templates/kube-burner.yml.j2
+++ b/roles/system-metrics/templates/kube-burner.yml.j2
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       labels:
-        app: kube-burner-benchmark-{{ trunc_uuid }}
+        app: system-metrics-collector-{{ trunc_uuid }}
     spec:
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"

--- a/roles/system-metrics/templates/kube-burner.yml.j2
+++ b/roles/system-metrics/templates/kube-burner.yml.j2
@@ -15,15 +15,11 @@ spec:
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}
-      tolerations: {{ workload_args.tolerations|default([]) }}
       restartPolicy: Never
       containers:
       - name: kube-burner
         image: quay.io/cloud-bulldozer/kube-burner:latest
         imagePullPolicy: Always
-        env:
-        - name: prom_es
-          value: "{{ prometheus.es_url }}"
         workingDir: /tmp/kube-burner
         command: ["/bin/sh", "-c"]
         args:

--- a/roles/system-metrics/templates/kube-burner.yml.j2
+++ b/roles/system-metrics/templates/kube-burner.yml.j2
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: kube-burner
-        image: quay.io/cloud-bulldozer/kube-burner:latest
+        image: {{ system_metrics.image }}
         imagePullPolicy: Always
         workingDir: /tmp/kube-burner
         command: ["/bin/sh", "-c"]
@@ -27,12 +27,11 @@ spec:
           kube-burner index
           --uuid={{ uuid }}
           -c index.yml
-          -u {{ prometheus.prom_url|default("https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091") }}
-          -t {{ prometheus.prom_token }}
+          -u {{ system_metrics.prom_url }}
+          -t {{ system_metrics.prom_token }}
           --start={{ (cr_state.resources[0].metadata.creationTimestamp|to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') }}
-          --end=$(date +%s)
-          -m {{ prometheus.metrics_profile|default("metrics.yml") }}
-          --step={{ workload_args.step|default("30s") }}
+          -m {{ system_metrics.metrics_profile|default("metrics.yml") }}
+          --step={{ system_metrics.step }}
         volumeMounts:
           - name: system-metrics-collector
             mountPath: /tmp/kube-burner

--- a/roles/system-metrics/templates/node-metrics.yml
+++ b/roles/system-metrics/templates/node-metrics.yml
@@ -1,0 +1,38 @@
+metrics:
+  - query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0
+    metricName: nodeCPU
+
+  - query: avg(node_memory_MemAvailable_bytes) by (instance)
+    metricName: nodeMemoryAvailable
+
+  - query: avg(node_memory_Active_bytes) by (instance)
+    metricName: nodeMemoryActive
+
+  - query: avg(node_memory_Cached_bytes) by (instance) + avg(node_memory_Buffers_bytes) by (instance)
+    metricName: nodeMemoryCached+nodeMemoryBuffers
+
+  - query: irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
+    metricName: rxNetworkBytes
+
+  - query: irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
+    metricName: txNetworkBytes
+
+  - query: irate(node_network_receive_drop_total{device=~"^(ens|eth|bond|team).*"}[2m])
+    metricName: rxDroppedPackets
+
+  - query: irate(node_network_transmit_drop_total{device=~"^(ens|eth|bond|team).*"}[2m])
+    metricName: txDroppedPackets
+
+  - query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m])
+    metricName: nodeDiskWrittenBytes
+
+  - query: rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m])
+    metricName: nodeDiskReadBytes
+
+  - query: kube_node_role
+    metricName: nodeRoles
+    instant: true
+
+  - query: cluster_version{type="completed"}
+    metricName: clusterVersion
+    instant: true

--- a/roles/system-metrics/templates/node-metrics.yml
+++ b/roles/system-metrics/templates/node-metrics.yml
@@ -17,12 +17,6 @@ metrics:
   - query: irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
     metricName: txNetworkBytes
 
-  - query: irate(node_network_receive_drop_total{device=~"^(ens|eth|bond|team).*"}[2m])
-    metricName: rxDroppedPackets
-
-  - query: irate(node_network_transmit_drop_total{device=~"^(ens|eth|bond|team).*"}[2m])
-    metricName: txDroppedPackets
-
   - query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m])
     metricName: nodeDiskWrittenBytes
 

--- a/tests/test_byowl.sh
+++ b/tests/test_byowl.sh
@@ -20,7 +20,8 @@ trap finish EXIT
 function functional_test_byowl {
   wait_clean
   apply_operator
-  kubectl apply -f tests/test_crs/valid_byowl.yaml
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" tests/test_crs/valid_byowl.yaml | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
   

--- a/tests/test_crs/valid_byowl.yaml
+++ b/tests/test_crs/valid_byowl.yaml
@@ -4,6 +4,13 @@ metadata:
   name: byowl-benchmark
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
   metadata:

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -4,6 +4,13 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-fio

--- a/tests/test_crs/valid_fiod.yaml
+++ b/tests/test_crs/valid_fiod.yaml
@@ -4,10 +4,9 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_fiod_bsrange.yaml
+++ b/tests/test_crs/valid_fiod_bsrange.yaml
@@ -4,6 +4,13 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-fio

--- a/tests/test_crs/valid_fiod_bsrange.yaml
+++ b/tests/test_crs/valid_fiod_bsrange.yaml
@@ -4,10 +4,9 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -4,6 +4,13 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-fio

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -4,10 +4,9 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_flent.yaml
+++ b/tests/test_crs/valid_flent.yaml
@@ -4,6 +4,13 @@ metadata:
   name: flent-benchmark
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-flent

--- a/tests/test_crs/valid_flent.yaml
+++ b/tests/test_crs/valid_flent.yaml
@@ -4,10 +4,9 @@ metadata:
   name: flent-benchmark
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_flent_resources.yaml
+++ b/tests/test_crs/valid_flent_resources.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: my-ripsaw
 spec:
   clustername: myk8scluster
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-flent

--- a/tests/test_crs/valid_flent_resources.yaml
+++ b/tests/test_crs/valid_flent_resources.yaml
@@ -5,10 +5,9 @@ metadata:
   namespace: my-ripsaw
 spec:
   clustername: myk8scluster
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -7,6 +7,13 @@ spec:
   test_user: homer_simpson
   # to separate this test run from everyone else's
   clustername: test_ci
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   # where elastic search is running
   elasticsearch:
     url: ES_SERVER

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -7,10 +7,9 @@ spec:
   test_user: homer_simpson
   # to separate this test run from everyone else's
   clustername: test_ci
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_fs_drift_hostpath.yaml
+++ b/tests/test_crs/valid_fs_drift_hostpath.yaml
@@ -7,6 +7,13 @@ spec:
   test_user: homer_simpson
   # to separate this test run from everyone else's
   clustername: test_ci
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   # where elastic search is running
   elasticsearch:
     url: ES_SERVER

--- a/tests/test_crs/valid_fs_drift_hostpath.yaml
+++ b/tests/test_crs/valid_fs_drift_hostpath.yaml
@@ -7,10 +7,9 @@ spec:
   test_user: homer_simpson
   # to separate this test run from everyone else's
   clustername: test_ci
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_hammerdb.yaml
+++ b/tests/test_crs/valid_hammerdb.yaml
@@ -4,6 +4,13 @@ metadata:
   name: hammerdb
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-hammerdb

--- a/tests/test_crs/valid_hammerdb.yaml
+++ b/tests/test_crs/valid_hammerdb.yaml
@@ -4,10 +4,9 @@ metadata:
   name: hammerdb
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_iperf3.yaml
+++ b/tests/test_crs/valid_iperf3.yaml
@@ -4,6 +4,13 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
   metadata:

--- a/tests/test_crs/valid_iperf3.yaml
+++ b/tests/test_crs/valid_iperf3.yaml
@@ -4,10 +4,9 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_pgbench.yaml
+++ b/tests/test_crs/valid_pgbench.yaml
@@ -4,10 +4,9 @@ metadata:
   name: pgbench-benchmark
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_pgbench.yaml
+++ b/tests/test_crs/valid_pgbench.yaml
@@ -4,6 +4,13 @@ metadata:
   name: pgbench-benchmark
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-pgbench

--- a/tests/test_crs/valid_scale_down.yaml
+++ b/tests/test_crs/valid_scale_down.yaml
@@ -4,10 +4,9 @@ metadata:
   name: scale
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_scale_down.yaml
+++ b/tests/test_crs/valid_scale_down.yaml
@@ -4,6 +4,13 @@ metadata:
   name: scale
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: openshift-cluster-timings

--- a/tests/test_crs/valid_scale_up.yaml
+++ b/tests/test_crs/valid_scale_up.yaml
@@ -4,10 +4,9 @@ metadata:
   name: scale
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_scale_up.yaml
+++ b/tests/test_crs/valid_scale_up.yaml
@@ -4,6 +4,13 @@ metadata:
   name: scale
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: openshift-cluster-timings

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -7,6 +7,13 @@ spec:
   test_user: homer_simpson
   # to separate this test run from everyone else's
   clustername: test_ci
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   # where elastic search is running
   elasticsearch:
     url: ES_SERVER

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -7,10 +7,9 @@ spec:
   test_user: homer_simpson
   # to separate this test run from everyone else's
   clustername: test_ci
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_smallfile_hostpath.yaml
+++ b/tests/test_crs/valid_smallfile_hostpath.yaml
@@ -8,10 +8,9 @@ spec:
   test_user: homer_simpson
   # to separate this test run from everyone else's
   clustername: test_ci
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_smallfile_hostpath.yaml
+++ b/tests/test_crs/valid_smallfile_hostpath.yaml
@@ -8,6 +8,13 @@ spec:
   test_user: homer_simpson
   # to separate this test run from everyone else's
   clustername: test_ci
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-smallfile

--- a/tests/test_crs/valid_stressng.yaml
+++ b/tests/test_crs/valid_stressng.yaml
@@ -4,10 +4,9 @@ metadata:
   name: stressng
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_stressng.yaml
+++ b/tests/test_crs/valid_stressng.yaml
@@ -4,6 +4,13 @@ metadata:
   name: stressng
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-stressng

--- a/tests/test_crs/valid_sysbench.yaml
+++ b/tests/test_crs/valid_sysbench.yaml
@@ -4,6 +4,13 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
   metadata:

--- a/tests/test_crs/valid_sysbench.yaml
+++ b/tests/test_crs/valid_sysbench.yaml
@@ -4,10 +4,9 @@ metadata:
   name: example-benchmark
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -4,6 +4,13 @@ metadata:
   name: uperf
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-uperf

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -4,10 +4,9 @@ metadata:
   name: uperf
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_uperf_networkpolicy.yaml
+++ b/tests/test_crs/valid_uperf_networkpolicy.yaml
@@ -4,6 +4,13 @@ metadata:
   name: uperf
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-uperf

--- a/tests/test_crs/valid_uperf_networkpolicy.yaml
+++ b/tests/test_crs/valid_uperf_networkpolicy.yaml
@@ -4,10 +4,9 @@ metadata:
   name: uperf
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_uperf_resources.yaml
+++ b/tests/test_crs/valid_uperf_resources.yaml
@@ -4,6 +4,13 @@ metadata:
   name: uperf
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-uperf

--- a/tests/test_crs/valid_uperf_resources.yaml
+++ b/tests/test_crs/valid_uperf_resources.yaml
@@ -4,10 +4,9 @@ metadata:
   name: uperf
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_uperf_serviceip.yaml
+++ b/tests/test_crs/valid_uperf_serviceip.yaml
@@ -4,6 +4,13 @@ metadata:
   name: uperf
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-uperf

--- a/tests/test_crs/valid_uperf_serviceip.yaml
+++ b/tests/test_crs/valid_uperf_serviceip.yaml
@@ -4,10 +4,9 @@ metadata:
   name: uperf
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_vegeta.yaml
+++ b/tests/test_crs/valid_vegeta.yaml
@@ -5,6 +5,13 @@ metadata:
   name: vegeta-benchmark
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-vegeta

--- a/tests/test_crs/valid_vegeta.yaml
+++ b/tests/test_crs/valid_vegeta.yaml
@@ -5,10 +5,9 @@ metadata:
   name: vegeta-benchmark
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_vegeta_hostnetwork.yaml
+++ b/tests/test_crs/valid_vegeta_hostnetwork.yaml
@@ -5,10 +5,9 @@ metadata:
   name: vegeta-benchmark-hostnetwork
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_vegeta_hostnetwork.yaml
+++ b/tests/test_crs/valid_vegeta_hostnetwork.yaml
@@ -5,6 +5,13 @@ metadata:
   name: vegeta-benchmark-hostnetwork
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-vegeta

--- a/tests/test_crs/valid_ycsb-mongo.yaml
+++ b/tests/test_crs/valid_ycsb-mongo.yaml
@@ -4,10 +4,9 @@ metadata:
   name: ycsb-mongo-benchmark
   namespace: my-ripsaw
 spec:
-  prometheus:
-    system_metrics_collection: true
+  system_metrics:
+    collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    system_metrics_index: system-metrics
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml

--- a/tests/test_crs/valid_ycsb-mongo.yaml
+++ b/tests/test_crs/valid_ycsb-mongo.yaml
@@ -4,6 +4,13 @@ metadata:
   name: ycsb-mongo-benchmark
   namespace: my-ripsaw
 spec:
+  prometheus:
+    system_metrics_collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    system_metrics_index: system-metrics
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-ycsb

--- a/tests/test_fiod.sh
+++ b/tests/test_fiod.sh
@@ -24,6 +24,8 @@ function functional_test_fio {
   test_name=$1
   cr=$2
   echo "Performing: ${test_name}"
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" ${cr} | kubectl apply -f -
   kubectl apply -f ${cr}
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}

--- a/tests/test_flent.sh
+++ b/tests/test_flent.sh
@@ -22,7 +22,8 @@ function functional_test_flent {
   test_name=$1
   cr=$2
   echo "Performing: ${test_name}"
-  kubectl apply -f ${cr}
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" ${cr} | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 

--- a/tests/test_fs_drift.sh
+++ b/tests/test_fs_drift.sh
@@ -23,7 +23,8 @@ function functional_test_fs_drift {
   test_name=$1
   cr=$2
   echo "Performing: ${test_name}"
-  kubectl apply -f ${cr}
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" ${cr} | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 

--- a/tests/test_hammerdb.sh
+++ b/tests/test_hammerdb.sh
@@ -23,7 +23,8 @@ function functional_test_hammerdb {
   wait_clean
   apply_operator
   initdb_pod
-  kubectl apply -f tests/test_crs/valid_hammerdb.yaml
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" tests/test_crs/valid_hammerdb.yaml | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 

--- a/tests/test_iperf3.sh
+++ b/tests/test_iperf3.sh
@@ -21,7 +21,8 @@ function functional_test_iperf {
   wait_clean
   apply_operator
   echo "Performing iperf3: ${1}"
-  sed -e "s/hostnetwork:.*/${1}/g" tests/test_crs/valid_iperf3.yaml | kubectl apply -f -
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" -e "s/hostnetwork:.*/${1}/g" tests/test_crs/valid_iperf3.yaml | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 

--- a/tests/test_smallfile.sh
+++ b/tests/test_smallfile.sh
@@ -25,7 +25,8 @@ function functional_test_smallfile {
   test_name=$1
   cr=$2
   echo "Performing: ${test_name}"
-  kubectl apply -f ${cr}
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" ${cr} | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 

--- a/tests/test_stressng.sh
+++ b/tests/test_stressng.sh
@@ -19,7 +19,8 @@ trap finish EXIT
 function functional_test_stressng {
   wait_clean
   apply_operator
-  kubectl apply -f tests/test_crs/valid_stressng.yaml
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" tests/test_crs/valid_stressng.yaml | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -46,7 +46,7 @@ function functional_test_uperf {
 }
 
 figlet $(basename $0)
-functional_test_uperf "Uperf without resources definition and system-metrics collection" tests/test_crs/valid_uperf.yaml
+functional_test_uperf "Uperf without resources definition" tests/test_crs/valid_uperf.yaml
 functional_test_uperf "Uperf with ServiceIP" tests/test_crs/valid_uperf_serviceip.yaml
 functional_test_uperf "Uperf with resources definition and hostNetwork" tests/test_crs/valid_uperf_resources.yaml
 functional_test_uperf "Uperf with networkpolicy" tests/test_crs/valid_uperf_networkpolicy.yaml

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -19,10 +19,11 @@ trap finish EXIT
 function functional_test_uperf {
   wait_clean
   apply_operator
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
   test_name=$1
   cr=$2
   echo "Performing: ${test_name}"
-  kubectl apply -f ${cr}
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" ${cr} | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 
@@ -45,7 +46,7 @@ function functional_test_uperf {
 }
 
 figlet $(basename $0)
-functional_test_uperf "Uperf without resources definition" tests/test_crs/valid_uperf.yaml
+functional_test_uperf "Uperf without resources definition and system-metrics collection" tests/test_crs/valid_uperf.yaml
 functional_test_uperf "Uperf with ServiceIP" tests/test_crs/valid_uperf_serviceip.yaml
 functional_test_uperf "Uperf with resources definition and hostNetwork" tests/test_crs/valid_uperf_resources.yaml
 functional_test_uperf "Uperf with networkpolicy" tests/test_crs/valid_uperf_networkpolicy.yaml

--- a/tests/test_vegeta.sh
+++ b/tests/test_vegeta.sh
@@ -25,7 +25,8 @@ function functional_test_vegeta {
   test_name=$1
   cr=$2
   echo "Performing: ${test_name}"
-  kubectl apply -f ${cr}
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" ${cr} | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 

--- a/tests/test_ycsb.sh
+++ b/tests/test_ycsb.sh
@@ -64,7 +64,8 @@ spec:
          ports:
            - containerPort: 27017
 EOF
-  kubectl apply -f tests/test_crs/valid_ycsb-mongo.yaml
+  token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+  sed -e "s/PROMETHEUS_TOKEN/${token}/g" tests/test_crs/valid_ycsb-mongo.yaml | kubectl apply -f -
   long_uuid=$(get_uuid 20)
   uuid=${long_uuid:0:8}
 


### PR DESCRIPTION
## Description
System metrics collection implementation. Can be enabled by adding the following lines to the prometheus section of the Benchmark CR:

```yaml
  system_metrics:
    collection: true (Defaults to false)
    prom_url: <Valid prometheus endpoint, by default https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091>
    index_name: <ES index name, defaults to system-metrics>
    es_url: <valid ES endpoint>
    prom_token: <valid prometheus token, can be obtained with oc sa get-token -n openshift-monitoring prometheus-k8s>
    metrics_profile: <valid metrics profile name or URL, by default it uses node-metrics.yml>

```
When the workload is marked as Complete, benchmark-operator creates a kube-burner based job that collect the metrics configured in the metric profile using the benchmark creationTimestamp as start date and the current date as end date. This system metrics collection is available for all workloads except kube-burner and backpack.

## Fixes
#542 

### Task list

- [x] Initial implementation
- [x] Update documentation
- [x] Include some tests

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>
