### PR TITLE
Shorten max-services to max-serv to avoid line length issue

### DIFF
--- a/roles/kube-burner/templates/max-services.yml.j2
+++ b/roles/kube-burner/templates/max-services.yml.j2
@@ -14,7 +14,7 @@ global:
 {% endif %}
 
 jobs:
-  - name: max-services
+  - name: max-serv
     jobIterations: {{ workload_args.job_iterations }}
     qps: {{ workload_args.qps|default(5) }}
     burst: {{ workload_args.burst|default(10) }}
@@ -30,11 +30,11 @@ jobs:
       - objectTemplate: simple-deployment.yml
         replicas: 1
         inputVars:
-          name: max-services
+          name: max-serv
           nodeSelectorKey: {{ workload_args.node_selector.key|default("node-role.kubernetes.io/worker") }}
           nodeSelectorValue: "{{ workload_args.node_selector.value|default("") }}"
 
       - objectTemplate: service.yml
         replicas: 1
         inputVars:
-          name: max-services
+          name: max-serv


### PR DESCRIPTION
### Description
Shorten max-services to max-serv to avoid line length issue. Can now successfully create 5000 services in a single namespace.
### Fixes
