### PR TITLE
Update namespace count query

### DIFF
--- a/roles/kube-burner/files/metrics-aggregated.yaml
+++ b/roles/kube-burner/files/metrics-aggregated.yaml
@@ -140,7 +140,7 @@ metrics:
     metricName: P99APIEtcdRequestLatency
 
 # Cluster metrics
-  - query: count(kube_namespace_created)
+  - query: sum(kube_namespace_status_phase) by (phase) > 0
     metricName: namespaceCount
 
   - query: sum(kube_pod_status_phase{}) by (phase)

--- a/roles/kube-burner/files/metrics.yaml
+++ b/roles/kube-burner/files/metrics.yaml
@@ -87,7 +87,7 @@ metrics:
     instant: true
 
 # Cluster metrics
-  - query: count(kube_namespace_created)
+  - query: sum(kube_namespace_status_phase) by (phase) > 0
     metricName: namespaceCount
 
   - query: sum(kube_pod_status_phase{}) by (phase)


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Updating namespace count query since that metric is no longer being scraped in OpenShift. Context at https://github.com/openshift/cluster-monitoring-operator/pull/1141

### Fixes
