### PR TITLE
Adding concurrent builds to benchmark operator

### DIFF
--- a/docs/kube-burner.md
+++ b/docs/kube-burner.md
@@ -63,6 +63,13 @@ Each iteration of this workload creates the following objects:
 Each iteration of this workload creates the following object:
   - 1 pod. (sleep)
 
+- **concurrent-builds**: Creates a buildconfig, imagestream and corresponding build for a set application. **This will create as many namespaces with these objects as the configured job_iterations**. 
+See https://github.com/cloud-bulldozer/e2e-benchmarking/tree/master/workloads/kube-burner/builds for example parameters for each application
+Each iteration of this workload creates the following object:
+  - 1 imagestream (dependent on application type set)
+  - 1 buildconfig (also dependent on application type set)
+  - 1 build created from buildconfig 
+  
 The workload type is specified by the parameter `workload` from the `args` object of the configuration. Each workload supports several configuration parameters, detailed in the [configuration section](#configuration)
 
 ## Configuration

--- a/resources/crds/ripsaw_v1alpha1_concurrent_builds_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_concurrent_builds_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: kube-burner-cluster-density-example
+  name: kube-burner-concurrent-builds-example
   namespace: my-ripsaw
 spec:
   # Metadata information
@@ -19,7 +19,7 @@ spec:
     name: kube-burner
     args:
       # Workload name
-      workload: cluster-density
+      workload: concurrent-builds
       # Kube-burner Job timeout
       job_timeout: 7200
       # ES index name
@@ -56,17 +56,17 @@ spec:
       # remote_metrics_profile: http://yourdomain/metrics-profile.yml
       # kube-burner pod tolerations
       # Application to build
-      #app: django
-      #source_strat_env: PIP_INDEX_URL
-      #source_strat_from: python
-      #source_strat_from_version: latest
+      app: django
+      source_strat_env: PIP_INDEX_URL
+      source_strat_from: python
+      source_strat_from_version: latest
       # Script to run after build
-      #post_commit_script: "./manage.py test"
+      post_commit_script: "./manage.py test"
       # Build Image name
-      #build_image_stream: django-psql-example
+      build_image_stream: django-psql-example
       # Git url for application
-      #git_url: https://github.com/sclorg/django-ex.git
-      #build_image: image-registry.openshift-image-registry.svc:5000/svt-django/django-psql-example
+      git_url: https://github.com/sclorg/django-ex.git
+      build_image: image-registry.openshift-image-registry.svc:5000/svt-django/django-psql-example
       tolerations:
       - key: role
         value: workload

--- a/roles/kube-burner/files/buildconfig_triggers.yml
+++ b/roles/kube-burner/files/buildconfig_triggers.yml
@@ -1,0 +1,39 @@
+---
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: {{.JobName}}-{{.Replica}}
+  annotations:
+    template.alpha.openshift.io/wait-for-ready: 'true'
+spec:
+  nodeSelector:
+    {{.nodeSelectorKey}}: {{.nodeSelectorValue}}
+  triggers:
+  - type: GitHub
+    github:
+      secret: {{.JobName}}-{{.Replica}}
+  - type: ImageChange
+  - type: ConfigChange
+  source:
+    git:
+      uri: {{.gitUri}}
+    type: Git
+  strategy:
+    type: Source
+    sourceStrategy:
+{{ if index . "sourceStratEnv" }}
+      env:
+        - name: {{.sourceStratEnv}}
+{{ end }}
+      from:
+        kind: ImageStreamTag
+        name: {{.fromSource}}:{{.fromSourceVersion}}
+        namespace: 'openshift'
+{{ if index . "postCommitScript" }}
+  postCommit:
+    script: {{.postCommitScript}}
+{{ end }}
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{.imageStream}}-{{.Replica}}:latest

--- a/roles/kube-burner/tasks/main.yml
+++ b/roles/kube-burner/tasks/main.yml
@@ -134,7 +134,24 @@
           metrics.yaml: "{{ lookup('file', workload_args.metrics_profile|default('metrics-aggregated.yaml')) }}"
           simple-deployment.yml: "{{ lookup('file', 'simple-deployment.yml')}}"
           service.yml: "{{ lookup('file', 'service.yml')}}"
+
     when: workload_args.workload == "max-services"
+
+  - name: Create concurrent builds
+    k8s:
+      definition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: kube-burner-config-{{ trunc_uuid }}
+          namespace: "{{ operator_namespace }}"
+        data:
+          config.yml: "{{ lookup('template', 'concurrent-builds.yml.j2')}}"
+          metrics.yaml: "{{ lookup('file', workload_args.metrics_profile|default('metrics-aggregated.yaml')) }}"
+          buildconfig_triggers.yml: "{{ lookup('file', 'buildconfig_triggers.yml')}}"
+          configmap.yml: "{{ lookup('file', 'configmap.yml')}}"
+          imagestream.yml: "{{ lookup('file', 'imagestream.yml')}}"
+    when: workload_args.workload == "concurrent-builds"
 
   - name: Launching kube-burner job
     k8s:

