### PR TITLE
Always use benchmark-operator for service account

### DIFF
--- a/charts/benchmark-operator/templates/service-account.yaml
+++ b/charts/benchmark-operator/templates/service-account.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "benchmark-operator.fullname" . }}
+  # do not change - hard coded in ansible roles
+  name: "benchmark-operator"
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The service account name is hard coded in some of the workload
roles, ie:

https://github.com/cloud-bulldozer/benchmark-operator/blob/master/roles/fio_distributed/templates/servers.yaml#L48

If someone were to change the fullnameOverride in values.yaml the
workload would fail.
