### PR TITLE
UPERF: Fix node name truncation to avoid ending with a dot  '.' char

### DIFF
--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -7,7 +7,11 @@ items:
   - kind: Job
     apiVersion: batch/v1
     metadata:    
-      name: 'uperf-server-{{worker_node_list[ node_idx_item ] | truncate(27,true,'') }}-{{ item }}-{{ trunc_uuid }}'
+{% if (worker_node_list[ node_idx_item]|length>27) and (worker_node_list[ node_idx_item ][26] == '.') %}
+      name: 'uperf-server-{{worker_node_list[ node_idx_item ] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}'
+{% else %}
+      name: 'uperf-server-{{worker_node_list[ node_idx_item ] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}'
+{% endif %}
       namespace: "{{ operator_namespace }}"
     spec:
       ttlSecondsAfterFinished: 600
@@ -18,7 +22,12 @@ items:
             benchmark-uuid: {{ uuid }}
             benchmark-operator-workload: uperf
             benchmark-operator-role: server
-            app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(27,true,'') }}-{{ item  }}-{{ trunc_uuid }}
+{% if (worker_node_list[ node_idx_item]|length>27) and (worker_node_list[ node_idx_item ][26] == '.') %}
+            app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(26,true,'')}}-{{ item  }}-{{ trunc_uuid }}
+{% else %}
+            app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(27,true,'')}}-{{ item  }}-{{ trunc_uuid }}
+{% endif %}
+
             type: {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
           annotations:
 {% if workload_args.multus.enabled is sameas true %}

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -7,10 +7,10 @@ items:
   - kind: Job
     apiVersion: batch/v1
     metadata:    
-{% if (worker_node_list[ node_idx_item]|length>27) and (worker_node_list[ node_idx_item ][26] == '.') %}
-      name: 'uperf-server-{{worker_node_list[ node_idx_item ] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}'
+{% if (worker_node_list[node_idx_item]|length>27) and (worker_node_list[node_idx_item][26] == '.') %}
+      name: 'uperf-server-{{worker_node_list[node_idx_item] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}'
 {% else %}
-      name: 'uperf-server-{{worker_node_list[ node_idx_item ] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}'
+      name: 'uperf-server-{{worker_node_list[node_idx_item] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}'
 {% endif %}
       namespace: "{{ operator_namespace }}"
     spec:
@@ -22,7 +22,7 @@ items:
             benchmark-uuid: {{ uuid }}
             benchmark-operator-workload: uperf
             benchmark-operator-role: server
-{% if (worker_node_list[ node_idx_item]|length>27) and (worker_node_list[ node_idx_item ][26] == '.') %}
+{% if (worker_node_list[node_idx_item]|length>27) and (worker_node_list[node_idx_item][26] == '.') %}
             app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(26,true,'')}}-{{ item  }}-{{ trunc_uuid }}
 {% else %}
             app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(27,true,'')}}-{{ item  }}-{{ trunc_uuid }}

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -12,10 +12,10 @@ items:
       labels:
         benchmark-uuid: {{ uuid }}
         benchmark-operator-workload: uperf
-{% if (worker_node_list[ node_idx_item]|length>27) and (worker_node_list[ node_idx_item ][26] == '.') %}
-        app: uperf-bench-server-{{ worker_node_list[ node_idx_item ] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}
+{% if (worker_node_list[node_idx_item]|length>27) and (worker_node_list[node_idx_item][26] == '.') %}
+        app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}
 {% else %}
-        app: uperf-bench-server-{{ worker_node_list[ node_idx_item ] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
+        app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
 {% endif %}
         type: {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
       annotations:
@@ -23,10 +23,10 @@ items:
         pod_idx: '{{ item }}'
     spec:
       selector:
-{% if (worker_node_list[ node_idx_item]|length>27) and (worker_node_list[ node_idx_item ][26] == '.') %}
-        app: uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}
+{% if (worker_node_list[node_idx_item]|length>27) and (worker_node_list[node_idx_item][26] == '.') %}
+        app: uperf-bench-server-{{worker_node_list[node_idx_item] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}
 {% else %}
-        app: uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
+        app: uperf-bench-server-{{worker_node_list[node_idx_item] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
 {% endif %}
       ports:
       - name: uperf

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -12,14 +12,22 @@ items:
       labels:
         benchmark-uuid: {{ uuid }}
         benchmark-operator-workload: uperf
+{% if (worker_node_list[ node_idx_item]|length>27) and (worker_node_list[ node_idx_item ][26] == '.') %}
+        app: uperf-bench-server-{{ worker_node_list[ node_idx_item ] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}
+{% else %}
         app: uperf-bench-server-{{ worker_node_list[ node_idx_item ] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
+{% endif %}
         type: {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
       annotations:
         node_idx: '{{ node_idx_item }}'
         pod_idx: '{{ item }}'
     spec:
       selector:
+{% if (worker_node_list[ node_idx_item]|length>27) and (worker_node_list[ node_idx_item ][26] == '.') %}
+        app: uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}
+{% else %}
         app: uperf-bench-server-{{worker_node_list[ node_idx_item ] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
+{% endif %}
       ports:
       - name: uperf
         port: 20000


### PR DESCRIPTION
### Description
Internally UPERF benchmark task(s) may truncate a node name and combine it with a suffix to create other name(s) for internal use.  The truncation is based on a fixed length and hence could result in the truncated portion ended with a dot '.' character. Subsequently the combined name may be an illegal name e.g. "abc.-0-suffix" per RFC 1123
### Fixes
During truncation if the corner case happens, truncate one more char to trim off the dot.

### Test
The diff works on local unit-test and on the original system reported  by issue #644 