### PR TITLE
Adding Image Pull workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ helm delete benchmark-operator -n my-ripsaw --purge
 | [testpmd](docs/testpmd.md)         | TestPMD DPDK App      | No           |  Used   | Not Supported          | Preview         | No |
 | [Flent](docs/flent.md)         | Network Performance    | Yes           |  Used, default : 3second  | Not Supported          | Not Supported   | Yes |
 | [Log-Generator](docs/log_generator.md)         | Log Throughput to Backend    | Yes           |  Used, default : 3second  | Not Supported          | Yes  | Yes |
+| [Image-Pull](docs/image_pull.md)         | Time to Pull Image from Container Repo    | Yes           |  Used, default : 3second  | Not Supported          | Yes  | Yes |
 
 ### Reconciliation
 

--- a/docs/image_pull.md
+++ b/docs/image_pull.md
@@ -1,0 +1,50 @@
+# Image Pull
+
+## What does it do?
+
+The Image Pull workload will take a list of images that exist in a container repository (e.x. Quay)
+and copy them to the containers local working directory via [skopeo](https://github.com/containers/skopeo).
+It will then display and/or index relevant data regarding the amount of time it took as well as any retries
+or failures that occurred.
+
+Additioanlly, it can be configured to run multiple pods at the same time, each reporting its own relevant data.
+This allows the user to test concurrency of image pulls on a container image.
+
+## Variables
+
+### Required variables:
+
+`image_list` a list of images in the format [image_transport]://[image_location]
+
+### Optional variables:
+
+`pod_count` total number of concurrent pods/tests to run (default: 1)
+
+`timeout` how long, in seconds, to wait for the image to copy (default: 600)
+
+`retries` how many times to retry failed copies (default: 0)
+
+### Example CR
+
+Your resource file may look like this when running 10 concurrent pods with 1 retry:
+
+```yaml
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: image-pull
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    url: "http://es-instance.com:9200"
+    index_name: "image-pull"
+  workload:
+    name: image_pull
+    args:
+      pod_count: 2
+      timeout: 600
+      retries: 1
+      image_list:
+        - docker://quay.io/cloud-bulldozer/backpack
+        - docker://quay.io/cloud-bulldozer/fio
+```

--- a/roles/image_pull/tasks/main.yml
+++ b/roles/image_pull/tasks/main.yml
@@ -1,0 +1,89 @@
+---
+- name: Get benchmark state
+  k8s_facts:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ operator_namespace }}"
+  register: benchmark_state
+
+- operator_sdk.util.k8s_status:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ operator_namespace }}"
+    status:
+      state: "Starting Image Pull Pods"
+      complete: false
+  when: benchmark_state.resources[0].status.state is not defined
+
+- name: Get benchmark state 
+  k8s_facts:
+    api_version: ripsaw.cloudbulldozer.io/v1alpha1
+    kind: Benchmark
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ operator_namespace }}"
+  register: benchmark_state
+
+- block:
+  
+  - name: Image pull pods
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'image_pull.yml') }}"
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ ansible_operator_meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Building Pods"
+
+  when: benchmark_state.resources[0].status.state == "Starting Image Pull Pods"
+
+- block:
+
+  - name: Get server pods
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - app = image-pull-{{ trunc_uuid }}
+    register: image_pods
+
+  - name: Update resource state
+    operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ ansible_operator_meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Image Pull Pods Running"
+    when: "workload_args.pod_count|default('1')|int == image_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
+  
+  when: benchmark_state.resources[0].status.state == "Building Pods"
+
+- block:
+
+  - name: Get server pods
+    k8s_facts:
+      kind: Pod
+      api_version: v1
+      namespace: '{{ operator_namespace }}'
+      label_selectors:
+        - app = image-pull-{{ trunc_uuid }}
+    register: image_pods
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ ansible_operator_meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: Complete
+        complete: true
+    when: "workload_args.pod_count|default('1')|int == (image_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
+
+  when: benchmark_state.resources[0].status.state == "Image Pull Pods Running"

