### PR TITLE
Set restartPolicy Never to all jobs deployed by benchmark-operator

### DIFF
--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -32,7 +32,7 @@ spec:
         {{ label }}: {{ value | to_json }}
 {% endfor %}
 {% endif %}
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% if workload_args.nodeselector is defined %}
       nodeSelector: 
 {% for label, value in  workload_args.nodeselector.items() %}

--- a/roles/flent/templates/workload.yml.j2
+++ b/roles/flent/templates/workload.yml.j2
@@ -89,7 +89,7 @@ spec:
       volumes:
         - name: flent-tmp
           emptyDir: {}
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% if workload_args.pin is sameas true %}
       nodeSelector:
           kubernetes.io/hostname: '{{ workload_args.pin_client }}'

--- a/roles/hammerdb/templates/db_creation.yml
+++ b/roles/hammerdb/templates/db_creation.yml
@@ -45,5 +45,5 @@ spec:
         configMap:
           name: "{{ ansible_operator_meta.name }}-creator-{{ trunc_uuid }}"
           defaultMode: 0640
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% include "metadata.yml.j2" %}

--- a/roles/hammerdb/templates/db_mariadb_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mariadb_workload.yml.j2
@@ -104,6 +104,6 @@ spec:
         configMap:
           name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0640
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% include "metadata.yml.j2" %}
 

--- a/roles/hammerdb/templates/db_mssql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mssql_workload.yml.j2
@@ -110,5 +110,5 @@ spec:
         configMap:
           name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0640
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% include "metadata.yml.j2" %}

--- a/roles/hammerdb/templates/db_postgres_workload.yml.j2
+++ b/roles/hammerdb/templates/db_postgres_workload.yml.j2
@@ -108,5 +108,5 @@ spec:
         configMap:
           name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0640
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% include "metadata.yml.j2" %}

--- a/roles/iperf3/templates/client.yml.j2
+++ b/roles/iperf3/templates/client.yml.j2
@@ -48,7 +48,7 @@ spec:
             {% if workload_args.ip_tos is defined %}  -S {{ workload_args.ip_tos }} {% endif %}
             {% if workload_args.omit_start is defined %} -O {{ workload_args.omit_start }} {% endif %}
             {% if workload_args.extra_options_client is defined %} {{ workload_args.extra_options_client }} {% endif %}"
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% if workload_args.pin_client is defined %}
       nodeSelector:
           kubernetes.io/hostname: '{{ workload_args.pin_client }}'

--- a/roles/iperf3/templates/client_store.yml.j2
+++ b/roles/iperf3/templates/client_store.yml.j2
@@ -60,4 +60,4 @@ spec:
       nodeSelector:
           kubernetes.io/hostname: '{{ workload_args.pin_client }}'
 {% endif %}
-      restartPolicy: OnFailure
+      restartPolicy: Never

--- a/roles/iperf3/templates/server.yml.j2
+++ b/roles/iperf3/templates/server.yml.j2
@@ -36,7 +36,7 @@ spec:
       - "iperf3 -s
         {% if workload_args.port is defined %} -p {{ workload_args.port }} {% endif %}
         {% if workload_args.extra_options_server is defined %} {{ workload_args.extra_options_server }} {% endif %}"
-  restartPolicy: OnFailure
+  restartPolicy: Never
 {% if workload_args.pin_server is defined %}
   nodeSelector:
     kubernetes.io/hostname: '{{ workload_args.pin_server }}'

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -88,7 +88,7 @@ spec:
                  break;
                done;
              fi"
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% if item.1.pin_node is defined and item.1.pin_node %}
       nodeSelector:
         kubernetes.io/hostname: '{{ item.1.pin_node }}'

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -106,5 +106,5 @@ spec:
         configMap:
           name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
           defaultMode: 0660
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% include "metadata.yml.j2" %}

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -39,5 +39,5 @@ spec:
         configMap:
           name: "sysbench-config-{{ trunc_uuid }}"
           defaultMode: 0777
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% include "metadata.yml.j2" %}

--- a/roles/testpmd/templates/testpmd.yml.j2
+++ b/roles/testpmd/templates/testpmd.yml.j2
@@ -80,7 +80,7 @@ spec:
       - name: hugepage
         emptyDir:
           medium: HugePages
-      restartPolicy: OnFailure
+      restartPolicy: Never
       serviceAccountName: benchmark-operator
 {% include "metadata.yml.j2" %}
 

--- a/roles/testpmd/templates/trex.yml.j2
+++ b/roles/testpmd/templates/trex.yml.j2
@@ -138,7 +138,7 @@ spec:
       - name: modules
         hostPath:
           path: /lib/modules
-      restartPolicy: OnFailure
+      restartPolicy: Never
       serviceAccountName: benchmark-operator
 {% include "metadata.yml.j2" %}
 

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -194,7 +194,7 @@ items:
             - name: config-volume
               configMap:
                 name: uperf-test-{{ trunc_uuid }}
-          restartPolicy: OnFailure
+          restartPolicy: Never
 {% if workload_args.pin is sameas false %}
 {% if workload_args.colocate is sameas true %}
           nodeSelector:

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -91,7 +91,7 @@ spec:
         - name: targets-volume
           configMap:
             name: vegeta-targets-{{ trunc_uuid }}
-      restartPolicy: OnFailure
+      restartPolicy: Never
 {% if workload_args.nodeselector is defined %}
       nodeSelector: {{ nodeselector|to_json }}
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
Our jobs must be one shot, and we should keep failed or completed pods to ease debugging.

Restart policy must be set to Never to prevent garbage collecting failed pods, more info at https://github.com/kubernetes/kubernetes/issues/74848#issuecomment-475178355

### Fixes
