### PR TITLE
Add loop handling for vars to log-generator workload

### DIFF
--- a/docs/log_generator.md
+++ b/docs/log_generator.md
@@ -12,17 +12,17 @@ This data will also be indexed if Elasticsearch information is provided.
 
 ### Required variables:
 
-`size` the size, in bytes, of the message to send
+`size` (list) the size, in bytes, of the message to send
 
 `duration` how long, in minutes, messages should be sent for
 
-`messages_per_second` the number of messages per second (mutually exclusive with messages_per_minute)
+`messages_per_second` (list) the number of messages per second (mutually exclusive with messages_per_minute)
 
-`messages_per_minute` the number of messages per minute (mutually exclusive with messages_per_second)
+`messages_per_minute` (list) the number of messages per minute (mutually exclusive with messages_per_second)
 
 ### Optional variables:
 
-`pod_count` total number of log generator pods to launch (default: 1)
+`pod_count` (list) total number of log generator pods to launch (default: 1)
 
 `timeout` how long, in seconds, after have been sent to allow the backend service to receive all the messages (default: 600)
 
@@ -72,9 +72,12 @@ spec:
   workload:
     name: log_generator
     args:
-      pod_count: 2
-      size: 512
-      messages_per_second: 10
+      pod_count:
+        - 2
+      size:
+        - 512
+      messages_per_second:
+        - 10
       duration: 1
       es_url: "https://my-es-backend.com"
       es_token: "sha256~myToken"
@@ -99,9 +102,12 @@ spec:
   workload:
     name: log_generator
     args:
-      pod_count: 10
-      size: 1024
-      messages_per_second: 100
+      pod_count:
+        - 10
+      size:
+        - 1024
+      messages_per_second:
+        - 100
       duration: 10
       cloudwatch_log_group: "my_log_group"
       aws_region: "us-west-2"
@@ -128,9 +134,12 @@ spec:
   workload:
     name: log_generator
     args:
-      pod_count: 2
-      size: 512
-      messages_per_second: 10
+      pod_count:
+        - 2
+      size:
+        - 512
+      messages_per_second:
+        - 10
       duration: 1
       kafka_bootstrap_server: "my-cluster-kafka-bootstrap.amq:9092"
       kafka_topic: "topic-logging-app"

--- a/resources/crds/ripsaw_v1alpha1_log_generator_cr.yaml
+++ b/resources/crds/ripsaw_v1alpha1_log_generator_cr.yaml
@@ -19,11 +19,20 @@ spec:
     name: log_generator
     args:
       # Number of log generator pods to launch
-      pod_count: 1
+      pod_count:
+        - 1
+        - 10
+        - 100
       # size of message in bytes
-      size: 512
+      size:
+        - 512
+        - 1024
+        - 2048
       # number of messages per second to send
-      messages_per_second: 10
+      messages_per_second:
+        - 10
+        - 100
+        - 1000
       # duration of time to send messages in minutes
       duration: 1
       # url of the backend elasticsearch to be used for verification

--- a/roles/log_generator/tasks/main.yml
+++ b/roles/log_generator/tasks/main.yml
@@ -7,14 +7,32 @@
     namespace: "{{ operator_namespace }}"
   register: benchmark_state
 
-- operator_sdk.util.k8s_status:
-    api_version: ripsaw.cloudbulldozer.io/v1alpha1
-    kind: Benchmark
-    name: "{{ ansible_operator_meta.name }}"
-    namespace: "{{ operator_namespace }}"
-    status:
-      state: "Starting Log Generator Pods"
-      complete: false
+- name: Set redis pod count list name
+  set_fact:
+    pod_count_list: "{{ ansible_operator_meta.name }}-{{ uuid }}-pod-count-list"
+
+- name: Set redis pod count list index name
+  set_fact:
+    pod_count_list_index: "{{ ansible_operator_meta.name }}-{{ uuid }}-pod-count-list-index"
+
+- block:
+
+  - operator_sdk.util.k8s_status:
+      api_version: ripsaw.cloudbulldozer.io/v1alpha1
+      kind: Benchmark
+      name: "{{ ansible_operator_meta.name }}"
+      namespace: "{{ operator_namespace }}"
+      status:
+        state: "Starting Log Generator Pods"
+        complete: false
+
+  - name: Write pod count list to redis
+    command: "redis-cli rpush {{ pod_count_list }} {{ item }}"
+    loop: "{{ workload_args.pod_count | default(1) }}"
+
+  - name: Initialize pod count list index
+    command: "redis-cli set {{ pod_count_list_index }} 0"
+
   when: benchmark_state.resources[0].status.state is not defined
 
 - name: Get benchmark state 
