### PR TITLE
Removing default value for image_name as it was causing the real defa…

### DIFF
--- a/config/crd/bases/ripsaw.cloudbulldozer.io_benchmarks.yaml
+++ b/config/crd/bases/ripsaw.cloudbulldozer.io_benchmarks.yaml
@@ -32,7 +32,6 @@ spec:
                     default: ""
                   index_name:
                     type: string
-                    default: ""
                   parallel:
                     type: boolean
                     default: false


### PR DESCRIPTION
…ults defined in the yaml template not to be used

### Description
Recently merged PR https://github.com/cloud-bulldozer/benchmark-operator/pull/665 set the index_name default to "" for Null. This is causing the defaults in the yaml template of the workload to no longer be honored.

### Fixes
