### PR TITLE
Enable connect type workloads in uperf

### DIFF
--- a/deploy/50_pod_security_policy.yml
+++ b/deploy/50_pod_security_policy.yml
@@ -23,3 +23,5 @@ spec:
     rule: 'RunAsAny'
   fsGroup:
     rule: 'RunAsAny'
+  allowedUnsafeSysctls:
+  - "*"

--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -132,6 +132,35 @@ For example:
 Will run the `rr` test with `tcp`, first with a symmectic size of `1024` and then with an
 asymmetric size of `8192` write and `4096` read.
 
+### Connect
+
+For the connect `test_type`, it is possible to provide the `sizes` values as a list of two values where the first value is the write size and the second value is the read size.
+
+It is also possible to define a zero size in order to test connections/second (CPS) (the number of L4 connections established per second). If there is a size defined, the metric obtained will be request/second (RPS) or transactions/second (TPS) (the number of L5/L7 requests satisfied per second).
+
+For this kind of testing, it is necessary to apply some sysctl tunning, both to the worker nodes and to the pods (see [Using sysctls in containers](https://docs.openshift.com/container-platform/4.7/nodes/containers/nodes-containers-sysctls.html)). If these parameters are not applied, two things can happen as a result of port exhaustion issues:
+ - The uperf client pod will crash
+ - The results will be too low
+
+Enable the `tuned` parameter in order to get sysctl pod level tunning:
+```yaml       
+      test_types:
+        - connect
+      protos:
+        - tcp
+      sizes:
+        - [0, 128]
+      nthrs:
+        - 1
+      runtime: 20
+      tuned: true
+```
+
+For this `tuned` parameter to work, the `KubeletConfig` should allow the following sysctl parameters configuration:
+ - `net.ipv4.ip_local_port_range`
+ - `net.ipv4.tcp_tw_reuse`
+ - `net.netfilter.nf_conntrack_tcp_timeout_time_wait`
+
 ### Multus
 
 If the user desires to test with Multus, use the below Multus `NetworkAtachmentDefinition`

--- a/roles/uperf/templates/configmap.yml.j2
+++ b/roles/uperf/templates/configmap.yml.j2
@@ -8,12 +8,17 @@ data:
 {% for test in workload_args.test_types %}
 {% for proto in workload_args.protos %}
 {% for size in workload_args.sizes %}
+{% if size is defined %}
 {% if size is iterable %}
 {% set wsize = size[0] %}
 {% set rsize = size[1] %}
 {% else %}
 {% set wsize = size %}
 {% set rsize = size %}
+{% endif %}
+{% else %}
+{% set wsize = 0 %}
+{% set rsize = 0 %}
 {% endif %}
 {% for nthr in workload_args.nthrs %}
   uperf-{{test}}-{{proto}}-{{wsize}}-{{rsize}}-{{nthr}} : |
@@ -55,6 +60,20 @@ data:
           </transaction>
           <transaction iterations="1">
             <flowop type=disconnect />
+          </transaction>
+      </group>
+    {% endif %}
+    {% if ( 'connect' == test ) %}
+      <group nthreads="{{nthr}}">
+          <transaction duration="{{workload_args.runtime}}" iterations="{{workload_args.samples}}">
+            <flowop type="connect" options="remotehost=$h protocol={{proto}}"/>
+            {% if rsize != 0 %}
+            <flowop type=read options="size={{rsize}}"/>
+            {% endif %}
+            {% if wsize != 0 %}
+            <flowop type=write options="size={{wsize}}"/>
+            {% endif %}
+            <flowop type="disconnect" />
           </transaction>
       </group>
     {% endif %}

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -57,6 +57,18 @@ items:
             - name: net.ipv4.ip_local_port_range
               value: 20000 20011
 {% endif %}
+{% if workload_args.tuned is sameas true %}
+          serviceAccountName: benchmark-operator
+          securityContext:
+            privileged: true
+            sysctls:
+            - name: net.ipv4.ip_local_port_range
+              value: 1024 65535
+            - name: net.ipv4.tcp_tw_reuse
+              value: "1"
+            - name: net.netfilter.nf_conntrack_tcp_timeout_time_wait
+              value: "1"
+{% endif %}
 {% macro metadata() %}{% include "metadata.yml.j2" %}{% endmacro %}
     {{ metadata()|indent }}
 {% endmacro %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -195,6 +195,18 @@ items:
               configMap:
                 name: uperf-test-{{ trunc_uuid }}
           restartPolicy: OnFailure
+{% if workload_args.tuned is sameas true %}
+          serviceAccountName: benchmark-operator
+          securityContext:
+            privileged: true
+            sysctls:
+            - name: net.ipv4.ip_local_port_range
+              value: 1024 65535
+            - name: net.ipv4.tcp_tw_reuse
+              value: "1"
+            - name: net.netfilter.nf_conntrack_tcp_timeout_time_wait
+              value: "1"
+{% endif %}
 {% if workload_args.pin is sameas false %}
 {% if workload_args.colocate is sameas true %}
           nodeSelector:

--- a/tests/test_crs/valid_uperf.yaml
+++ b/tests/test_crs/valid_uperf.yaml
@@ -32,6 +32,7 @@ spec:
         - stream
         - rr
         - bidirec
+        - connect
       protos:
         - tcp
         - udp


### PR DESCRIPTION
### Description

Enable connect type workloads in uperf

### Notes
For this new connect `test_type`, it is possible to provide the `sizes` values as a list of two values where the first value is the write size and the second value is the read size.

It is also possible to define a zero size in order to test connections/second (CPS) (the number of L4 connections established per second). If there is a size defined, the metric obtained will be request/second (RPS) or transactions/second (TPS) (the number of L5/L7 requests satisfied per second).

For this kind of testing, it is necessary to apply some sysctl tunning, both to the worker nodes and to the pods (see [Using sysctls in containers](https://docs.openshift.com/container-platform/4.7/nodes/containers/nodes-containers-sysctls.html)). If these parameters are not applied, two things can happen as a result of port exhaustion issues:
 - The uperf client pod will crash
 - The results will be too low

Enable the `tuned` parameter in order to get sysctl pod level tunning:
```yaml
      test_types:
        - connect
      protos:
        - tcp
      sizes:
        - [0, 128]
      nthrs:
        - 1
      runtime: 20
      tuned: true
```

For this `tuned` parameter to work, the `KubeletConfig` should allow the following sysctl parameters configuration:
 - `net.ipv4.ip_local_port_range`
 - `net.ipv4.tcp_tw_reuse`
 - `net.netfilter.nf_conntrack_tcp_timeout_time_wait`