### PR TITLE
Update installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ Note: If you're on a vanilla k8s distribution, then you can also deploy Ripsaw t
 First we'll need to clone the operator:
 
 ```bash
-# git clone https://github.com/cloud-bulldozer/ripsaw
+# git clone https://github.com/cloud-bulldozer/benchmark-operator.git
 # cd ripsaw
 # export KUBECONFIG=<your_kube_config> # if not already done
 ```


### PR DESCRIPTION
### Description
wrong path 
### Fixes
change of file name from ripsaw to benchmark-operator