### PR TITLE
Backpack needs a RW root

### DIFF
--- a/playbooks/templates/metadata.yml.j2
+++ b/playbooks/templates/metadata.yml.j2
@@ -29,6 +29,7 @@
         imagePullPolicy: Always
         securityContext:
           privileged: {{ metadata.privileged }}
+          readOnlyRootFilesystem: false
           runAsNonRoot: false
         env:
           - name: my_node_name

--- a/roles/backpack/templates/backpack.yml
+++ b/roles/backpack/templates/backpack.yml
@@ -61,6 +61,7 @@ spec:
         imagePullPolicy: Always
         securityContext:
           privileged: {{ metadata.privileged }}
+          readOnlyRootFilesystem: false
           runAsNonRoot: false
         readinessProbe:
           exec:


### PR DESCRIPTION
### Description

ACS sets a security context constraint (SCC) that is more restrictive than the SCC that previously applied to backpack when it was deployed as an initContainer for kube-burner. Some more background on this [here](https://bugzilla.redhat.com/show_bug.cgi?id=1942725) and [here](https://coreos.slack.com/archives/CNKHL6076/p1626366399496100).

### Fixes

Backpack i.e. stockpile needs a RW root, so this change sets that explicitly in the container specs for backpack.

### Testing

Tested similar changes against v0.1 where it [passed](http://gavin-stackrox-rhacs-airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/graph?dag_id=4.7_aws_rhacs2&run_id=manual__2021-07-22T14%3A37%3A05.791476%2B00%3A00&execution_date=2021-07-22+14%3A37%3A05.791476%2B00%3A00) (previously cluster_density would [fail](http://gavin-stackrox-rhacs-airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/graph?dag_id=4.7_aws_rhacs&run_id=manual__2021-07-21T11%3A00%3A17.116367%2B00%3A00&execution_date=2021-07-21+11%3A00%3A17.116367%2B00%3A00)).