### PR TITLE
fix vm complete state

### DIFF
--- a/roles/hammerdb/tasks/main.yaml
+++ b/roles/hammerdb/tasks/main.yaml
@@ -269,7 +269,29 @@
 
   when: benchmark_state.resources[0].status.state == "Starting DB Workload"
 
-- include_role:
-    name: benchmark_state
-    tasks_from: completed.yml
+- block:
+
+  - include_role:
+      name: benchmark_state
+      tasks_from: completed.yml
+    when: resource_kind == "pod"
+
+
+  - block:
+
+      - name: get complete
+        command: "redis-cli get complete-{{ trunc_uuid }}"
+        register: complete_status
+
+      - operator_sdk.util.k8s_status:
+          api_version: ripsaw.cloudbulldozer.io/v1alpha1
+          kind: Benchmark
+          name: "{{ ansible_operator_meta.name }}"
+          namespace: "{{ operator_namespace }}"
+          status:
+            state: Complete
+            complete: true
+        when: complete_status.stdout == "true"
+    when: resource_kind == "vm"
   when: benchmark_state.resources[0].status.state == "Running"
+

--- a/roles/hammerdb/templates/db_mariadb_workload_vm.sh.j2
+++ b/roles/hammerdb/templates/db_mariadb_workload_vm.sh.j2
@@ -59,4 +59,4 @@ cd /hammer;
 ./hammerdbcli auto /creator/createdb.tcl;
 redis-cli set db-creation-{{trunc_uuid}} true;
 run_snafu --tool hammerdb -u {{ uuid }};
-
+redis-cli -h {{bo.resources[0].status.podIP}} set complete-{{trunc_uuid}} true;

--- a/roles/hammerdb/templates/db_mssql_workload_vm.sh.j2
+++ b/roles/hammerdb/templates/db_mssql_workload_vm.sh.j2
@@ -63,4 +63,4 @@ cd /hammer;
 ./hammerdbcli auto /creator/createdb.tcl;
 redis-cli set db-creation-{{trunc_uuid}} true;
 run_snafu --tool hammerdb -u {{ uuid }};
-
+redis-cli -h {{bo.resources[0].status.podIP}} set complete-{{trunc_uuid}} true;

--- a/roles/hammerdb/templates/db_postgres_workload_vm.sh.j2
+++ b/roles/hammerdb/templates/db_postgres_workload_vm.sh.j2
@@ -68,4 +68,4 @@ cd /hammer;
 ./hammerdbcli auto /creator/createdb.tcl;
 redis-cli set db-creation-{{trunc_uuid}} true;
 run_snafu --tool hammerdb -u {{ uuid }};
-
+redis-cli -h {{bo.resources[0].status.podIP}} set complete-{{trunc_uuid}} true;

--- a/roles/stressng/templates/stressng_workload_vm.yml.j2
+++ b/roles/stressng/templates/stressng_workload_vm.yml.j2
@@ -82,7 +82,7 @@ spec:
           - dnf install -y git redis stress-ng
           - pip install git+https://github.com/cloud-bulldozer/benchmark-wrapper
           - run_snafu --tool stressng -j /tmp/stressng-test/jobfile -u {{ uuid }}
-          - redis-cli -h {{bo.resources[0].status.podIP}} set complete true
+          - redis-cli -h {{bo.resources[0].status.podIP}} set complete-{{ trunc_uuid }} true
     name: cloudinitdisk
   - configMap:
       name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"

--- a/roles/uperf/templates/configmap_script.yml.j2
+++ b/roles/uperf/templates/configmap_script.yml.j2
@@ -57,6 +57,6 @@ data:
       fi;
       break;
     done;
-    redis-cli -h {{bo.resources[0].status.podIP}} set start false
+    redis-cli -h {{bo.resources[0].status.podIP}} set start-{{trunc_uuid}} false
     redis-cli -h {{bo.resources[0].status.podIP}} del clients-{{trunc_uuid}}
-    redis-cli -h {{bo.resources[0].status.podIP}} set complete true
+    redis-cli -h {{bo.resources[0].status.podIP}} set complete-{{trunc_uuid}} true

--- a/roles/uperf/templates/configmap_script.yml.j2
+++ b/roles/uperf/templates/configmap_script.yml.j2
@@ -26,7 +26,7 @@ data:
     redis-cli -h {{bo.resources[0].status.podIP}} setnx clients-{{trunc_uuid}} 0
     redis-cli -h {{bo.resources[0].status.podIP}} incr clients-{{trunc_uuid}}
     while true; do
-      BO_START=$(redis-cli -h {{bo.resources[0].status.podIP}} get start)
+      BO_START=$(redis-cli -h {{bo.resources[0].status.podIP}} get start-{{ trunc_uuid }})
       CLIENTS_READY=$(redis-cli -h {{bo.resources[0].status.podIP}} get clients-{{ trunc_uuid }})
       SERVERS_READY=$(redis-cli -h {{bo.resources[0].status.podIP}} get {{ trunc_uuid }})
       if [[ ("${BO_START}" =~ 'true') && ("${CLIENTS_READY}" == "${SERVERS_READY}") ]]; then


### PR DESCRIPTION
### Description
Benchmark-runner: CNV CI: Fix VM complete state for Stressng, Uperf, Hammerdb 
### Fixes
Stressng - adding {{ trunc_uuid }} to roles/stressng/templates/stressng_workload_vm.yml.j2
Uperf - adding {{ trunc_uuid }} to roles/uperf/templates/configmap_script.yml.j2
hammedb - adding back VM section to roles/hammerdb/tasks/main.yaml and add {{ trunc_uuid }} to the following:
roles/hammerdb/templates/db_mariadb_workload_vm.sh.j2
roles/hammerdb/templates/db_mssql_workload_vm.sh.j2
roles/hammerdb/templates/db_postgres_workload_vm.sh.j2

Those fixes already tested and verified by benchmark-runner framework
Please merge it ASAP to make benchmark-runner CNV CI pass. [https://github.com/redhat-performance/benchmark-runner/actions/runs/1151747467](benchmark runner CI)
