### PR TITLE
Disable readonly fs in kube-burner pod

### DIFF
--- a/roles/kube-burner/templates/kube-burner.yml.j2
+++ b/roles/kube-burner/templates/kube-burner.yml.j2
@@ -31,9 +31,7 @@ spec:
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/kube-burner:latest') }}
         imagePullPolicy: Always
         securityContext:
-          privileged: true 
           readOnlyRootFilesystem: false
-          runAsNonRoot: false
 {% if workload_args.extra_env_vars is defined and workload_args.extra_env_vars is mapping %}
         env:
 {% for name, value in workload_args.extra_env_vars.items() %}

--- a/roles/kube-burner/templates/kube-burner.yml.j2
+++ b/roles/kube-burner/templates/kube-burner.yml.j2
@@ -30,6 +30,10 @@ spec:
       - name: kube-burner
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/kube-burner:latest') }}
         imagePullPolicy: Always
+        securityContext:
+          privileged: true 
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
 {% if workload_args.extra_env_vars is defined and workload_args.extra_env_vars is mapping %}
         env:
 {% for name, value in workload_args.extra_env_vars.items() %}


### PR DESCRIPTION
### Fixes
Changes the kube-burner container config by disabling the readonlyfilesystem option. This is required to create a pprof-directory on the container.
### Reviewers
@rsevilla87 