### PR TITLE
Fix uuid error

### DIFF
--- a/playbooks/benchmark.yml
+++ b/playbooks/benchmark.yml
@@ -30,8 +30,6 @@
         - control-plane = controller-manager
     register: bo
 
-  - debug:
-      msg: "{{ cr_state }}"
 
   - name: Set Workload UUID
     block:
@@ -61,6 +59,10 @@
   - set_fact:
       uuid: "{{ cr_state.resources[0].status.uuid }}"
       trunc_uuid: "{{ cr_state.resources[0].status.suuid }}"
+    when:
+    - cr_state.resources[0].status is defined
+    - cr_state.resources[0].status.uuid is defined
+    - cr_state.resources[0].status.uuid != ""
 
   - name: Run Workload
     rescue:

--- a/roles/uuid/tasks/main.yml
+++ b/roles/uuid/tasks/main.yml
@@ -5,6 +5,3 @@
 
 - name: set the truncated uuid
   set_fact: trunc_uuid={{ uuid.split("-")[0] }}
-
-- debug:
-    msg: " The results of current execution of the workload {{ workload.name }} will be associated with uuid: {{ uuid }}"


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
An error like this one is printed as soon as a new Benchmark is created, the code change proposed here should fix it.

### Fixes

```
                                                                                                                                                                                                                                            --------------------------- Ansible Task StdOut -------------------------------
TASK [set_fact] ******************************** 
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'uuid'\n\nThe error appears to be in '/opt/ansible/playbooks/benchmark.yml': line 61, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n  - set_fact:\n    ^ here\n" 

```
