### PR TITLE
Truncate UPERF node names to 27 chars max.

### DIFF
--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -7,7 +7,7 @@ items:
   - kind: Job
     apiVersion: batch/v1
     metadata:    
-      name: 'uperf-server-{{worker_node_list[ node_idx_item ] | truncate(32,true,'') }}-{{ item }}-{{ trunc_uuid }}'
+      name: 'uperf-server-{{worker_node_list[ node_idx_item ] | truncate(27,true,'') }}-{{ item }}-{{ trunc_uuid }}'
       namespace: "{{ operator_namespace }}"
     spec:
       ttlSecondsAfterFinished: 600
@@ -15,7 +15,7 @@ items:
       template:
         metadata:
           labels:
-            app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(32,true,'') }}-{{ item  }}-{{ trunc_uuid }}
+            app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(27,true,'') }}-{{ item  }}-{{ trunc_uuid }}
             type: {{ meta.name }}-bench-server-{{ trunc_uuid }}
           annotations:
 {% if workload_args.multus.enabled is sameas true %}

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -7,17 +7,17 @@ items:
   - kind: Service
     apiVersion: v1
     metadata:
-      name:  uperf-service-{{ worker_node_list[ node_idx_item ] | truncate(32,true,'') }}-{{ item }}-{{ trunc_uuid }}
+      name:  uperf-service-{{ worker_node_list[ node_idx_item ] | truncate(27,true,'') }}-{{ item }}-{{ trunc_uuid }}
       namespace: '{{ operator_namespace }}'
       labels:
-        app: uperf-bench-server-{{ worker_node_list[ node_idx_item ] | truncate(32,true,'')}}-{{ item }}-{{ trunc_uuid }}
+        app: uperf-bench-server-{{ worker_node_list[ node_idx_item ] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
         type: {{ meta.name }}-bench-server-{{ trunc_uuid }}
       annotations:
         node_idx: '{{ node_idx_item }}'
         pod_idx: '{{ item }}'
     spec:
       selector:
-        app: uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(32,true,'')}}-{{ item }}-{{ trunc_uuid }}
+        app: uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
       ports:
       - name: uperf
         port: 20000


### PR DESCRIPTION


### Description
This PR truncates names to 27 chars. It was discovered that jinja 'truncate' filter does not truncate for less than 5 chars.  So the current code that relies on truncate(32) would not take effect for names with length between 32 to 37 chars. Without truncation, these node names produce UPERF objects with meta.names and labels that exceed 63 chars violating k8s API.
### Fixes
Truncate 5 more chars.
### Test
On a cluster that has node names of 37 chars (berrymar19-9wc5t-worker-eastus1-pnfrk) UPERF failed before the fix, but with the fix it works.
