### PR TITLE
Stressng: add elasticsearch fields for visualization

### DIFF
--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -91,6 +91,15 @@ spec:
 {% endif %}
         command: ["/bin/sh", "-c"]
         args:
+{% if workload_args.es_custom_field is sameas true %}
+             export es_ocp_version={{workload_args.es_ocp_version}};
+             export es_cnv_version={{workload_args.es_cnv_version}};
+             export es_vm_os_version={{workload_args.es_vm_os_version}};
+             export es_rhcos_version={{workload_args.es_rhcos_version}};
+             export es_kata_version={{workload_args.es_kata_version}};
+             export es_kind={{workload_args.es_kind}};
+             export es_data={{workload_args.es_data}};
+{% endif %}
           - run_snafu --tool stressng -j /workload/jobfile -u {{ uuid }}
 {% if workload_args.debug is defined and workload_args.debug %}
             -v

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -98,6 +98,7 @@ spec:
              export es_rhcos_version={{workload_args.es_rhcos_version}};
              export es_kata_version={{workload_args.es_kata_version}};
              export es_kind={{workload_args.es_kind}};
+             export es_build_version={{workload_args.es_build_version}};
              export es_data={{workload_args.es_data}};
 {% endif %}
           - run_snafu --tool stressng -j /workload/jobfile -u {{ uuid }}

--- a/roles/stressng/templates/stressng_workload_vm.yml.j2
+++ b/roles/stressng/templates/stressng_workload_vm.yml.j2
@@ -78,6 +78,15 @@ spec:
           - dnf install -y ethtool
           - ethtool -L eth0 combined {{ workload_args.client_vm.network.multiqueue.queues }}
 {% endif %}
+{% if workload_args.es_custom_field is sameas true %}
+          - export es_ocp_version={{workload_args.es_ocp_version}};
+          - export es_cnv_version={{workload_args.es_cnv_version}};
+          - export es_vm_os_version={{workload_args.es_vm_os_version}};
+          - export es_rhcos_version={{workload_args.es_rhcos_version}};
+          - export es_kata_version={{workload_args.es_kata_version}};
+          - export es_kind={{workload_args.es_kind}};
+          - export es_data={{workload_args.es_data}};
+{% endif %}
           - dnf install -y python3-pip
           - dnf install -y git redis stress-ng
           - pip install git+https://github.com/cloud-bulldozer/benchmark-wrapper

--- a/roles/stressng/templates/stressng_workload_vm.yml.j2
+++ b/roles/stressng/templates/stressng_workload_vm.yml.j2
@@ -85,6 +85,7 @@ spec:
           - export es_rhcos_version={{workload_args.es_rhcos_version}};
           - export es_kata_version={{workload_args.es_kata_version}};
           - export es_kind={{workload_args.es_kind}};
+          - export es_build_version={{workload_args.es_build_version}};
           - export es_data={{workload_args.es_data}};
 {% endif %}
           - dnf install -y python3-pip


### PR DESCRIPTION
### Description
Stressng: Adding ElasticSearch fields for visualization ( This PR is depend on the same benchmark-wrapper PR https://github.com/cloud-bulldozer/benchmark-wrapper/pull/324)
### Fixes
Adding the following elasticsearch fields:
es_ocp_version
es_cnv_version
es_vm_os_version
es_rhcos_version
es_kata_version
es_kind
es_build_version
es_data