### PR TITLE
Elasticsearch URL

### DIFF
--- a/config/crd/bases/ripsaw.cloudbulldozer.io_benchmarks.yaml
+++ b/config/crd/bases/ripsaw.cloudbulldozer.io_benchmarks.yaml
@@ -29,8 +29,10 @@ spec:
                 properties:
                   url:
                     type: string
+                    default: ""
                   index_name:
                     type: string
+                    default: ""
                   parallel:
                     type: boolean
                     default: false

--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -43,7 +43,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url}}"
           - name: es_index

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -39,7 +39,7 @@ spec:
           - name: CEPH_CACHE_DROP_PORT_NUM
             value: "{{ ceph_cache_drop_svc_port }}"
 {% endif %}
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/flent/templates/workload.yml.j2
+++ b/roles/flent/templates/workload.yml.j2
@@ -42,7 +42,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -48,7 +48,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/hammerdb/templates/db_mariadb_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mariadb_workload.yml.j2
@@ -41,7 +41,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/hammerdb/templates/db_mariadb_workload_vm.sh.j2
+++ b/roles/hammerdb/templates/db_mariadb_workload_vm.sh.j2
@@ -1,11 +1,9 @@
-{% if elasticsearch is defined %}
-{% if elasticsearch.url is defined %}
+{% if elasticsearch.url %}
 export es={{ elasticsearch.url }};
 export es_index={{ elasticsearch.index_name | default("ripsaw-hammerdb") }};
 export es_verify_cert={{ elasticsearch.verify_cert | default("true") }};
 export parallel={{ elasticsearch.parallel | default("false") }};
 export uuid={{uuid}};
-{% endif %}
 {% endif %}
 {% if workload_args.client_vm.network.multiqueue.enabled %}
 dnf install -y ethtool;

--- a/roles/hammerdb/templates/db_mssql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mssql_workload.yml.j2
@@ -41,7 +41,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/hammerdb/templates/db_mssql_workload_vm.sh.j2
+++ b/roles/hammerdb/templates/db_mssql_workload_vm.sh.j2
@@ -1,11 +1,9 @@
-{% if elasticsearch is defined %}
-{% if elasticsearch.url is defined %}
+{% if elasticsearch.url %}
 export es={{ elasticsearch.url }};
 export es_index={{ elasticsearch.index_name | default("ripsaw-hammerdb") }};
 export es_verify_cert={{ elasticsearch.verify_cert | default("true") }};
 export parallel={{ elasticsearch.parallel | default("false") }};
 export uuid={{uuid}};
-{% endif %}
 {% endif %}
 {% if workload_args.client_vm.network.multiqueue.enabled %}
 dnf install -y ethtool;

--- a/roles/hammerdb/templates/db_postgres_workload.yml.j2
+++ b/roles/hammerdb/templates/db_postgres_workload.yml.j2
@@ -41,7 +41,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/hammerdb/templates/db_postgres_workload_vm.sh.j2
+++ b/roles/hammerdb/templates/db_postgres_workload_vm.sh.j2
@@ -1,11 +1,9 @@
-{% if elasticsearch is defined %}
-{% if elasticsearch.url is defined %}
+{% if elasticsearch.url %}
 export es={{ elasticsearch.url }};
 export es_index={{ elasticsearch.index_name | default("ripsaw-hammerdb") }};
 export es_verify_cert={{ elasticsearch.verify_cert | default("true") }};
 export parallel={{ elasticsearch.parallel | default("false") }};
 export uuid={{uuid}};
-{% endif %}
 {% endif %}
 {% if workload_args.client_vm.network.multiqueue.enabled %}
 dnf install -y ethtool;

--- a/roles/image_pull/templates/image_pull.yml
+++ b/roles/image_pull/templates/image_pull.yml
@@ -52,7 +52,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/log_generator/templates/log_generator.yml
+++ b/roles/log_generator/templates/log_generator.yml
@@ -54,7 +54,7 @@ spec:
             value: "{{ clustername }}"
           - name: snafu_disable_logs
             value: "{{ workload_args.snafu_disable_logs | default(false) }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -44,7 +44,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url}}"
           - name: es_index

