### PR TITLE
Add the ability to spin up log generator pods in their own namespace

### DIFF
--- a/deploy/25_role.yaml
+++ b/deploy/25_role.yaml
@@ -11,3 +11,35 @@ rules:
   - get
   - list
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - batch
+  - extensions
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+

--- a/docs/log_generator.md
+++ b/docs/log_generator.md
@@ -28,6 +28,8 @@ This data will also be indexed if Elasticsearch information is provided.
 
 `snafu_disable_logs` Disable all logging in the pod from the snafu logger, thereby only leaving the generated log messages on stdout (default: False)
 
+`custom_namespace` Useful when you want to create the log generator pods in a custom namespace of you liking, by default they are created in the operator namespace
+
 ### Verification variables:
 
 To verify your messages have been received by the backend aggregator you must provide information for ONLY ONE of the supported

--- a/roles/log_generator/tasks/main.yml
+++ b/roles/log_generator/tasks/main.yml
@@ -27,6 +27,14 @@
 
 - block:
 
+  - name: Create namespace
+    k8s:
+        api_version: v1
+        name: "{{ workload_args.custom_namespace }}"
+        kind: Namespace
+        state: present
+    when: workload_args.custom_namespace is defined and workload_args.custom_namespace != ""
+
   - name: Create log generator pods
     k8s:
       state: present

--- a/roles/log_generator/templates/log_generator.yml
+++ b/roles/log_generator/templates/log_generator.yml
@@ -3,7 +3,11 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: 'log-generator-{{ trunc_uuid }}'
+{% if workload_args.custom_namespace is defined %}
+  namespace: '{{  workload_args.custom_namespace }}'
+{% else %}
   namespace: '{{ operator_namespace }}'
+{% endif %}
 spec:
   parallelism: {{ workload_args.pod_count | default(1) | int }}
   template:


### PR DESCRIPTION
Might not be required for the regular user, but in our testing
we would like to isolate the log generator pods to a namespace
and have all the logs from the namespace forwarded to a dedicated kafka
topic.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
