### PR TITLE
--show-current flag is not available for git versions < 2.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ REGISTRY ?= quay.io
 ORG ?= cloud-bulldozer
 # Get the current branch/tag name
 # In case this is the master branch, rename it to latest
-VERSION ?= $(shell hack/tag_name.sh)
+VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --abbrev-ref HEAD | sed 's/master/latest/g')
 IMG ?= $(REGISTRY)/$(ORG)/benchmark-operator:$(VERSION)-$(ARCH)
 IMG_NOARCH ?= $(REGISTRY)/$(ORG)/benchmark-operator:$(VERSION)
 MANIFEST ?= $(REGISTRY)/$(ORG)/benchmark-operator:$(VERSION)

--- a/hack/tag_name.sh
+++ b/hack/tag_name.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-if [[ -z $(git branch --show-current) ]]; then
-  git describe --tags
-else
-  git branch --show-current | sed 's/master/latest/g'
-fi


### PR DESCRIPTION
### Description

Turns out that the `--show-current` flag of the `git branch` subcommand is not available in old git versions.
```
git describe --tags 2>/dev/null || git rev-parse --abbrev-ref HEAD | sed 's/master/latest/g'
```

If the first command works, means we're in a tag, otherwise, we're in a branch.

cc: @kedark3

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>