### PR TITLE
Enhance node-density heavy to use livenessprobes

### DIFF
--- a/roles/kube-burner/files/app-deployment.yml
+++ b/roles/kube-burner/files/app-deployment.yml
@@ -46,7 +46,6 @@ spec:
           value: '5432'
         - name: POSTGRESQL_RETRY_INTERVAL
           value: '5'
-        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false
       restartPolicy: Always

--- a/roles/kube-burner/files/app-deployment.yml
+++ b/roles/kube-burner/files/app-deployment.yml
@@ -13,6 +13,7 @@ spec:
       containers:
       - name: perfapp
         image: quay.io/rsevilla/perfapp:latest
+        imagePullPolicy: Always
         readinessProbe:
           httpGet:
             path: /ready
@@ -20,6 +21,14 @@ spec:
           periodSeconds: {{ .readinessPeriod }}
           failureThreshold: 1
           timeoutSeconds: 60
+          initialDelaySeconds: 30
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          periodSeconds: {{ .livenessPeriod }}
+          failureThreshold: 1
+          timeoutSeconds: 15
           initialDelaySeconds: 30
         ports:
         - containerPort: 8080

--- a/roles/kube-burner/templates/max-namespaces.yml.j2
+++ b/roles/kube-burner/templates/max-namespaces.yml.j2
@@ -37,6 +37,7 @@ jobs:
         replicas: 5
         inputVars:
           readinessPeriod: 10
+          livenessPeriod: 10
           nodeSelectorKey: {{ workload_args.node_selector.key|default("node-role.kubernetes.io/worker") }}
           nodeSelectorValue: "{{ workload_args.node_selector.value|default("") }}"
 

--- a/roles/kube-burner/templates/node-density-heavy.yml.j2
+++ b/roles/kube-burner/templates/node-density-heavy.yml.j2
@@ -37,6 +37,7 @@ jobs:
         replicas: 1
         inputVars:
           readinessPeriod: 10
+          livenessPeriod: 10
           nodeSelectorKey: {{ workload_args.node_selector.key|default("node-role.kubernetes.io/worker") }}
           nodeSelectorValue: "{{ workload_args.node_selector.value|default("") }}"
 


### PR DESCRIPTION
Using livenessprobes in addition to readinessprobes increases the load
on the kubelet which is what we want with this test.

### Description

### Fixes