@@ -24,6 +42,22 @@
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
   register: benchmark_state
+
+- name: Get pod count list index
+  command: "redis-cli get {{ pod_count_list_index }}"
+  register: pod_count_index_get
+
+- name: Set pod count index
+  set_fact:
+    pod_count_index: "{{ pod_count_index_get.stdout | int }}"
+
+- name: Get pod count from index
+  command: "redis-cli lindex {{ pod_count_list }} {{ pod_count_index }}"
+  register: pod_count_get
+
+- name: Set pod count 
+  set_fact:
+    pod_count: "{{ pod_count_get.stdout | int }}"
 
 - block:
 
@@ -50,7 +84,7 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - app = log-generator-{{ trunc_uuid }}
+        - app = log-generator-{{ pod_count }}-{{ trunc_uuid }}
     register: log_pods
 
   - name: Update resource state
@@ -61,7 +95,7 @@
       namespace: "{{ operator_namespace }}"
       status:
         state: "Log Generator Running"
-    when: "workload_args.pod_count|default('1')|int == log_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
+    when: "pod_count|default('1')|int == log_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
   
   when: benchmark_state.resources[0].status.state == "Building Pods"
 
@@ -73,17 +107,37 @@
       api_version: v1
       namespace: '{{ operator_namespace }}'
       label_selectors:
-        - app = log-generator-{{ trunc_uuid }}
+        - app = log-generator-{{ pod_count }}-{{ trunc_uuid }}
     register: log_pods
 
-  - operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ ansible_operator_meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: Complete
-        complete: true
-    when: "workload_args.pod_count|default('1')|int == (log_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
+  - block:
+
+    - operator_sdk.util.k8s_status:
+        api_version: ripsaw.cloudbulldozer.io/v1alpha1
+        kind: Benchmark
+        name: "{{ ansible_operator_meta.name }}"
+        namespace: "{{ operator_namespace }}"
+        status:
+          state: "Starting Log Generator Pods"
+
+    - name: Increment pod count list index
+      command: "redis-cli incr {{ pod_count_list_index }}"
+
+    when: (pod_count|default('1')|int == (log_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)) and
+          (pod_count_index|int < (workload_args.pod_count|length - 1))
+
+  - block:
+
+    - operator_sdk.util.k8s_status:
+        api_version: ripsaw.cloudbulldozer.io/v1alpha1
+        kind: Benchmark
+        name: "{{ ansible_operator_meta.name }}"
+        namespace: "{{ operator_namespace }}"
+        status:
+          state: Complete
+          complete: true
+
+    when: (pod_count|default('1')|int == (log_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)) and
+          (pod_count_index|int == (workload_args.pod_count|length - 1))
 
   when: benchmark_state.resources[0].status.state == "Log Generator Running"

--- a/roles/log_generator/templates/log_generator.yml
+++ b/roles/log_generator/templates/log_generator.yml
@@ -2,14 +2,14 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: 'log-generator-{{ trunc_uuid }}'
+  name: 'log-generator-{{ pod_count }}-{{ trunc_uuid }}'
   namespace: '{{ operator_namespace }}'
 spec:
-  parallelism: {{ workload_args.pod_count | default(1) | int }}
+  parallelism: {{ pod_count | default(1) | int }}
   template:
     metadata:
       labels:
