### PR TITLE
API & golang metrics

### DIFF
--- a/roles/kube-burner/files/metrics-aggregated.yaml
+++ b/roles/kube-burner/files/metrics-aggregated.yaml
@@ -1,4 +1,18 @@
 metrics:
+# API server
+  - query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!~"WATCH", subresource!="log"}[2m])) by (verb,resource,subresource,instance,le)) > 0
+    metricName: API99thLatency
+
+  - query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH",subresource!="log"}[2m])) by (verb,instance,resource,code) > 0
+    metricName: APIRequestRate
+
+  - query: sum(apiserver_current_inflight_requests{}) by (request_kind) > 0
+    metricName: APIInflightRequests
+
+# Container & pod metrics
+  - query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
+    metricName: containerMemory-Masters
+
   - query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|sdn|ovn-kubernetes|.*apiserver|authentication|.*controller-manager|.*scheduler)"}[2m]) * 100) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
     metricName: containerCPU-Masters
 
@@ -11,12 +25,6 @@ metrics:
   - query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring|image-registry|logging)"}[2m]) * 100 and on (node) kube_node_role{role="infra"}) by (namespace, container)) > 0
     metricName: containerCPU-AggregatedInfra
 
-  - query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH"}[5m])) by (le, verb)) > 0
-    metricName: API99thLatency
-
-  - query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
-    metricName: containerMemory-Masters
-
   - query: (sum(container_memory_rss{pod!="",namespace="openshift-monitoring",name!="",container="prometheus"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
     metricName: containerMemory-Prometheus
 
@@ -26,18 +34,7 @@ metrics:
   - query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring|image-registry|logging)"} and on (node) kube_node_role{role="infra"}) by (container, namespace)
     metricName: containerMemory-AggregatedInfra
 
-  - query: avg(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100 and on (node) kube_node_role{role="worker"})
-    metricName: KubeletCPU-AggregatedWorkers
-
-  - query: avg(process_resident_memory_bytes{service="kubelet",job="kubelet"} and on (node) kube_node_role{role="worker"})
-    metricName: KubeletMemory-AggregatedWorkers
-
-  - query: avg(irate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m]) * 100  and on (node) kube_node_role{role="worker"})
-    metricName: CrioCPU-AggregatedWorkers
-
-  - query: avg(process_resident_memory_bytes{service="kubelet",job="crio"} and on (node) kube_node_role{role="worker"})
-    metricName: CrioMemory-AggregatedWorkers
-
+# Node metrics
   - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
     metricName: nodeCPU-Masters
 
