### PR TITLE
Smf cleanup delay

### DIFF
--- a/roles/smallfile/templates/smallfilejob.other_parameters.yaml.j2
+++ b/roles/smallfile/templates/smallfilejob.other_parameters.yaml.j2
@@ -15,11 +15,11 @@ files: {{ workload_args.files }}
 {% endif %}
 
 {% if workload_args.fsync is defined %}
-fsync: y
+fsync: {{ workload_args.fsync }}
 {% endif %}
 
 {% if workload_args.response_times is defined %}
-response-times: true
+response-times: {{ workload_args.response_times }}
 {% endif %}
 
 {% if workload_args.network_sync_dir is defined %}
@@ -79,19 +79,19 @@ verbose: {{workload_args.verbose}}
 {% endif %}
 
 {% if workload_args.permute_host_dirs is defined %}
-permute-host-dirs: true
+permute-host-dirs: {{ workload_args.permute_host_dirs }}
 {% endif %}
 
 {% if workload_args.record_ctime_size is defined %}
-record-ctime-size: true
+record-ctime-size: {{ workload_args.record_ctime_size }}
 {% endif %}
 
 {% if workload_args.verify_read is defined %}
-verify-read: true
+verify-read: {{ workload_args.verify_read }}
 {% endif %}
 
 {% if workload_args.incompressible is defined %}
-incompressible: true
+incompressible: {{ workload_args.incompressible }}
 {% endif %}
 
 {% if workload_args.cleanup_delay_usec_per_file is defined %}

--- a/roles/smallfile/templates/smallfilejob.other_parameters.yaml.j2
+++ b/roles/smallfile/templates/smallfilejob.other_parameters.yaml.j2
@@ -93,3 +93,7 @@ verify-read: true
 {% if workload_args.incompressible is defined %}
 incompressible: true
 {% endif %}
+
+{% if workload_args.cleanup_delay_usec_per_file is defined %}
+cleanup-delay-usec-per-file: {{workload_args.cleanup_delay_usec_per_file}}
+{% endif %}

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -25,6 +25,21 @@ spec:
       clients: 2
       operation: ["create", "read", "append", "delete"]
       threads: 1
-      file_size: 0
+      file_size: 2
+      record_size: 1
+      xattr_size: 50
+      pause: 2
+      stonewall: n
+      finish: y
+      prefix: abc
+      hash_into_dirs: true
+      same_dir: y
+      incompressible: y
+      verify_read: y
+      xattr_count: 10
+      fsync: true
+      files_per_dir: 2000
+      dirs_per_dir: 4
       files: 100000
+      cleanup_delay_usec_per_file: 200
       debug: true

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -37,7 +37,7 @@ spec:
       incompressible: y
       verify_read: y
       xattr_count: 10
-      fsync: true
+      fsync: false
       files_per_dir: 2000
       dirs_per_dir: 4
       files: 100000


### PR DESCRIPTION
### Description

allows delay after cleanup operation to give Cephfs provisioner time to clean up files in deleted Cephfs PVs

### Fixes

higher-than-expected variance in smallfile samples
also add test coverage for full set of smallfile parameters.