### PR TITLE
Add uperf resource labels

### DIFF
--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -15,6 +15,9 @@ items:
       template:
         metadata:
           labels:
+            benchmark-operator-uuid: {{ uuid }}
+            benchmark-operator-workload: uperf
+            benchmark-operator-role: server
             app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(27,true,'') }}-{{ item  }}-{{ trunc_uuid }}
             type: {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
           annotations:

--- a/roles/uperf/templates/server_vm.yml.j2
+++ b/roles/uperf/templates/server_vm.yml.j2
@@ -5,6 +5,9 @@ metadata:
   name: 'uperf-server-{{ item }}-{{ trunc_uuid }}'
   namespace: '{{ operator_namespace }}'
   labels:
+    benchmark-operator-uuid: {{ uuid }}
+    benchmark-operator-workload: uperf
+    benchmark-operator-role: server
     app : uperf-bench-server-{{ item }}-{{ trunc_uuid }}
     type : {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
 spec:

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -10,6 +10,8 @@ items:
       name:  uperf-service-{{ item }}-{{ trunc_uuid }}
       namespace: '{{ operator_namespace }}'
       labels:
+        benchmark-operator-uuid: {{ uuid }}
+        benchmark-operator-workload: uperf
         app: uperf-bench-server-{{ worker_node_list[ node_idx_item ] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
         type: {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
       annotations:

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -17,6 +17,9 @@ items:
       template:
         metadata:
           labels:
+            benchmark-operator-uuid: {{ uuid }}
+            benchmark-operator-workload: uperf
+            benchmark-operator-role: client
             app: uperf-bench-client-{{ trunc_uuid }}
             clientfor: {{ item.metadata.labels.app }}
             type: {{ ansible_operator_meta.name }}-bench-client-{{ trunc_uuid }}

--- a/roles/uperf/templates/workload_vm.yml.j2
+++ b/roles/uperf/templates/workload_vm.yml.j2
@@ -5,6 +5,9 @@ metadata:
   name: 'uperf-client-{{item.status.interfaces[0].ipAddress}}-{{ trunc_uuid }}'
   namespace: '{{ operator_namespace }}'
   labels:
+    benchmark-operator-uuid: {{ uuid }}
+    benchmark-operator-workload: uperf
+    benchmark-operator-role: client
     app: uperf-bench-client-{{ trunc_uuid }}
     type: {{ ansible_operator_meta.name }}-bench-client-{{ trunc_uuid }}
 spec:


### PR DESCRIPTION
### Description

Adding labels to resources created by benchmark-operator to more easily identify them during benchmark run.

Will end up adding these to the other workloads.