### PR TITLE
Bump operator-sdk to v1.5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,12 +129,10 @@ case of failure or when disabled. This ensures no interference with subsequent w
 
 ### The operator container image
 Any changes to the [roles](roles/) tree or to the [playbook](playbook.yml) file will necessitate a new build of the operator container image.
-The container is built using the [Operator SDK](https://github.com/operator-framework/operator-sdk) (v0.1.5) and pushed to a public repository.
+The benchmark-operator container can be built using [podman](https://podman.io/) and pushed to a public repository.
 The public repository could be [quay](https://quay.io) in which case you'll need to:
 
 ```bash
-$ operator-sdk build quay.io/<username>/benchmark-operator:testing --image-builder podman 
-OR
 $ podman build -f build/Dockerfile -t quay.io/<username>/benchmark-operator:testing .
 
 $ podman push quay.io/<username>/benchmark-operator:testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ case of failure or when disabled. This ensures no interference with subsequent w
 
 ### The operator container image
 Any changes to the [roles](roles/) tree or to the [playbook](playbook.yml) file will necessitate a new build of the operator container image.
-The container is built using the [Operator SDK](https://github.com/operator-framework/operator-sdk) (v.0.10.0 and before) and pushed to a public repository.
+The container is built using the [Operator SDK](https://github.com/operator-framework/operator-sdk) (v0.1.5) and pushed to a public repository.
 The public repository could be [quay](https://quay.io) in which case you'll need to:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ to [uperf](docs/uperf.md)
 * Add the link for your workload guide to [installation guide](docs/installation.md#running-workloads)
 * Ensure all resources created are within the `my-ripsaw` namespace, this can be done by setting namespace
 to use `operator_namespace` var. This is to ensure that the resources aren't defaulted to current active
-namespace which is what `meta.namespace` would default to.
+namespace which is what `ansible_operator_meta.namespace` would default to.
 * All resources created as part of your role should use `trunc_uuid` ansible var in their names and labels, so
 for example [fio-client job template](roles/fio-distributed/templates/client.yaml) has the name `fio-client` and label `app: fiod-client`, instead we'll append the var `trunc_uuid` to both
 the name and label so it'll be `fio-client-{{ trunc_uuid }}` and label would be `app:fiod-client-{{ trunc_uuid }}`. The reason for this

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.17.1
+FROM quay.io/operator-framework/ansible-operator:v1.5.0
 USER root
 
 COPY requirements.yml ${HOME}/requirements.yml

--- a/charts/benchmark-operator/templates/operator.yaml
+++ b/charts/benchmark-operator/templates/operator.yaml
@@ -15,17 +15,6 @@ spec:
     spec:
       serviceAccountName: {{ include "benchmark-operator.fullname" . }}
       containers:
-        - name: ansible
-          command:
-          - /usr/local/bin/ao-logs
-          - /tmp/ansible-operator/runner
-          - stdout
-          image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
-          imagePullPolicy: {{ .Values.operator.image.pullPolicy}}
-          volumeMounts:
-          - mountPath: /tmp/ansible-operator/runner
-            name: runner
-            readOnly: true
         - name: benchmark-operator
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy}}

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -56,11 +56,11 @@ the workload template with an init container section that looks like:
 {% if metadata.force is sameas true %}
             --force
 {% endif %}
-{% if metadata.stockpile_tags|length > 0 %}
-            --tags={{ metadata.stockpile_tags|join(",") }}
+{% if metadata.stockpileTags|length > 0 %}
+            --tags={{ metadata.stockpileTags|join(",") }}
 {% endif %}
-{% if metadata.stockpile_skip_tags|length > 0 %}
-            --skip-tags={{ metadata.stockpile_skip_tags|join(",") }}
+{% if metadata.stockpileSkipTags|length > 0 %}
+            --skip-tags={{ metadata.stockpileSkipTags|join(",") }}
 {% endif %}
 {% if metadata.ssl is sameas true %}
             --sslskipverify

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,4 +1,4 @@
 ---
-operator_namespace: '{{ meta.namespace }}'
+operator_namespace: '{{ ansible_operator_meta.namespace }}'
 clustername: 'myk8scluster'
 kernel_cache_drop_svc_port: 9222

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,7 +20,7 @@
     k8s_facts:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: '{{ meta.name }}'
+      name: '{{ ansible_operator_meta.name }}'
       namespace: '{{ operator_namespace }}'
     register: cr_state
 
@@ -45,7 +45,7 @@
       operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
-        name: "{{ meta.name }}"
+        name: "{{ ansible_operator_meta.name }}"
         namespace: "{{ operator_namespace }}"
         status:
           uuid: "{{ uuid }}"
@@ -73,7 +73,7 @@
       - operator_sdk.util.k8s_status:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
           kind: Benchmark
-          name: "{{ meta.name }}"
+          name: "{{ ansible_operator_meta.name }}"
           namespace: "{{ operator_namespace }}"
           status:
             metadata: "Collecting"

--- a/resources/operator.yaml
+++ b/resources/operator.yaml
@@ -29,17 +29,6 @@ spec:
                 - ""
       serviceAccountName: benchmark-operator
       containers:
-        - name: ansible
-          command:
-          - /usr/local/bin/ao-logs
-          - /tmp/ansible-operator/runner
-          - stdout
-          image: quay.io/benchmark-operator/benchmark-operator:master
-          imagePullPolicy: "Always"
-          volumeMounts:
-          - mountPath: /tmp/ansible-operator/runner
-            name: runner
-            readOnly: true
         - name: benchmark-operator
           image: quay.io/benchmark-operator/benchmark-operator:master
           imagePullPolicy: Always

--- a/roles/backpack/tasks/main.yml
+++ b/roles/backpack/tasks/main.yml
@@ -3,14 +3,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
   register: benchmark_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: "Metadata Collecting"
@@ -22,7 +22,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
   register: benchmark_state
 
@@ -61,7 +61,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Metadata Collecting"
@@ -73,7 +73,7 @@
     k8s_facts:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
     register: benchmark_state
 
@@ -92,7 +92,7 @@
       - operator_sdk.util.k8s_status:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
           kind: Benchmark
-          name: "{{ meta.name }}"
+          name: "{{ ansible_operator_meta.name }}"
           namespace: "{{ operator_namespace }}"
           status:
             state: null
@@ -103,7 +103,7 @@
         k8s_facts:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
           kind: Benchmark
-          name: "{{ meta.name }}"
+          name: "{{ ansible_operator_meta.name }}"
           namespace: "{{ operator_namespace }}"
         register: benchmark_state
 

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -50,9 +50,9 @@ spec:
 {% if metadata.force is sameas true %}
             --force
 {% endif %}
-            --tags={{ metadata.stockpile_tags|default(["common", "k8s", "openshift"])|join(",") }}
-{% if metadata.stockpile_skip_tags|length > 0 %}
-            --skip-tags={{ metadata.stockpile_skip_tags|join(",") }}
+            --tags={{ metadata.stockpileTags|default(["common", "k8s", "openshift"])|join(",") }}
+{% if metadata.stockpileSkipTags|length > 0 %}
+            --skip-tags={{ metadata.stockpileSkipTags|join(",") }}
 {% endif %}
 {% if metadata.ssl is sameas true %}
             --sslskipverify True

--- a/roles/byowl/tasks/main.yml
+++ b/roles/byowl/tasks/main.yml
@@ -4,14 +4,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Starting
@@ -22,7 +22,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -37,7 +37,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Running
@@ -59,7 +59,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/cerberus/tasks/main.yml
+++ b/roles/cerberus/tasks/main.yml
@@ -9,7 +9,7 @@
   operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       cerberus: "Connected"
@@ -20,7 +20,7 @@
   operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       cerberus: "Connected"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -5,7 +5,7 @@
       kind: NetworkPolicy
       api_version: networking.k8s.io/v1
       namespace: '{{ operator_namespace }}'
-      name: "{{ meta.name }}-networkpolicy-{{ trunc_uuid }}"
+      name: "{{ ansible_operator_meta.name }}-networkpolicy-{{ trunc_uuid }}"
     register: network_policy
 
   - name: Create Network policy if enabled

--- a/roles/common/templates/networkpolicy.yml.j2
+++ b/roles/common/templates/networkpolicy.yml.j2
@@ -1,14 +1,14 @@
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: "{{ meta.name }}-networkpolicy-{{ trunc_uuid }}"
+  name: "{{ ansible_operator_meta.name }}-networkpolicy-{{ trunc_uuid }}"
   namespace: '{{ operator_namespace }}'
 spec:
   podSelector: 
     matchLabels:
-      type: "{{ meta.name }}-bench-server-{{ trunc_uuid }}"
+      type: "{{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}"
   ingress:
   - from:
     - podSelector: 
         matchLabels:
-          type: "{{ meta.name }}-bench-client-{{ trunc_uuid }}"
+          type: "{{ ansible_operator_meta.name }}-bench-client-{{ trunc_uuid }}"

--- a/roles/cyclictest/tasks/main.yml
+++ b/roles/cyclictest/tasks/main.yml
@@ -4,14 +4,14 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Building
@@ -22,7 +22,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -34,7 +34,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ meta.name }}-workload-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
         data:
           cyclictest.sh: "{{ lookup('file', 'cyclictest.sh') }}"
@@ -43,7 +43,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: ConfigMaps Created
@@ -60,7 +60,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Benchmark Running
@@ -74,7 +74,7 @@
     k8s_facts:
       kind: Job
       api_version: batch/v1
-      name: '{{ meta.name }}-workload-{{ trunc_uuid }}'
+      name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
       namespace: "{{ operator_namespace }}"
     register: cyclictest_status
 
@@ -82,7 +82,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Benchmark Complete
@@ -93,7 +93,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Failed

--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+  name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
   namespace: "{{ operator_namespace }}"
 spec:
   template:
@@ -85,7 +85,7 @@ spec:
           path: /dev/cpu_dma_latency
       - name: cyclictest-volume
         configMap:
-          name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+          name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0555
       restartPolicy: Never
       serviceAccountName: benchmark-operator

--- a/roles/fio_distributed/tasks/main.yml
+++ b/roles/fio_distributed/tasks/main.yml
@@ -3,14 +3,14 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Building
@@ -21,7 +21,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -75,7 +75,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: StartingServers
@@ -97,7 +97,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: StartingClient
@@ -125,7 +125,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: StartingClient
@@ -169,7 +169,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Running
@@ -190,7 +190,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/flent/tasks/main.yml
+++ b/roles/flent/tasks/main.yml
@@ -4,14 +4,14 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Building
@@ -22,7 +22,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -56,7 +56,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Servers"
@@ -78,7 +78,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Clients"
@@ -107,7 +107,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Waiting for Clients
@@ -130,7 +130,7 @@
       operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
-        name: "{{ meta.name }}"
+        name: "{{ ansible_operator_meta.name }}"
         namespace: "{{ operator_namespace }}"
         status:
           state: Clients Running
@@ -147,7 +147,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Running"
@@ -168,7 +168,7 @@
     - operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
-        name: "{{ meta.name }}"
+        name: "{{ ansible_operator_meta.name }}"
         namespace: "{{ operator_namespace }}"
         status:
           state: Cleanup
@@ -211,7 +211,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/fs-drift/tasks/main.yml
+++ b/roles/fs-drift/tasks/main.yml
@@ -4,14 +4,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Starting
@@ -22,7 +22,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -83,7 +83,7 @@
         kind: Job
         apiVersion: batch/v1
         metadata:
-          name: "{{ meta.name }}-fs-drift-publisher-{{ trunc_uuid }}"
+          name: "{{ ansible_operator_meta.name }}-fs-drift-publisher-{{ trunc_uuid }}"
           namespace: "{{ operator_namespace }}"
         spec:
           ttlSecondsAfterFinished: 600
@@ -119,7 +119,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Running
@@ -141,7 +141,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -2,7 +2,7 @@
 kind: Job
 apiVersion: batch/v1
 metadata:
-  name: "{{ meta.name }}-fs-drift-client-benchmark-{{ trunc_uuid }}-pod-{{ item }}"
+  name: "{{ ansible_operator_meta.name }}-fs-drift-client-benchmark-{{ trunc_uuid }}-pod-{{ item }}"
   namespace: "{{ operator_namespace }}"
 spec:
   ttlSecondsAfterFinished: 600

--- a/roles/hammerdb/tasks/main.yaml
+++ b/roles/hammerdb/tasks/main.yaml
@@ -3,14 +3,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Building
@@ -21,7 +21,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -33,7 +33,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata: 
-          name: '{{ meta.name }}-creator-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-creator-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
         data: 
           createdb.tcl: "{{ lookup('template', 'createdb_mysql.tcl.j2') }}"
@@ -45,7 +45,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ meta.name }}-creator-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-creator-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
         data:
           createdb.tcl: "{{ lookup('template', 'createdb_mssql.tcl.j2') }}"
@@ -57,7 +57,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ meta.name }}-creator-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-creator-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
         data:
           createdb.tcl: "{{ lookup('template', 'createdb_pg.tcl.j2') }}"
@@ -69,7 +69,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ meta.name }}-workload-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
         data:
           tpcc-workload-mysql.tcl: "{{ lookup('template', 'tpcc-workload-mysql.tcl.j2') }}"
@@ -81,7 +81,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ meta.name }}-workload-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
         data:
           tpcc-workload-mssql.tcl: "{{ lookup('template', 'tpcc-workload-mssql.tcl.j2') }}"
@@ -93,7 +93,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ meta.name }}-workload-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
         data:
           tpcc-workload-pg.tcl: "{{ lookup('template', 'tpcc-workload-pg.tcl.j2') }}"
@@ -102,7 +102,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Starting DB
@@ -112,7 +112,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Starting DB Workload
@@ -122,7 +122,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: ConfigMaps Created
@@ -140,7 +140,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: DB Creating
@@ -154,14 +154,14 @@
     k8s_facts:
       kind: Job
       api_version: batch/v1
-      name: '{{ meta.name }}-creator-{{ trunc_uuid }}'
+      name: '{{ ansible_operator_meta.name }}-creator-{{ trunc_uuid }}'
       namespace: "{{ operator_namespace }}"
     register: hammerdb_creator_pod
 
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Starting DB Workload
@@ -171,7 +171,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: DB Created
@@ -202,7 +202,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: DB workload running
@@ -215,14 +215,14 @@
     k8s_facts:
       kind: Job
       api_version: batch/v1
-      name: '{{ meta.name }}-workload-{{ trunc_uuid }}'
+      name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
       namespace: "{{ operator_namespace }}"
     register: hammerdb_workload_pod
 
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: DB Workload Complete

--- a/roles/hammerdb/templates/db_creation.yml
+++ b/roles/hammerdb/templates/db_creation.yml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: "job"
 metadata:
-  name: "{{ meta.name }}-creator-{{ trunc_uuid }}"
+  name: "{{ ansible_operator_meta.name }}-creator-{{ trunc_uuid }}"
   namespace: "{{ operator_namespace }}"
 spec:
   ttlSecondsAfterFinished: 600
@@ -26,7 +26,7 @@ spec:
       volumes:
       - name: hammerdb-creator-volume
         configMap:
-          name: "{{ meta.name }}-creator-{{ trunc_uuid }}"
+          name: "{{ ansible_operator_meta.name }}-creator-{{ trunc_uuid }}"
           defaultMode: 0640
       restartPolicy: OnFailure
 {% include "metadata.yml.j2" %}

--- a/roles/hammerdb/templates/db_mssql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mssql_workload.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: "job"
 metadata:
-  name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+  name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
   namespace: "{{ operator_namespace }}"
 spec:
   ttlSecondsAfterFinished: 600
@@ -89,7 +89,7 @@ spec:
       volumes:
       - name: hammerdb-workload-volume
         configMap:
-          name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+          name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0640
       restartPolicy: OnFailure
 {% include "metadata.yml.j2" %}

--- a/roles/hammerdb/templates/db_mysql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mysql_workload.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: "job"
 metadata:
-  name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+  name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
   namespace: "{{ operator_namespace }}"
 spec:
   ttlSecondsAfterFinished: 600
@@ -83,7 +83,7 @@ spec:
       volumes:
       - name: hammerdb-workload-volume
         configMap:
-          name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+          name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0640
       restartPolicy: OnFailure
 {% include "metadata.yml.j2" %}

--- a/roles/hammerdb/templates/db_postgres_workload.yml.j2
+++ b/roles/hammerdb/templates/db_postgres_workload.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: "job"
 metadata:
-  name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+  name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
   namespace: "{{ operator_namespace }}"
 spec:
   ttlSecondsAfterFinished: 600
@@ -87,7 +87,7 @@ spec:
       volumes:
       - name: hammerdb-workload-volume
         configMap:
-          name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+          name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0640
       restartPolicy: OnFailure
 {% include "metadata.yml.j2" %}

--- a/roles/iperf3/tasks/main.yml
+++ b/roles/iperf3/tasks/main.yml
@@ -3,14 +3,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Starting
@@ -21,7 +21,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -36,7 +36,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Server"
@@ -58,7 +58,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Clients"
@@ -86,7 +86,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Waiting for Clients"  
@@ -107,7 +107,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Running
@@ -129,7 +129,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/kube-burner/tasks/main.yml
+++ b/roles/kube-burner/tasks/main.yml
@@ -4,14 +4,14 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Building
@@ -22,7 +22,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -144,7 +144,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Running
@@ -165,7 +165,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete
@@ -176,7 +176,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Failed

--- a/roles/log_generator/tasks/main.yml
+++ b/roles/log_generator/tasks/main.yml
@@ -3,14 +3,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
   register: benchmark_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: "Starting Log Generator Pods"
@@ -21,7 +21,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
   register: benchmark_state
 
@@ -35,7 +35,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Building Pods"
@@ -57,7 +57,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Log Generator Running"
@@ -79,7 +79,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/oslat/tasks/main.yml
+++ b/roles/oslat/tasks/main.yml
@@ -4,14 +4,14 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Building
@@ -22,7 +22,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -34,7 +34,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ meta.name }}-workload-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
         data:
           oslat.sh: "{{ lookup('file', 'oslat.sh') }}"
@@ -43,7 +43,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: ConfigMaps Created
@@ -60,7 +60,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Benchmark Running
@@ -74,7 +74,7 @@
     k8s_facts:
       kind: Job
       api_version: batch/v1
-      name: '{{ meta.name }}-workload-{{ trunc_uuid }}'
+      name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
       namespace: "{{ operator_namespace }}"
     register: oslat_status
 
@@ -82,7 +82,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Benchmark Complete
@@ -93,7 +93,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Failed

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+  name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
   namespace: "{{ operator_namespace }}"
 spec:
   template:
@@ -85,7 +85,7 @@ spec:
           path: /dev/cpu_dma_latency
       - name: oslat-volume
         configMap:
-          name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+          name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0555
       restartPolicy: Never
       serviceAccountName: benchmark-operator

--- a/roles/pgbench/tasks/check_clients.yml
+++ b/roles/pgbench/tasks/check_clients.yml
@@ -6,7 +6,7 @@
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: "Run Workload"

--- a/roles/pgbench/tasks/init.yml
+++ b/roles/pgbench/tasks/init.yml
@@ -5,7 +5,7 @@
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: "Prep Workload"

--- a/roles/pgbench/tasks/main.yml
+++ b/roles/pgbench/tasks/main.yml
@@ -3,14 +3,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: "Init"
@@ -21,7 +21,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 

--- a/roles/pgbench/tasks/prep_workload.yml
+++ b/roles/pgbench/tasks/prep_workload.yml
@@ -14,7 +14,7 @@
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: "Check Clients"

--- a/roles/pgbench/tasks/run_workload.yml
+++ b/roles/pgbench/tasks/run_workload.yml
@@ -18,7 +18,7 @@
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: "Prep Workload"
@@ -28,7 +28,7 @@
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: "Complete"

--- a/roles/scale_openshift/tasks/main.yml
+++ b/roles/scale_openshift/tasks/main.yml
@@ -3,14 +3,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
   register: benchmark_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: "Starting Scale Pod"
@@ -21,7 +21,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
   register: benchmark_state
 
@@ -35,7 +35,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Scaling Cluster"
@@ -56,7 +56,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/servicemesh/tasks/main.yml
+++ b/roles/servicemesh/tasks/main.yml
@@ -3,19 +3,19 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - name: Define variables
   set_fact:
     servicemesh: "{{ servicemesh_defaults | combine(workload_args, recursive=True) }}"
-    controlplane_namespace: "{{ meta.name }}-controlplane-{{ trunc_uuid }}"
-    workload_namespace: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+    controlplane_namespace: "{{ ansible_operator_meta.name }}-controlplane-{{ trunc_uuid }}"
+    workload_namespace: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
     owner:
       - apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
         kind: Benchmark
-        name: "{{ meta.name }}"
+        name: "{{ ansible_operator_meta.name }}"
         namespace: "{{ operator_namespace }}"
         uid: "{{ resource_state.resources[0].metadata.uid }}"
 
@@ -59,7 +59,7 @@
         apiVersion: hyperfoil.io/v1alpha2
         kind: Hyperfoil
         metadata:
-          name: '{{ meta.name }}-hyperfoil-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-hyperfoil-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
           ownerReferences: "{{ owner }}"
         spec:
@@ -69,7 +69,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Init"
@@ -80,7 +80,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -90,7 +90,7 @@
     k8s_info:
       api_version: hyperfoil.io/v1alpha2
       kind: Hyperfoil
-      name: "{{ meta.name }}-hyperfoil-{{ trunc_uuid }}"
+      name: "{{ ansible_operator_meta.name }}-hyperfoil-{{ trunc_uuid }}"
       namespace: '{{ operator_namespace }}'
     register: hf_state
 
@@ -98,7 +98,7 @@
     k8s_info:
       api_version: maistra.io/v1
       kind: ServiceMeshControlPlane
-      name: '{{ meta.name }}'
+      name: '{{ ansible_operator_meta.name }}'
       namespace: "{{ controlplane_namespace }}"
     register: smcp_state
 
@@ -110,7 +110,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Deploy"
@@ -120,7 +120,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -136,7 +136,7 @@
   when: ingress_route.resources | length > 0
   set_fact:
     #TODO: maybe use trunc_uuid in the hostname?
-    app_route: "{{ meta.name }}-app-{{ trunc_uuid}}{{ ingress_route.resources[0].status.ingress[0].host | regex_replace('^[^.]*', '')}}"
+    app_route: "{{ ansible_operator_meta.name }}-app-{{ trunc_uuid}}{{ ingress_route.resources[0].status.ingress[0].host | regex_replace('^[^.]*', '')}}"
 
 - when: resource_state.resources[0].status.state == "Deploy"
   block:
@@ -200,7 +200,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Ready"
@@ -210,7 +210,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -223,7 +223,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: "{{ meta.name }}-test-{{ trunc_uuid }}"
+          name: "{{ ansible_operator_meta.name }}-test-{{ trunc_uuid }}"
           namespace: '{{ operator_namespace }}'
           ownerReferences: "{{ owner }}"
         data:
@@ -236,7 +236,7 @@
       kind: Pod
       namespace: '{{ operator_namespace }}'
       label_selectors:
-      - app = {{ meta.name }}-hyperfoil-{{ trunc_uuid }}
+      - app = {{ ansible_operator_meta.name }}-hyperfoil-{{ trunc_uuid }}
       - role = controller
     register: hf_pod
 
@@ -248,7 +248,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Running"
@@ -258,7 +258,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -269,7 +269,7 @@
       api_version: v1
       kind: Job
       namespace: '{{ operator_namespace }}'
-      name: "{{ meta.name }}-{{ trunc_uuid }}"
+      name: "{{ ansible_operator_meta.name }}-{{ trunc_uuid }}"
     register: job_state
 
   - name: Complete benchmark
@@ -277,7 +277,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Complete"
@@ -288,7 +288,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Failed"
@@ -298,7 +298,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -311,7 +311,7 @@
         apiVersion: hyperfoil.io/v1alpha2
         kind: Hyperfoil
         metadata:
-          name: '{{ meta.name }}-hyperfoil-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-hyperfoil-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
 
   - name: Delete config map
@@ -321,7 +321,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ meta.name }}-test-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-test-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
 
   - name: Delete workload namespace

--- a/roles/servicemesh/templates/job.yaml.j2
+++ b/roles/servicemesh/templates/job.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ meta.name }}-{{ trunc_uuid }}"
+  name: "{{ ansible_operator_meta.name }}-{{ trunc_uuid }}"
   namespace: '{{ operator_namespace }}'
   ownerReferences: "{{ owner }}"
 spec:
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-      app: "{{ meta.name }}-{{ trunc_uuid }}"
+      app: "{{ ansible_operator_meta.name }}-{{ trunc_uuid }}"
     spec:
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
@@ -31,4 +31,4 @@ spec:
       - name: files
         configMap:
           defaultMode: 493
-          name: "{{ meta.name }}-test-{{ trunc_uuid }}"
+          name: "{{ ansible_operator_meta.name }}-test-{{ trunc_uuid }}"

--- a/roles/servicemesh/templates/smcp.yaml.j2
+++ b/roles/servicemesh/templates/smcp.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: maistra.io/v1
 kind: ServiceMeshControlPlane
 metadata:
-  name: "{{ meta.name }}"
+  name: "{{ ansible_operator_meta.name }}"
   namespace: "{{ controlplane_namespace }}"
 spec:
   istio:

--- a/roles/smallfile/tasks/main.yml
+++ b/roles/smallfile/tasks/main.yml
@@ -3,7 +3,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -11,7 +11,7 @@
   operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Starting
@@ -22,7 +22,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -120,7 +120,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Running
@@ -142,7 +142,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/stressng/tasks/main.yaml
+++ b/roles/stressng/tasks/main.yaml
@@ -3,14 +3,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Building
@@ -21,7 +21,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -33,7 +33,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ meta.name }}-workload-{{ trunc_uuid }}'
+          name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
         data:
           jobfile: "{{ lookup ('template', 'jobfile.j2') }}"
@@ -41,7 +41,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: ConfigMaps Created
@@ -68,7 +68,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Benchmark running
@@ -82,14 +82,14 @@
       k8s_facts:
         kind: Job
         api_version: batch/v1
-        name: '{{ meta.name }}-workload-{{ trunc_uuid }}'
+        name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
         namespace: "{{ operator_namespace }}"
       register: stressng_workload_pod
 
     - operator_sdk.util.k8s_status:
         api_version: ripsaw.cloudbulldozer.io/v1alpha
         kind: Benchmark
-        name: "{{ meta.name }}"
+        name: "{{ ansible_operator_meta.name }}"
         namespace: "{{ operator_namespace }}"
         status:
           state: Benchmark Complete
@@ -104,7 +104,7 @@
       - operator_sdk.util.k8s_status:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
           kind: Benchmark
-          name: "{{ meta.name }}"
+          name: "{{ ansible_operator_meta.name }}"
           namespace: "{{ operator_namespace }}"
           status:
             state: Benchmark Complete

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: "job"
 metadata:
-  name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+  name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
   namespace: "{{ operator_namespace }}"
 spec:
   parallelism: {{ workload_args.instances }}
@@ -87,7 +87,7 @@ spec:
       volumes:
       - name: stressng-workload-volume
         configMap:
-          name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+          name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0660
       restartPolicy: OnFailure
 {% include "metadata.yml.j2" %}

--- a/roles/stressng/templates/stressng_workload_vm.yml.j2
+++ b/roles/stressng/templates/stressng_workload_vm.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: kubevirt.io/v1alpha3
 kind: VirtualMachineInstance
 metadata:
-  name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+  name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
   namespace: "{{ operator_namespace }}"
 spec:
   domain:
@@ -73,6 +73,6 @@ spec:
             ;
     name: cloudinitdisk
   - configMap:
-      name: "{{ meta.name }}-workload-{{ trunc_uuid }}"
+      name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
     name: stressng-workload-volume
 status: {}

--- a/roles/sysbench/tasks/main.yml
+++ b/roles/sysbench/tasks/main.yml
@@ -4,14 +4,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Starting
@@ -22,7 +22,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -53,7 +53,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Running
@@ -75,7 +75,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/system-metrics/tasks/main.yml
+++ b/roles/system-metrics/tasks/main.yml
@@ -30,7 +30,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         system_metrics: Collecting
@@ -49,7 +49,7 @@
   operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       system_metrics: Collected

--- a/roles/testpmd/tasks/main.yml
+++ b/roles/testpmd/tasks/main.yml
@@ -3,14 +3,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Starting
@@ -21,7 +21,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -55,7 +55,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting TestPMD"
@@ -77,7 +77,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting TRex"
@@ -114,7 +114,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Waiting for TRex"  
@@ -135,7 +135,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Running
@@ -157,7 +157,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/uperf/tasks/cleanup.yml
+++ b/roles/uperf/tasks/cleanup.yml
@@ -9,7 +9,7 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
+        - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_jobs
 
   - name: Get Server Pods
@@ -18,7 +18,7 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
+        - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_pods
 
   - name: Server Job and Pod names - to clean
@@ -74,7 +74,7 @@
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Complete

--- a/roles/uperf/tasks/init.yml
+++ b/roles/uperf/tasks/init.yml
@@ -10,7 +10,7 @@
   operator_sdk.util.k8s_status:
      api_version: ripsaw.cloudbulldozer.io/v1alpha1
      kind: Benchmark
-     name: "{{ meta.name }}"
+     name: "{{ ansible_operator_meta.name }}"
      namespace: "{{ operator_namespace }}"
      status:
         pod_hi_idx: "{{pod_hi_idx}}"

--- a/roles/uperf/tasks/next_set.yml
+++ b/roles/uperf/tasks/next_set.yml
@@ -67,7 +67,7 @@
       operator_sdk.util.k8s_status:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
           kind: Benchmark
-          name: "{{ meta.name }}"
+          name: "{{ ansible_operator_meta.name }}"
           namespace: "{{ operator_namespace }}"
           status:
             state: Running
@@ -88,7 +88,7 @@
       operator_sdk.util.k8s_status:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
           kind: Benchmark
-          name: "{{ meta.name }}"
+          name: "{{ ansible_operator_meta.name }}"
           namespace: "{{ operator_namespace }}"
           status:
             state: Clients Running

--- a/roles/uperf/tasks/run_a_set.yml
+++ b/roles/uperf/tasks/run_a_set.yml
@@ -15,7 +15,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Set Running

--- a/roles/uperf/tasks/send_client_run_signal.yml
+++ b/roles/uperf/tasks/send_client_run_signal.yml
@@ -9,7 +9,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Running"

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -4,14 +4,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Building
@@ -22,7 +22,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -161,7 +161,7 @@
     api_version: v1
     namespace: '{{ operator_namespace }}'
     label_selectors:
-      - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
+      - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
   register: serviceip
   when: workload_args.serviceip is defined and workload_args.serviceip
 

--- a/roles/uperf/tasks/start_client.yml
+++ b/roles/uperf/tasks/start_client.yml
@@ -6,7 +6,7 @@
     api_version: v1
     namespace: '{{ operator_namespace }}'
     label_selectors:
-      - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
+      - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
   register: server_pods
 
 - name: Generate uperf xml files
@@ -45,7 +45,7 @@
       api_version: kubevirt.io/v1alpha3
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
+        - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_vms
 
 
@@ -65,7 +65,7 @@
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Waiting for Clients

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -30,14 +30,14 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
+        - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_pods
 
   - name: Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Servers"
@@ -58,14 +58,14 @@
       api_version: kubevirt.io/v1alpha3
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
+        - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_vms
 
   - name: Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Servers"

--- a/roles/uperf/tasks/wait_client_done.yml
+++ b/roles/uperf/tasks/wait_client_done.yml
@@ -13,7 +13,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Cleanup
@@ -30,7 +30,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Cleanup

--- a/roles/uperf/tasks/wait_client_ready.yml
+++ b/roles/uperf/tasks/wait_client_ready.yml
@@ -16,7 +16,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Clients Running
@@ -38,7 +38,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Clients Running

--- a/roles/uperf/tasks/wait_server_ready.yml
+++ b/roles/uperf/tasks/wait_server_ready.yml
@@ -8,14 +8,14 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
+        - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_pods
 
   - name: Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Clients"
@@ -32,14 +32,14 @@
       api_version: kubevirt.io/v1alpha3
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - type = {{ meta.name }}-bench-server-{{ trunc_uuid }}
+        - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_vms
 
   - name: Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Clients"

--- a/roles/uperf/tasks/wait_set_done.yml
+++ b/roles/uperf/tasks/wait_set_done.yml
@@ -10,7 +10,7 @@
     - operator_sdk.util.k8s_status:
           api_version: ripsaw.cloudbulldozer.io/v1alpha1
           kind: Benchmark
-          name: "{{ meta.name }}"
+          name: "{{ ansible_operator_meta.name }}"
           namespace: "{{ operator_namespace }}"
           status:
             state: Run Next Set

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -16,7 +16,7 @@ items:
         metadata:
           labels:
             app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(27,true,'') }}-{{ item  }}-{{ trunc_uuid }}
-            type: {{ meta.name }}-bench-server-{{ trunc_uuid }}
+            type: {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
           annotations:
 {% if workload_args.multus.enabled is sameas true %}
             k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.server}}

--- a/roles/uperf/templates/server_vm.yml.j2
+++ b/roles/uperf/templates/server_vm.yml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: '{{ operator_namespace }}'
   labels:
     app : uperf-bench-server-{{ item }}-{{ trunc_uuid }}
-    type : {{ meta.name }}-bench-server-{{ trunc_uuid }}
+    type : {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
 spec:
   domain:
     cpu:

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -11,7 +11,7 @@ items:
       namespace: '{{ operator_namespace }}'
       labels:
         app: uperf-bench-server-{{ worker_node_list[ node_idx_item ] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
-        type: {{ meta.name }}-bench-server-{{ trunc_uuid }}
+        type: {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
       annotations:
         node_idx: '{{ node_idx_item }}'
         pod_idx: '{{ item }}'

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -19,7 +19,7 @@ items:
           labels:
             app: uperf-bench-client-{{ trunc_uuid }}
             clientfor: {{ item.metadata.labels.app }}
-            type: {{ meta.name }}-bench-client-{{ trunc_uuid }}
+            type: {{ ansible_operator_meta.name }}-bench-client-{{ trunc_uuid }}
 {% if workload_args.multus.enabled is sameas true %}
           annotations:
             k8s.v1.cni.cncf.io/networks: {{ workload_args.multus.client }}

--- a/roles/uperf/templates/workload_vm.yml.j2
+++ b/roles/uperf/templates/workload_vm.yml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: '{{ operator_namespace }}'
   labels:
     app: uperf-bench-client-{{ trunc_uuid }}
-    type: {{ meta.name }}-bench-client-{{ trunc_uuid }}
+    type: {{ ansible_operator_meta.name }}-bench-client-{{ trunc_uuid }}
 spec:
   domain:
     cpu:

--- a/roles/vegeta/tasks/main.yml
+++ b/roles/vegeta/tasks/main.yml
@@ -4,14 +4,14 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Building
@@ -22,7 +22,7 @@
   k8s_info:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: '{{ meta.name }}'
+    name: '{{ ansible_operator_meta.name }}'
     namespace: '{{ operator_namespace }}'
   register: resource_state
 
@@ -49,7 +49,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Running
@@ -72,7 +72,7 @@
   - operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: Complete

--- a/roles/ycsb/tasks/main.yml
+++ b/roles/ycsb/tasks/main.yml
@@ -3,14 +3,14 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
   register: resource_state
 
 - operator_sdk.util.k8s_status:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
       state: Building
@@ -21,7 +21,7 @@
   k8s_facts:
     api_version: ripsaw.cloudbulldozer.io/v1alpha1
     kind: Benchmark
-    name: "{{ meta.name }}"
+    name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
   register: resource_state
 
@@ -44,7 +44,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Running Load"
@@ -54,7 +54,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting First Workload"
@@ -82,7 +82,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting First Workload"
@@ -92,7 +92,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Complete"
@@ -103,16 +103,16 @@
 - block:
 
   - name: Add the workload list length to redis
-    command: "redis-cli set {{ meta.name }}-{{ uuid }}-ycsb {{ workload_args.workloads|length }}"
+    command: "redis-cli set {{ ansible_operator_meta.name }}-{{ uuid }}-ycsb {{ workload_args.workloads|length }}"
 
   - name: Add the first workload index to redis
-    command: "redis-cli set {{ meta.name }}-{{ uuid }}-ycsb-current 0"
+    command: "redis-cli set {{ ansible_operator_meta.name }}-{{ uuid }}-ycsb-current 0"
     
   - name: Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Workload"
@@ -122,7 +122,7 @@
 - block:
    
   - name: Get current workload index
-    command: "redis-cli get {{ meta.name }}-{{ uuid }}-ycsb-current"
+    command: "redis-cli get {{ ansible_operator_meta.name }}-{{ uuid }}-ycsb-current"
     register: wrkload
 
   - name: set ycsb_workload variable
@@ -141,7 +141,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Running Workload"
@@ -151,7 +151,7 @@
 - block:
 
   - name: Get current workload from redis
-    command: "redis-cli get {{ meta.name }}-{{ uuid }}-ycsb-current"
+    command: "redis-cli get {{ ansible_operator_meta.name }}-{{ uuid }}-ycsb-current"
     register: wrkload
 
   - name: set ycsb_workload variable
@@ -172,7 +172,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Workload Complete"
@@ -183,11 +183,11 @@
 - block:
 
   - name: Get current workload from redis
-    command: "redis-cli get {{ meta.name }}-{{ uuid }}-ycsb-current"
+    command: "redis-cli get {{ ansible_operator_meta.name }}-{{ uuid }}-ycsb-current"
     register: current_workload
 
   - name: Get list length of workloads from redis
-    command: "redis-cli get {{ meta.name }}-{{ uuid }}-ycsb"
+    command: "redis-cli get {{ ansible_operator_meta.name }}-{{ uuid }}-ycsb"
     register: workload_list
 
   - name: Iterate index
@@ -195,13 +195,13 @@
       new_workload_index: "{{ current_workload.stdout|int + 1 }}"
 
   - name: Update current workload item in redis
-    command: "redis-cli set {{ meta.name }}-{{ uuid }}-ycsb-current {{ new_workload_index }}"
+    command: "redis-cli set {{ ansible_operator_meta.name }}-{{ uuid }}-ycsb-current {{ new_workload_index }}"
   
   - name: Update resource state
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Starting Workload"
@@ -211,7 +211,7 @@
     operator_sdk.util.k8s_status:
       api_version: ripsaw.cloudbulldozer.io/v1alpha1
       kind: Benchmark
-      name: "{{ meta.name }}"
+      name: "{{ ansible_operator_meta.name }}"
       namespace: "{{ operator_namespace }}"
       status:
         state: "Complete"

--- a/roles/ycsb/templates/ycsb_load.yaml
+++ b/roles/ycsb/templates/ycsb_load.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: '{{ meta.name }}-ycsb-data-load'
+      name: '{{ ansible_operator_meta.name }}-ycsb-data-load'
       namespace: '{{ operator_namespace }}'
       labels:
         name: 'ycsb-load-{{ trunc_uuid }}'

--- a/roles/ycsb/templates/ycsb_run.yaml
+++ b/roles/ycsb/templates/ycsb_run.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: '{{ meta.name }}-ycsb-bench'
+      name: '{{ ansible_operator_meta.name }}-ycsb-bench'
       namespace: '{{ operator_namespace }}'
       labels:
         name: 'ycsb-run-{{ trunc_uuid }}'

--- a/templates/metadata.yml.j2
+++ b/templates/metadata.yml.j2
@@ -19,9 +19,9 @@
 {% if metadata.force is sameas true %}
             --force
 {% endif %}
-            --tags={{ metadata.stockpile_tags|default(["common", "k8s", "openshift"])|join(",") }}
-{% if metadata.stockpile_skip_tags|length > 0 %}
-            --skip-tags={{ metadata.stockpile_skip_tags|join(",") }}
+            --tags={{ metadata.stockpileTags|default(["common", "k8s", "openshift"])|join(",") }}
+{% if metadata.stockpileSkipTags|length > 0 %}
+            --skip-tags={{ metadata.stockpileSkipTags|join(",") }}
 {% endif %}
 {% if metadata.ssl is sameas true %}
             --sslskipverify True

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -266,9 +266,7 @@ function error {
 
   echo "Error caught. Dumping logs before exiting"
   echo "Benchmark operator Logs"
-  kubectl -n my-ripsaw logs --tail=40 -l name=benchmark-operator -c benchmark-operator
-  echo "Ansible sidecar Logs"
-  kubectl -n my-ripsaw logs -l name=benchmark-operator -c ansible
+  kubectl -n my-ripsaw logs --tail=200 -l name=benchmark-operator -c benchmark-operator
 }
 
 function wait_for_backpack() {

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -213,7 +213,7 @@ function cleanup_operator_resources {
 
 function update_operator_image {
   tag_name="${NODE_NAME:-master}"
-  if operator-sdk build $image_location/$image_account/benchmark-operator:$tag_name --image-builder podman; then
+  if podman build -f build/Dockerfile -t $image_location/$image_account/benchmark-operator:$tag_name .; then
   # In case we have issues uploading to quay we will retry a few times
     for i in {1..3}; do
       podman push $image_location/$image_account/benchmark-operator:$tag_name && break


### PR DESCRIPTION
### Description

Updating operator-sdk version. Had to update snake_case variables by CamelCase because [snakeCaseParameters](https://sdk.operatorframework.io/docs/building-operators/ansible/reference/watches/) parameter works in this version.
https://github.com/cloud-bulldozer/benchmark-operator/blob/master/watches.yaml#L8

Also replacing `operator-sdk build` command by `podman build` as `operator-sdk build` is no longer available in the operator-sdk cli.
