### PR TITLE
Remove iperf3 compulsory arguments

### DIFF
--- a/roles/iperf3/templates/client.yml.j2
+++ b/roles/iperf3/templates/client.yml.j2
@@ -36,7 +36,16 @@ spec:
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args:
-          - "iperf3 -c {{ item.status.podIP }} -p {{ workload_args.port }} --{{ workload_args.transmit_type }} {{ workload_args.transmit_value }} -l {{ workload_args.length_buffer }} -P {{ workload_args.streams }} -w {{ workload_args.window_size }} -M {{ workload_args.mss }} -S {{ workload_args.ip_tos }} -O {{ workload_args.omit_start }} {{ workload_args.extra_options_client }}"
+          - "iperf3 -c {{ item.status.podIP }}
+            {% if workload_args.port is defined %} -p {{ workload_args.port }} {% endif %}
+            {% if workload_args.transmit_type is defined and workload_args.transmit_value is defined %} --{{ workload_args.transmit_type }} {{ workload_args.transmit_value }} {% endif %}
+            {% if workload_args.length_buffer is defined %} -l {{ workload_args.length_buffer }} {% endif %}
+            {% if workload_args.streams is defined %} -P {{ workload_args.streams }} {% endif %}
+            {% if workload_args.window_size is defined %} -w {{ workload_args.window_size }} {% endif %}
+            {% if workload_args.mss is defined %} -M {{ workload_args.mss }} {% endif %}
+            {% if workload_args.ip_tos is defined %}  -S {{ workload_args.ip_tos }} {% endif %}
+            {% if workload_args.omit_start is defined %} -O {{ workload_args.omit_start }} {% endif %}
+            {% if workload_args.extra_options_client is defined %} {{ workload_args.extra_options_client }} {% endif %}"
       restartPolicy: OnFailure
 {% if workload_args.pin_client is defined %}
       nodeSelector:

--- a/roles/iperf3/templates/client_store.yml.j2
+++ b/roles/iperf3/templates/client_store.yml.j2
@@ -37,7 +37,17 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - "mkdir -p {{results.path}}/iperf3-{{ uuid }};
-             iperf3 -c {{ item.status.podIP }} -J -p {{ workload_args.port }} --{{ workload_args.transmit_type }} {{ workload_args.transmit_value }} -l {{ workload_args.length_buffer }} -P {{ workload_args.streams }} -w {{ workload_args.window_size }} -M {{ workload_args.mss }} -S {{ workload_args.ip_tos }} -O {{ workload_args.omit_start }} {{ workload_args.extra_options_client }} >> {{results.path}}/iperf3-{{ uuid }}/iperf_result.json"
+             iperf3 -c {{ item.status.podIP }} -J
+             {% if workload_args.port is defined %} -p {{ workload_args.port }} {% endif %}
+             {% if workload_args.transmit_type is defined and workload_args.transmit_value is defined %} --{{ workload_args.transmit_type }} {{ workload_args.transmit_value }} {% endif %}
+             {% if workload_args.length_buffer is defined %} -l {{ workload_args.length_buffer }} {% endif %}
+             {% if workload_args.streams is defined %} -P {{ workload_args.streams }} {% endif %}
+             {% if workload_args.window_size is defined %} -w {{ workload_args.window_size }} {% endif %}
+             {% if workload_args.mss is defined %} -M {{ workload_args.mss }} {% endif %}
+             {% if workload_args.ip_tos is defined %}  -S {{ workload_args.ip_tos }} {% endif %}
+             {% if workload_args.omit_start is defined %} -O {{ workload_args.omit_start }} {% endif %}
+             {% if workload_args.extra_options_client is defined %} {{ workload_args.extra_options_client }} {% endif %}
+             >> {{results.path}}/iperf3-{{ uuid }}/iperf_result.json"
         volumeMounts:
           - name: result-data
             mountPath: "{{results.path}}"

--- a/roles/iperf3/templates/server.yml.j2
+++ b/roles/iperf3/templates/server.yml.j2
@@ -36,7 +36,9 @@ spec:
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args:
-          - "iperf3 -s -p {{ workload_args.port }} {{ workload_args.extra_options_server }}"
+          - "iperf3 -s
+            {% if workload_args.port is defined %} -p {{ workload_args.port }} {% endif %}
+            {% if workload_args.extra_options_server is defined %} {{ workload_args.extra_options_server }} {% endif %}"
       restartPolicy: OnFailure
 {% if workload_args.pin_server is defined %}
       nodeSelector:


### PR DESCRIPTION
# Description
During iPerf3 network measurements, we have noticed that we have to pass all these following compulsory arguments.
```
      transmit_type: time
      transmit_value: 60
      omit_start: 0
      length_buffer: 128K
      window_size: 64k
      ip_tos: 0
      mss: 900
      streams: 1
```
As a result it generates the following command-lines for Server and Client POD.
Server POD Command: `iperf3 -s -p 5201 --forceflush`
Client POD Command: `iperf3 -c <IP_ADDRESS> -p 5201 --time 60 -l 128K -P 1 -w 64k -M 900 -S 0 -O 0 -R`

I get better performance with these following simple command-lines:
Server POD Command: `iperf3 -s -p 5201 --forceflush`
Client POD Command: `iperf3 -c <IP_ADDRESS> -p 5201 --time 60 -R`

It would be helpful if we make these compulsory arguments to optional arguments. It will help to reduce search time for default value for all compulsory arguments.

Thanks.

Fixes #535
