### PR TITLE
Osd cache drop rbac

### DIFF
--- a/docs/cache_dropping.md
+++ b/docs/cache_dropping.md
@@ -58,21 +58,35 @@ Benchmarks supported for kernel cache dropping at present are:
 
 ## how to drop Ceph OSD cache
 
-for this to work with OpenShift Container Storage, you must start both the Ceph toolbox pod in OCS
-and the cache dropper pod.   You can do this with:
+for this to work with OpenShift Container Storage, you must do these steps once the benchmark-operator is running:
+and the cache dropper pod, and enable benchmark-operator to see into the openshift-storage namespace.   
+You can do this with:
 
 ```
+
+# enable the benchmark operator to look for pods in the openshift-storage namespace
+oc create -f roles/ceph_osd_cache_drop/ocs-cache-drop-clusterrole.yaml
+
+# start the Ceph toolbox pod in openshift-storage namespace
 oc patch OCSInitialization ocsinit -n openshift-storage --type json --patch \
   '[{ "op": "replace", "path": "/spec/enableCephTools", "value": true }]'
 
+# start the OSD cache dropper pod in openshift-storage namespace
 oc create -f roles/ceph_osd_cache_drop/rook_ceph_drop_cache_pod.yaml
 
+# repeat until you see if the 2 pods are both running
 oc -n openshift-storage get pod | awk '/tool/||/drop/'
+
 ```
 
 when you see both of these pods in the running state, then you can use benchmark operator.   The reason that
 you have to manually start these two pods running is that the benchmark-operator does not have authorization
 to run them in the openshift-storage namespace and get access to the secrets needed to do this.
+
+Benchmarks supported for Ceph OSD cache dropping are:
+
+- fio
+- smallfile
 
 # implementation notes
 

--- a/docs/cache_dropping.md
+++ b/docs/cache_dropping.md
@@ -58,7 +58,7 @@ Benchmarks supported for kernel cache dropping at present are:
 
 ## how to drop Ceph OSD cache
 
-for this to work with OpenShift Container Storage, you must do these steps once the benchmark-operator is running:
+For this to work with OpenShift Container Storage, you must do these steps once the benchmark-operator is running:
 and the cache dropper pod, and enable benchmark-operator to see into the openshift-storage namespace.   
 You can do this with:
 

--- a/roles/ceph_osd_cache_drop/ocs-cache-drop-clusterrole.yaml
+++ b/roles/ceph_osd_cache_drop/ocs-cache-drop-clusterrole.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: benchmark-operator-openshift-storage
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: benchmark-operator-openshift-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: benchmark-operator-openshift-storage
+subjects:
+- kind: ServiceAccount
+  name: benchmark-operator
+  namespace: openshift-storage


### PR DESCRIPTION
### Description

add an RBAC YAML that permits cache dropping role to detect cache dropper pod and toolbox pod in openshift-storage namespace.   Tell OSD cache dropping users to use this YAML.   A similar thing had to be done for the kernel cache dropper.  

### Fixes

benchmark-operator got HTTP 403 access denied errors from K8S trying to detect pods running in openshift-storage namespace.  
