### PR TITLE
Fix not targeted metadata collection

### DIFF
--- a/roles/backpack/tasks/main.yml
+++ b/roles/backpack/tasks/main.yml
@@ -5,7 +5,6 @@
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ operator_namespace }}"
     status:
-      state: "Metadata Collecting"
       complete: false
       metadata: "Collecting"
   when: benchmark_state.resources[0].status.state is not defined
@@ -71,6 +70,16 @@
             state: Complete
             complete: true
             metadata: Complete
+        when: workload.name == "backpack"
+
+      - operator_sdk.util.k8s_status:
+          api_version: ripsaw.cloudbulldozer.io/v1alpha1
+          kind: Benchmark
+          name: "{{ ansible_operator_meta.name }}"
+          namespace: "{{ operator_namespace }}"
+          status:
+            metadata: Complete
+        when: workload.name != "backpack"
       
       - name: Get benchmark state
         k8s_facts:


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
Workloads using not targeted metadata collection are not working since the latest changes pushed into the backpack role. The condition https://github.com/cloud-bulldozer/benchmark-operator/blob/9826c52bd02ec21302e656155fcb3d2369de00c4/playbooks/benchmark.yml#L100
is never met since the backpack role sets status.state regardless it's running a purely backpack workload or not, we need to set it only when running a standalone backpack workload.

cc: @kedark3 

### Fixes

Workloads using daemonset based metadata collection.