-        app: log-generator-{{ trunc_uuid }}
+        app: log-generator-{{ pod_count }}-{{ trunc_uuid }}
     spec:
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
@@ -74,27 +74,33 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - > 
-{% if workload_args.pod_count | default(1) | int > 1 %}
-            if [[ "${snafu_disable_logs}" == "False" ]]; then echo "Waiting for all pods to be Ready"; fi;
-            redis-cli -h {{ bo.resources[0].status.podIP }} INCR "log-generator-{{ trunc_uuid }}" > /dev/null 2>&1;
-            pods=`redis-cli -h {{ bo.resources[0].status.podIP }} GET "log-generator-{{ trunc_uuid }}"`;
-            while [[ $pods != {{ workload_args.pod_count | int }} ]]; do
-              pods=`redis-cli -h {{ bo.resources[0].status.podIP }} GET "log-generator-{{ trunc_uuid }}"`;
+{% if workload_args.messages_per_second is defined %}
+{% set rates = workload_args.messages_per_second %}
+{% elif workload_args.messages_per_minute is defined %}
+{% set rates = workload_args.messages_per_minute %}
+{% endif %}
+{% for size in workload_args.size %}
+{% for rate in rates %}
+{% if pod_count | default(1) | int > 1 %}
+            if [[ "${snafu_disable_logs}" == "False" ]]; then echo "Waiting for {{ pod_count }} pods to be Ready"; fi;
+            redis-cli -h {{ bo.resources[0].status.podIP }} INCR "log-generator-{{ pod_count }}-{{ size }}-{{ rate }}-{{ trunc_uuid }}" > /dev/null 2>&1;
+            pods=`redis-cli -h {{ bo.resources[0].status.podIP }} GET "log-generator-{{ pod_count }}-{{ size }}-{{ rate }}-{{ trunc_uuid }}"`;
+            while [[ $pods != {{ pod_count | int }} ]]; do
               sleep 1;
+              pods=`redis-cli -h {{ bo.resources[0].status.podIP }} GET "log-generator-{{ pod_count }}-{{ size }}-{{ rate }}-{{ trunc_uuid }}"`;
             done;
 {% endif %}
             run_snafu
             --tool log_generator
 {% if workload_args.debug is defined and workload_args.debug %}
-            -v
-{% endif %}
+            -v {% endif %}
             -u "{{ uuid }}"
-            --size "{{ workload_args.size | default(512) }}"
+            --size "{{ size | default(512) }}"
 {% if workload_args.messages_per_second is defined %}
-            --messages-per-second "{{ workload_args.messages_per_second }}"
+            --messages-per-second "{{ rate }}"
 {% endif %}
 {% if workload_args.messages_per_minute is defined %}
-            --messages-per-minue "{{ workload_args.messages_per_minute }}"
+            --messages-per-minute "{{ rate }}"
 {% endif %}
             --duration "{{ workload_args.duration | default(10) }}"
 {% if workload_args.es_url is defined %}
@@ -115,7 +121,10 @@ spec:
 {% endif %}
             --pod-name ${my_pod_name}
             --timeout "{{ workload_args.timeout | default(600) }}"
-            --pod-count {{ workload_args.pod_count | default(1) | int }}
+            --pod-count {{ pod_count | default(1) | int }};
+{% endfor %}
+{% endfor %}
+             if [[ "${snafu_disable_logs}" == "False" ]]; then echo "Run Finished"; fi
         imagePullPolicy: Always
       restartPolicy: Never
 {% include "metadata.yml.j2" %}

--- a/tests/test_crs/valid_log_generator.yaml
+++ b/tests/test_crs/valid_log_generator.yaml
@@ -10,9 +10,15 @@ spec:
   workload:
     name: log_generator
     args:
-      pod_count: 1
-      size: 512
-      messages_per_second: 1
+      pod_count:
+        - 1
+        - 2
+      size:
+        - 256
+        - 512
+      messages_per_second:
+        - 1
+        - 2
       duration: 1
       es_url: ES_SERVER
       timeout: 600


### PR DESCRIPTION
### Description
This adds looping through variables to the log generator workload for pods, size, and message rate.

This is tested now and I believe everything works properly with the nested loops. Thanks for the help @dry923 .

### Fixes
Issue #574 