### PR TITLE
Fix system-metrics collection

### DIFF
--- a/roles/system-metrics/tasks/main.yml
+++ b/roles/system-metrics/tasks/main.yml
@@ -12,7 +12,7 @@
           namespace: "{{ operator_namespace }}"
         data:
           index.yml: "{{ lookup('template', 'index.yml')}}"
-          metrics.yml: "{{ lookup('template', 'node-metrics.yml')}}"
+          node-metrics.yml: "{{ lookup('template', 'node-metrics.yml')}}"
   
   - name: Launching kube-burner job to index system-metrics
     k8s:

--- a/roles/system-metrics/templates/kube-burner.yml.j2
+++ b/roles/system-metrics/templates/kube-burner.yml.j2
@@ -30,7 +30,7 @@ spec:
           -u {{ system_metrics.prom_url }}
           -t {{ system_metrics.prom_token }}
           --start={{ (cr_state.resources[0].metadata.creationTimestamp|to_datetime('%Y-%m-%dT%H:%M:%SZ')).strftime('%s') }}
-          -m {{ system_metrics.metrics_profile|default("metrics.yml") }}
+          -m {{ system_metrics.metrics_profile|default("node-metrics.yml") }}
           --step={{ system_metrics.step }}
         volumeMounts:
           - name: system-metrics-collector

--- a/roles/system-metrics/templates/node-metrics.yml
+++ b/roles/system-metrics/templates/node-metrics.yml
@@ -1,32 +1,31 @@
-metrics:
-  - query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0
-    metricName: nodeCPU
+- query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0
+  metricName: nodeCPU
 
-  - query: avg(node_memory_MemAvailable_bytes) by (instance)
-    metricName: nodeMemoryAvailable
+- query: avg(node_memory_MemAvailable_bytes) by (instance)
+  metricName: nodeMemoryAvailable
 
-  - query: avg(node_memory_Active_bytes) by (instance)
-    metricName: nodeMemoryActive
+- query: avg(node_memory_Active_bytes) by (instance)
+  metricName: nodeMemoryActive
 
-  - query: avg(node_memory_Cached_bytes) by (instance) + avg(node_memory_Buffers_bytes) by (instance)
-    metricName: nodeMemoryCached+nodeMemoryBuffers
+- query: avg(node_memory_Cached_bytes) by (instance) + avg(node_memory_Buffers_bytes) by (instance)
+  metricName: nodeMemoryCached+nodeMemoryBuffers
 
-  - query: irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
-    metricName: rxNetworkBytes
+- query: irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
+  metricName: rxNetworkBytes
 
-  - query: irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
-    metricName: txNetworkBytes
+- query: irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
+  metricName: txNetworkBytes
 
-  - query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m])
-    metricName: nodeDiskWrittenBytes
+- query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m])
+  metricName: nodeDiskWrittenBytes
 
-  - query: rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m])
-    metricName: nodeDiskReadBytes
+- query: rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m])
+  metricName: nodeDiskReadBytes
 
-  - query: kube_node_role
-    metricName: nodeRoles
-    instant: true
+- query: kube_node_role
+  metricName: nodeRoles
+  instant: true
 
-  - query: cluster_version{type="completed"}
-    metricName: clusterVersion
-    instant: true
+- query: cluster_version{type="completed"}
+  metricName: clusterVersion
+  instant: true


### PR DESCRIPTION
### Description

The current implementation of system-metrics was broken due to recent changes in kube-burner's metrics-collection config structure.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>