--- a/roles/pgbench/templates/workload.yml.j2
+++ b/roles/pgbench/templates/workload.yml.j2
@@ -34,7 +34,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: '{{ clustername }}'
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -44,7 +44,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -60,7 +60,7 @@ spec:
             value: "{{ ceph_cache_drop_svc_port }}"
 {% endif %}
 {% endif %}
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/stressng/templates/stressng_workload.yml.j2
+++ b/roles/stressng/templates/stressng_workload.yml.j2
@@ -70,7 +70,7 @@ spec:
           - name: mem_stressors
             value: "{{workload_args.mem_stressors}}"
 {% endif %}
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/stressng/templates/stressng_workload_vm.yml.j2
+++ b/roles/stressng/templates/stressng_workload_vm.yml.j2
@@ -65,14 +65,12 @@ spec:
           - "mkdir /tmp/stressng-test/jobfile"
           - "mount /dev/$(lsblk --nodeps -no name,serial | grep CVLY623300HK240D | cut -f1 -d' ') /tmp/stressng-test"
         runcmd:
-{% if elasticsearch is defined %}
-{% if elasticsearch.url is defined %}
+{% if elasticsearch.url %}
           - export es={{ elasticsearch.url }};
           - export es_index={{ elasticsearch.index_name | default("ripsaw-stressng") }};
           - export es_verify_cert={{ elasticsearch.verify_cert | default("true") }};
           - export parallel={{ elasticsearch.parallel | default("false") }};
           - export uuid={{uuid}};
-{% endif %}
 {% endif %}
 {% if workload_args.client_vm.network.multiqueue.enabled %}
           - dnf install -y ethtool

--- a/roles/testpmd/templates/trex.yml.j2
+++ b/roles/testpmd/templates/trex.yml.j2
@@ -113,7 +113,7 @@ spec:
           value: "{{ value }}"
 {% endfor %}
 {% endif %}
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
         - name: es
           value: "{{ elasticsearch.url }}"
         - name: es_index

--- a/roles/uperf/templates/configmap_script.yml.j2
+++ b/roles/uperf/templates/configmap_script.yml.j2
@@ -7,14 +7,12 @@ metadata:
 data:
   run_script.sh : |
     export h={{item.status.interfaces[0].ipAddress}}
-{% if elasticsearch is defined %}
-{% if elasticsearch.url is defined %}
+{% if elasticsearch.url %}
     export es={{ elasticsearch.url }}
     export es_index={{ elasticsearch.index_name | default("ripsaw-uperf") }}
     export es_verify_cert={{ elasticsearch.verify_cert | default(true) }}
     export parallel={{ elasticsearch.parallel | default(false) }}
     export uuid={{uuid}}
-{% endif %}
 {% endif %}
 {% if test_user is defined %}
     export test_user={{test_user}}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -57,7 +57,7 @@ items:
                 value: "{{ test_user | default("ripsaw") }}"
               - name: clustername
                 value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
               - name: es
                 value: "{{ elasticsearch.url }}"
               - name: es_index

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -42,7 +42,7 @@ spec:
             value: "{{ test_user | default("ripsaw") }}"
           - name: clustername
             value: "{{ clustername }}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
           - name: es
             value: "{{ elasticsearch.url }}"
           - name: es_index

--- a/roles/ycsb/templates/ycsb_load.yaml
+++ b/roles/ycsb/templates/ycsb_load.yaml
@@ -32,7 +32,7 @@ spec:
           value: "{{workload_args.operationcount}}"
         - name: uuid
           value: "{{uuid}}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
         - name: es
           value: "{{ elasticsearch.url }}"
         - name: es_index

--- a/roles/ycsb/templates/ycsb_run.yaml
+++ b/roles/ycsb/templates/ycsb_run.yaml
@@ -32,7 +32,7 @@ spec:
           value: "{{workload_args.operationcount}}"
         - name: uuid
           value: "{{uuid}}"
-{% if elasticsearch is defined %}
+{% if elasticsearch.url %}
         - name: es
           value: "{{ elasticsearch.url }}"
         - name: es_index


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

With this change, elasticsearch indexing is enabled when the elasticsearch.url parameter is filled with something different from ""

### Fixes

The current implementation is not possible to disable ES indexing since the elasticsearch dictionary defaults to {}
