### PR TITLE
Use IMG to push the image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ORG ?= cloud-bulldozer
 # Get the current branch/tag name
 # In case this is the master branch, rename it to latest
 VERSION ?= $(shell hack/tag_name.sh)
-IMG = $(REGISTRY)/$(ORG)/benchmark-operator:$(VERSION)
+IMG ?= $(REGISTRY)/$(ORG)/benchmark-operator:$(VERSION)-$(ARCH)
 MANIFEST_ARCHS ?= amd64 arm64 ppc64le
 
 # Containers
@@ -77,10 +77,10 @@ run: ansible-operator ## Run against the configured Kubernetes cluster in ~/.kub
 	$(ANSIBLE_OPERATOR) run
 
 image-build: ## Build container image with the manager.
-	${ENGINE} build --arch=$(ARCH) -t ${IMG}-${ARCH} .
+	${ENGINE} build --arch=$(ARCH) -t $(IMG) .
 
 image-push: ## Push container image with the manager.
-	${ENGINE} push ${IMG}-${ARCH}
+	${ENGINE} push $(IMG)
 
 manifest: manifest-build ## Builds a container manifest and push it to the registry
 	$(ENGINE) manifest push $(IMG) $(IMG)


### PR DESCRIPTION
### Description

We shouldn't append the architecture when IMG is set.

With the previous implementation, executing `$ make image-build IMG=quay.io/bla/blabla:latest`


Ended up with the image `quay.io/bla/blabla:latest-amd64` being built and pushed, which is incorrect, we shouldn't append the architecture suffix when IMG is set.


Signed-off-by: Raul Sevilla <rsevilla@redhat.com>