@@ -92,24 +89,6 @@ metrics:
   - query: avg(irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
     metricName: txNetworkBytes-AggregatedInfra
 
-  - query: (irate(node_network_receive_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
-    metricName: rxDroppedPackets-Masters
-
-  - query: (avg(irate(node_network_receive_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)) > 0
-    metricName: rxDroppedPackets-AggregatedWorkers
-
-  - query: (avg(irate(node_network_receive_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)) > 0
-    metricName: rxDroppedPackets-AggregatedInfra
-
-  - query: irate(node_network_transmit_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-    metricName: txDroppedPackets-Masters
-
-  - query: (avg(irate(node_network_transmit_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)) > 0
-    metricName: txDroppedPackets-AggregatedWorkers
-
-  - query: (avg(irate(node_network_transmit_drop_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)) > 0
-    metricName: txDroppedPackets-AggregatedInfra
-
   - query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
     metricName: nodeDiskWrittenBytes-Masters
 
@@ -128,6 +107,7 @@ metrics:
   - query: avg(rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
     metricName: nodeDiskReadBytes-AggregatedInfra
 
+# Etcd metrics
   - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
     metricName: etcdLeaderChangesRate
 
@@ -149,6 +129,17 @@ metrics:
   - query: etcd_mvcc_db_total_size_in_use_in_bytes
     metricName: etcdDBLogicalSizeBytes
 
+  - query: sum by (cluster_version)(etcd_cluster_version)
+    metricName: etcdVersion
+    instant: true
+
+  - query: sum(rate(etcd_object_counts{}[5m])) by (resource) > 0
+    metricName: etcdObjectCount
+
+  - query: histogram_quantile(0.99,sum(rate(etcd_request_duration_seconds_bucket[2m])) by (le,operation,apiserver)) > 0
+    metricName: P99APIEtcdRequestLatency
+
+# Cluster metrics
   - query: count(kube_namespace_created)
     metricName: namespaceCount
 
@@ -177,13 +168,17 @@ metrics:
   - query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
     metricName: containerDiskUsage
 
-  - query: sum(rate(etcd_object_counts{}[5m])) by (resource) > 0
-    metricName: etcdObjectCount
-
   - query: cluster_version{type="completed"}
     metricName: clusterVersion
     instant: true
 
-  - query: sum by (cluster_version)(etcd_cluster_version)
-    metricName: etcdVersion
-    instant: true
+# Golang metrics
+
+  - query: go_memstats_heap_alloc_bytes{job=~"apiserver|api|etcd"}
+    metricName: goHeapAllocBytes
+
+  - query: go_memstats_heap_inuse_bytes{job=~"apiserver|api|etcd"}
+    metricName: goHeapInuseBytes
+  
+  - query: go_gc_duration_seconds{job=~"apiserver|api|etcd",quantile="1"}
+    metricName: goGCDurationSeconds

--- a/roles/kube-burner/files/metrics.yaml
+++ b/roles/kube-burner/files/metrics.yaml
@@ -1,13 +1,25 @@
 metrics:
+# API server
+  - query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!~"WATCH", subresource!="log"}[2m])) by (verb,resource,subresource,instance,le)) > 0
+    metricName: API99thLatency
+
+  - query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH",subresource!="log"}[2m])) by (verb,instance,resource,code) > 0
+    metricName: APIRequestRate
+
+  - query: sum(apiserver_current_inflight_requests{}) by (request_kind) > 0
+    metricName: APIInflightRequests
+
+# Containers & pod metrics
   - query: sum(irate(container_cpu_usage_seconds_total{name!="",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|monitoring|logging|image-registry)"}[2m]) * 100) by (pod, namespace, node)
     metricName: podCPU
-
-  - query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH"}[5m])) by (le, verb)) > 0
-    metricName: API99thLatency
 
   - query: sum(container_memory_rss{name!="",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|monitoring|logging|image-registry)"}) by (pod, namespace, node)
     metricName: podMemory
 
+  - query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
+    metricName: containerDiskUsage
+
+# Kubelet & CRI-O metrics
   - query: sum(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
     metricName: kubeletCPU
 
@@ -20,6 +32,7 @@ metrics:
   - query: sum(process_resident_memory_bytes{service="kubelet",job="crio"}) by (node) and on (node) kube_node_role{role="worker"}
     metricName: crioMemory
 
+# Node metrics
   - query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0
     metricName: nodeCPU
 
@@ -38,12 +51,6 @@ metrics:
   - query: irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
     metricName: txNetworkBytes
 
-  - query: irate(node_network_receive_drop_total{device=~"^(ens|eth|bond|team).*"}[2m])
-    metricName: rxDroppedPackets
-
-  - query: irate(node_network_transmit_drop_total{device=~"^(ens|eth|bond|team).*"}[2m])
-    metricName: txDroppedPackets
-
   - query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m])
     metricName: nodeDiskWrittenBytes
 
@@ -53,6 +60,7 @@ metrics:
   - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
     metricName: etcdLeaderChangesRate
 
+# Etcd metrics
   - query: etcd_server_is_leader > 0
     metricName: etcdServerIsLeader
 
@@ -71,6 +79,14 @@ metrics:
   - query: etcd_mvcc_db_total_size_in_use_in_bytes
     metricName: etcdDBLogicalSizeBytes
 
+  - query: sum(rate(etcd_object_counts{}[5m])) by (resource) > 0
+    metricName: etcdObjectCount
+
+  - query: sum by (cluster_version)(etcd_cluster_version)
+    metricName: etcdVersion
+    instant: true
+
+# Cluster metrics
   - query: count(kube_namespace_created)
     metricName: namespaceCount
 
@@ -96,16 +112,6 @@ metrics:
   - query: sum(kube_node_status_condition{status="true"}) by (condition)
     metricName: nodeStatus
 
-  - query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
-    metricName: containerDiskUsage
-
-  - query: sum(rate(etcd_object_counts{}[5m])) by (resource) > 0
-    metricName: etcdObjectCount
-
   - query: cluster_version{type="completed"}
     metricName: clusterVersion
-    instant: true
-
-  - query: sum by (cluster_version)(etcd_cluster_version)
-    metricName: etcdVersion
     instant: true


### PR DESCRIPTION
### Description

- Add more API metrics to metrics-aggregated.yaml
- Add some comments
- Remove drop packet metrics. We should not use these reports to check for dropped packets. The dashboards provided by dittybopper should be used for this purpose
- Remove kubelet and cri-o metrics from metrics-aggregated.yaml. We don' use them here, these metrics fit better on the metrics.yaml profile (default for node-density)
- Add heap and gc metrics


Signed-off-by: Raul Sevilla <rsevilla@redhat.com>