### PR TITLE
Able to run the sysbench test on a specific node

### DIFF
--- a/config/samples/sysbench/cr.yaml
+++ b/config/samples/sysbench/cr.yaml
@@ -10,6 +10,7 @@ spec:
       enabled: true
       #kind: vm
       # If you want to run this as a VM uncomment the above
+      #pin_node: "worker-0.mylab.example.com"
       tests:
       - name: cpu
         parameters:

--- a/docs/sysbench.md
+++ b/docs/sysbench.md
@@ -11,6 +11,9 @@ The optional argument **runtime_class** can be set to specify an
 optional runtime_class to the podSpec runtimeClassName.  This is
 primarily intended for Kata containers.
 
+The `pin_node` parameter allows to place the sysbench pod 
+on a specific node, using the `hostname` label.
+
 Note: please ensure you set 0 for other workloads if editing the
 [cr.yaml](../config/samples/sysbench/cr.yaml) file otherwise
 
@@ -29,6 +32,7 @@ spec:
       enabled: true
       #kind: vm
       # If you want to run this as a VM uncomment the above
+      #pin_node: "worker-0.mylab.example.com"
       tests:
       - name: cpu
         parameters:

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -14,6 +14,10 @@ spec:
        app: sysbench-{{ trunc_uuid }}
        benchmark-uuid: {{ uuid }}
     spec:
+{% if workload_args.pin_node is defined %}
+      nodeSelector:
+        kubernetes.io/hostname: '{{ workload_args.pin_node }}'
+{% endif %}
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}


### PR DESCRIPTION
### Description
Enable running the sysbench test on specific node specifying a `pin_node` parameter in the cr.

### Fixes
Close #661 