### PR TITLE
Fio no log hist

### DIFF
--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -219,7 +219,8 @@ The workload loops are nested as such from the CR options:
   > using these parameters, but note this behavious is configured via the EXPERT AREA section of the CR as
   > [described below](#expert-specjob_params), and therefore this may be adjusted to user preferences.
 - **filesize**: The size of the file used for each job in the workload (per `numjobs * servers` as described above)
-- **log_sample_rate**: Applied to fio options `log_avg_msec` and `log_hist_msec` in the jobfile configmap; see `fio(1)`
+- **log_sample_rate**: (optional) Applied to fio options `log_avg_msec` (milliseconds) in the jobfile configmap; see `fio(1)`
+- **log_hist_msec** (optional) if set, enables histogram logging at this specified interval in milliseconds
 - **storageclass**: (optional) The K8S StorageClass to use for persistent volume claims (PVC) per server pod
 - **pvcaccessmode**: (optional) The AccessMode to request with the persistent volume claim (PVC) for the fio server. Can be one of ReadWriteOnce,ReadOnlyMany,ReadWriteMany Default: ReadWriteOnce
 - **pvcvolumemode**: (optional) The volmeMode to request with the persistent volume claim (PVC) for the fio server. Can be one of Filesystem,Block Default: Filesystem

--- a/roles/fio_distributed/templates/configmap.yml.j2
+++ b/roles/fio_distributed/templates/configmap.yml.j2
@@ -51,9 +51,13 @@ data:
     write_bw_log=fio
     write_iops_log=fio
     write_lat_log=fio
+{% if workload_args.log_sample_rate is defined %}
+    log_avg_msec={{ workload_args.log_sample_rate }}
+{% endif %}
+{% if workload.log_hist_msec is defined %}
     write_hist_log=fio
-    log_avg_msec={{workload_args.log_sample_rate}}
-    log_hist_msec={{workload_args.log_sample_rate}}
+    log_hist_msec={{ workload_args.log_hist_msec }}
+{% endif %}
     clocksource=clock_gettime
     kb_base=1000
     unit_base=8

--- a/tests/test_crs/valid_fiod_bsrange.yaml
+++ b/tests/test_crs/valid_fiod_bsrange.yaml
@@ -38,6 +38,7 @@ spec:
       write_ramp_time: 1
       filesize: 10MiB
       log_sample_rate: 2000
+      log_hist_msec: 3000
       storagesize: 16Mi
       debug: true
 #######################################

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -41,7 +41,6 @@ spec:
       read_ramp_time: 1
       write_ramp_time: 1
       filesize: 10MiB
-      log_sample_rate: 2000
       debug: true
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #

--- a/tests/test_crs/valid_fiod_hostpath.yaml
+++ b/tests/test_crs/valid_fiod_hostpath.yaml
@@ -26,14 +26,11 @@ spec:
       prefill: true
       jobs:
         - write
-        - read
-        - randwrite
         - randread
         - randrw
       bs:
         - 4KiB
       numjobs:
-        - 1
         - 2
       iodepth: 2
       read_runtime: 6
@@ -41,7 +38,7 @@ spec:
       read_ramp_time: 1
       write_ramp_time: 1
       filesize: 10MiB
-      debug: true
+      debug: false
 #######################################
 #  EXPERT AREA - MODIFY WITH CAUTION  #
 #######################################


### PR DESCRIPTION
do not merge yet, in process of running fio CI tests, but tested this on a small scale
This PR turns off histogram logging by default, while allowing the user to turn it back on for later development
This shrinks the amount of log data being fetched by fio-client pod, hopefully reducing chance of fio inflate error