### PR TITLE
fio prefill should use same numjobs value as fio samples

### DIFF
--- a/roles/fio_distributed/templates/configmap.yml.j2
+++ b/roles/fio_distributed/templates/configmap.yml.j2
@@ -5,6 +5,8 @@ metadata:
   name: fio-test-{{ trunc_uuid }}
   namespace: '{{ operator_namespace }}'
 data:
+# FIXME: I don't think prefill works correctly for a list of numjobs values, only for 1 of them
+{% for numjobs in workload_args.numjobs %}
 {% if workload_args.prefill is defined and workload_args.prefill is sameas true %}
   fiojob-prefill: |
     [global]
@@ -22,7 +24,7 @@ data:
 {% endif %}
     iodepth=1
     direct=1
-    numjobs=1
+    numjobs={{numjobs}}
     
     [write]
     rw=write
@@ -40,7 +42,6 @@ data:
 {% set loopvar = workload_args.bs %}
 {% set loopvar_str = 'bs' %}
 {% endif %}
-{% for numjobs in workload_args.numjobs %}
 {% for i in loopvar %}
 {% for job in workload_args.jobs %}
   fiojob-{{job}}-{{i}}-{{numjobs}}: |


### PR DESCRIPTION
move numjobs loop up above prefill section
pass numjobs var into prefill fio job file
This fixes problem where fio reported read throughput greater than the actual block device throughput that fio was reading.   The root cause was that the files were not completely populated so that reads to the unwritten portions of the file return immediately with zeroes, resulting in higher throughput from the files than the block device.