### PR TITLE
adding cerberus validate certs parameter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,14 +37,6 @@ In the interactive rebase screen, set the first commit to `pick` and all others 
 
 Push your rebased commits (you may need to force), then issue your PR.
 
-## Container Images
-
-Custom container image definitions are maintained in [magazine](https://github.com/cloud-bulldozer/magazine).
-We use quay for all storing all our custom container images, and if you're adding a new
-workload and not sure of where to add/maintain the container image. We highly recommend, to
-add the Dockerfile to magazine, as we've automation setup for updating images in Quay, when
-a git push happens to magazine.
-
 ## Add workload
 
 Adding new workloads are always welcome, but before you submit PR:

--- a/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+++ b/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
@@ -123,6 +123,8 @@ spec:
                 type: object
               cerberus_url:
                 type: string
+              cerberus_validate_certs:
+                type: boolean
               cleanup:
                 type: boolean
               test_user:

--- a/roles/cerberus/tasks/main.yml
+++ b/roles/cerberus/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Get status from Cerberus
   uri:
     url: "{{ cerberus_url }}"
+    validate_certs: "{{ cerberus_validate_certs |  default('False') }}"
     return_content: yes
   register: result
 


### PR DESCRIPTION
Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>

### Description
Cerberus may not always be running with valid certs when it is setup as an ephemeral instance, and it would be useful to provide ability to pass `validate_certs` parameter to the `uri` call. 

### Fixes
Extends CRD to add new boolean for `cerberus_validate_certs` and extends the role to accept that variable. It is being set to `false` as default as its more likely what users would want in my experience. URI Module defaults to `true` otherwise. 

CC:  @mffiedler 

Please review @chaitanyaenr