--- a/roles/kube-burner/templates/concurrent-builds.yml.j2
+++ b/roles/kube-burner/templates/concurrent-builds.yml.j2
@@ -1,0 +1,51 @@
+---
+global:
+  writeToFile: false
+{% if prometheus is defined and prometheus.prom_url is defined and prometheus.es_url != "" %}
+  indexerConfig:
+    enabled: true
+    esServers: ["{{ prometheus.es_url }}"]
+    insecureSkipVerify: true
+    defaultIndex: {{ workload_args.default_index|default("ripsaw-kube-burner") }}
+    type: elastic
+  measurements:
+    - name: podLatency
+      esIndex: {{ workload_args.default_index|default("ripsaw-kube-burner") }}
+{% endif %}
+
+jobs:
+  - name: concurrent-builds
+    jobIterations: {{ workload_args.job_iterations }}
+    qps: {{ workload_args.qps|default(5) }}
+    burst: {{ workload_args.burst|default(10) }}
+    namespacedIterations: true
+    namespace: svt-{{ uuid }}
+    cleanup: {{ workload_args.cleanup|default(true) }}
+    waitWhenFinished: {{ workload_args.wait_when_finished|default(true) }}
+    podWait: {{ workload_args.pod_wait|default(false) }}
+{% if wait_for is defined %}
+    waitFor: {{ wait_for|default(["Build"]) }}
+{% endif %}
+    verifyObjects: {{ workload_args.verify_objects|default(true) }}
+    errorOnVerify: {{ workload_args.error_on_verify|default(false) }}
+    objects:
+      - objectTemplate: imagestream.yml
+        replicas: 1
+        inputVars:
+          prefix: {{ workload_args.build_image_stream|default("") }}
+          image: {{ workload_args.build_image|default("")  }}
+      - objectTemplate: buildconfig_triggers.yml
+        replicas: 1
+        inputVars:
+          imageStream: {{ workload_args.build_image_stream|default("") }}
+          gitUri: {{ workload_args.git_url|default("") }}
+          nodeSelectorKey: {{ workload_args.node_selector.key|default("node-role.kubernetes.io/worker")}}
+          nodeSelectorValue: "{{ workload_args.node_selector.value|default("") }}"
+{% if source_strat_env is defined and source_strat_env != "" %}
+          sourceStratEnv: {{ workload_args.source_strat_env|default("") }}
+{% endif %}
+          fromSource: {{ workload_args.source_strat_from|default("") }}
+          fromSourceVersion: {{ workload_args.source_strat_from_version|default("latest") }}
+{% if post_commit_script is defined and post_commit_script != "" %}
+          postCommitScript: {{ workload_args.post_commit_script|default("") }}
+{% endif %}

--- a/tests/test_crs/valid_kube-burner.yaml
+++ b/tests/test_crs/valid_kube-burner.yaml
@@ -32,6 +32,14 @@ spec:
       error_on_verify: true
       step: 30s
       metrics_profile: METRICS_PROFILE
+      app: django
+      source_strat_env: PIP_INDEX_URL
+      source_strat_from: python
+      source_strat_from_version: latest
+      post_commit_script: "./manage.py test"
+      build_image_stream: django-psql-example
+      git_url: https://github.com/sclorg/django-ex.git
+      build_image: image-registry.openshift-image-registry.svc:5000/svt-django/django-psql-example
       node_selector:
         key: node-role.kubernetes.io/worker
         value:

--- a/tests/test_kubeburner.sh
+++ b/tests/test_kubeburner.sh
@@ -55,3 +55,4 @@ functional_test_kubeburner node-density metrics.yaml
 functional_test_kubeburner node-density-heavy metrics.yaml
 functional_test_kubeburner max-namespaces metrics-aggregated.yaml
 functional_test_kubeburner max-services metrics-aggregated.yaml
+functional_test_kubeburner concurrent-builds metrics-aggregated.yaml


### PR DESCRIPTION
### Description
This creates the start of the objects needed to run the concurrent builds test case. It will create a buildconfig and an image stream in each namespace. Because of the set up of the buildconfig a build and pod will also get created and run during the kube-burner run. 
The addition of starting builds concurrently seemed like too much to add to kube-burner at this time but I would be open to adding it to get the necessary benchmarks we want for this test. 

This is a little different from some of the other workloads in kube-burner because it just creates builds to later be used to start concurrent builds using the workloads/kube-burner/run_concurrentbuilds_test_fromgit.sh script in e2e-benchmarking. 

Not sure if the resources/crds/ripsaw_v1alpha1_concurrent_builds_cr.yaml file is necessary, but might be nice to give an example of working parameters for the kube-burner 