--- a/roles/image_pull/templates/image_pull.yml
+++ b/roles/image_pull/templates/image_pull.yml
@@ -1,0 +1,101 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: 'image-pull-{{ trunc_uuid }}'
+  namespace: '{{ operator_namespace }}'
+spec:
+  parallelism: {{ workload_args.pod_count | default(1) | int }}
+  template:
+    metadata:
+      labels:
+        app: image-pull-{{ trunc_uuid }}
+    spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
+{% if workload_args.tolerations is defined %}
+      tolerations:
+      - key: {{ workload_args.tolerations.key }}
+        value: {{ workload_args.tolerations.value }}
+        effect: {{ workload_args.tolerations.effect }}
+{% endif %}
+{% if workload_args.label is defined %}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ workload_args.label.key }}
+                operator: In
+                values:
+                - {{ workload_args.label.value }}
+{% endif %}
+      containers:
+      - image: {{ workload_args.image | default('quay.io/cloud-bulldozer/image_pull:latest') }}
+        name: pull-image
+        env:
+          - name: my_node_name
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: my_pod_name
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: uuid
+            value: "{{ uuid }}"
+          - name: test_user
+            value: "{{ test_user | default("ripsaw") }}"
+          - name: clustername
+            value: "{{ clustername }}"
+{% if elasticsearch is defined %}
+          - name: es
+            value: "{{ elasticsearch.url }}"
+          - name: es_index
+            value: "{{ elasticsearch.index_name | default("image-pull") }}"
+          - name: es_verify_cert
+            value: "{{ elasticsearch.verify_cert | default(true) }}"
+          - name: parallel
+            value: "{{ elasticsearch.parallel | default(false) }}"
+{% endif %}
+{% if prometheus is defined %}
+          - name: prom_es
+            value: "{{ prometheus.es_url }}"
+          - name: prom_parallel
+            value: "{{ prometheus.es_parallel | default(false) }}"
+          - name: prom_token
+            value: "{{ prometheus.prom_token | default() }}"
+          - name: prom_url
+            value: "{{ prometheus.prom_url | default() }}"
+{% endif %}
+        command: ["/bin/sh", "-c"]
+        args:
+          - > 
+{% for my_image in workload_args.image_list %}
+            echo "Testing image: {{ my_image }}";
+            echo "Waiting for all pods to be Ready";
+            redis-cli -h {{ bo.resources[0].status.podIP }} INCR "image-pull-{{ trunc_uuid }}" > /dev/null 2>&1;
+            pods=`redis-cli -h {{ bo.resources[0].status.podIP }} GET "image-pull-{{ trunc_uuid }}"`;
+            while [[ $pods != {{ workload_args.pod_count | default(1) | string }} ]]; do
+              pods=`redis-cli -h {{ bo.resources[0].status.podIP }} GET "image-pull-{{ trunc_uuid }}"`;
+              sleep .5;
+            done;
+            sleep 2;
+            redis-cli -h {{ bo.resources[0].status.podIP }} DECR "image-pull-{{ trunc_uuid }}" > /dev/null 2>&1;
+            date;
+            run_snafu
+            --tool image_pull
+{% if workload_args.debug is defined and workload_args.debug %}
+            -v
+{% endif %}
+            -u "{{ uuid }}"
+            --pod-name ${my_pod_name}
+            --timeout "{{ workload_args.timeout | default(600) }}"
+            --pod-count {{ workload_args.pod_count | default(1) | int }}
+            --retries {{ workload_args.retries | default(0) | int }}
+            --image "{{ my_image }}";
+{% endfor %}
+      imagePullPolicy: Always
+      restartPolicy: Never
+{% include "metadata.yml.j2" %}

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -29,6 +29,7 @@ function populate_test_list {
     if [[ $(echo ${item} | grep 'roles/kube-burner') ]]; then echo "test_kubeburner.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'roles/flent') ]]; then echo "test_flent.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'roles/log_generator') ]]; then echo "test_log_generator.sh" >> tests/iterate_tests; fi
+    if [[ $(echo ${item} | grep 'roles/image_pull') ]]; then echo "test_image_pull.sh" >> tests/iterate_tests; fi
 
 
     # Check for changes in cr files
@@ -49,6 +50,7 @@ function populate_test_list {
     if [[ $(echo ${item} | grep 'valid_kube-burner*') ]]; then echo "test_kubeburner.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'valid_flent*') ]]; then echo "test_flent.sh" >> tests/iterate_tests; fi
     if [[ $(echo ${item} | grep 'valid_log_generator*') ]]; then echo "test_log_generator.sh" >> tests/iterate_tests; fi
+    if [[ $(echo ${item} | grep 'valid_image_pull*') ]]; then echo "test_image_pull.sh" >> tests/iterate_tests; fi
 
 
     # Check for changes in test scripts

--- a/tests/test_crs/valid_image_pull.yaml
+++ b/tests/test_crs/valid_image_pull.yaml
@@ -1,0 +1,18 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: image-pull
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    url: ES_SERVER
+    index_name: "image-pull"
+  workload:
+    name: image_pull
+    args:
+      pod_count: 2
+      timeout: 100
+      retries: 1
+      image_list:
+        - docker://quay.io/cloud-bulldozer/backpack
+        - docker://quay.io/cloud-bulldozer/fio

--- a/tests/test_image_pull.sh
+++ b/tests/test_image_pull.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -xeEo pipefail
+
+source tests/common.sh
+
+function finish {
+  if [ $? -eq 1 ] && [ $ERRORED != "true" ]
+  then
+    error
+  fi
+
+  echo "Cleaning up Image Pull Test"
+  wait_clean
+}
+
+trap error ERR
+trap finish EXIT
+
+function functional_test_image_pull {
+  wait_clean
+  apply_operator
+  test_name=$1
+  cr=$2
+  
+  echo "Performing: ${test_name}"
+  kubectl apply -f ${cr}
+  long_uuid=$(get_uuid 20)
+  uuid=${long_uuid:0:8}
+
+  pod_count "app=image-pull-$uuid" 2 300
+  wait_for "kubectl wait -n my-ripsaw --for=condition=complete -l app=image-pull-$uuid jobs --timeout=500s" "500s"
+
+  index="image-pull-results"
+  if check_es "${long_uuid}" "${index}"
+  then
+    echo "${test_name} test: Success"
+  else
+    echo "Failed to find data for ${test_name} in ES"
+    exit 1
+  fi
+  kubectl delete -f ${cr}
+}
+
+figlet $(basename $0)
+functional_test_image_pull "Image Pull" tests/test_crs/valid_image_pull.yaml


### PR DESCRIPTION
Depends-On: https://github.com/cloud-bulldozer/benchmark-wrapper/pull/264

### Description

Adding Image Pull workload which takes a list of images to pull and X pod's to do them. It then coordinates each image to be pulled by the pod at roughly the same time (within a few second margin of error). It can then display and index the resultant data around timings, retries, etc.

### Fixes
