### PR TITLE
Adding contributing doc version updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,11 +129,14 @@ case of failure or when disabled. This ensures no interference with subsequent w
 
 ### The operator container image
 Any changes to the [roles](roles/) tree or to the [playbook](playbook.yml) file will necessitate a new build of the operator container image.
-The container is built using the [Operator SDK](https://github.com/operator-framework/operator-sdk) and pushed to a public repository.
+The container is built using the [Operator SDK](https://github.com/operator-framework/operator-sdk) (v.0.10.0 and before) and pushed to a public repository.
 The public repository could be [quay](https://quay.io) in which case you'll need to:
 
 ```bash
 $ operator-sdk build quay.io/<username>/benchmark-operator:testing --image-builder podman 
+OR
+$ podman build -f build/Dockerfile -t quay.io/<username>/benchmark-operator:testing .
+
 $ podman push quay.io/<username>/benchmark-operator:testing
 ```
 


### PR DESCRIPTION
### Description
Adding specific operator-sdk version and alternate command in contributing doc. 

NOTE: At the most recent version of operator-sdk (v1.3.0-ocp) `operator-sdk build` is no longer a valid command 