### PR TITLE
Add nodeSelector to kernel-cache-drop-daemonset.yaml daemonset

### DIFF
--- a/resources/kernel-cache-drop-daemonset.yaml
+++ b/resources/kernel-cache-drop-daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       #tolerations:
       #- key: node-role.kubernetes.io/master
       #  effect: NoSchedule
+      nodeSelector:
+        kernel-cache-dropper: "yes"
       containers:
       - name: kernel-cache-dropper
         image: quay.io/cloud-bulldozer/kernel_cache_dropper:latest


### PR DESCRIPTION
For kernel cache dropper to work nodes must be labeled with 

`kernel-cache-dropper=yes`

However, in my tests these pods were starting on infra nodes
even there was not this label present on these nodes.

Adding

```
    nodeSelector:
        kernel-cache-dropper: "yes"
```

to kernel-cache-drop-daemonset.yaml ensured that kernel cache dropper
pods to start only on nodes with specified labels.

