### PR TITLE
Lower reconcilePeriod

### DIFF
--- a/watches.yaml
+++ b/watches.yaml
@@ -4,7 +4,7 @@
   group: ripsaw.cloudbulldozer.io
   kind: Benchmark
   playbook: ./playbooks/benchmark.yml
-  reconcilePeriod: 1m
+  reconcilePeriod: 3s
   manageStatus: true
   snakeCaseParameters: false
   # FIXME: Specify the role or playbook for this resource.


### PR DESCRIPTION
### Description
We need to set reconcilePeriod as low as possible. As there are reconcile actions that does not modify the status of the Benchmark CR (modifying the Benchmark object triggers a reconcile),  (I observed this behaviour in the uperf benchmark), the benchmark-operator could wait up to 1 minute to perform the next actions of that Benchmark.

With this change we should dramatically drop the benchmark duration.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>