### PR TITLE
Add a nodeSelector for vegeta pods

### DIFF
--- a/config/samples/vegeta/cr.yaml
+++ b/config/samples/vegeta/cr.yaml
@@ -12,6 +12,7 @@ spec:
   workload:
     name: vegeta
     args:
+      # node_selector: "vegeta=true"
       hostnetwork: false
       clients: 2
       targets:

--- a/docs/vegeta.md
+++ b/docs/vegeta.md
@@ -11,6 +11,9 @@ The option **runtime_class** can be set to specify an optional
 runtime_class to the podSpec runtimeClassName.  This is primarily
 intended for Kata containers.
 
+The **node_selector** option can be used to limit the nodes where
+the vegeta pods are deployed.
+
 ```yaml
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
@@ -24,6 +27,7 @@ spec:
   workload:
     name: vegeta
     args:
+      # node_selector: "vegeta=true"
       clients: 2
       image: quay.io/cloud-bulldozer/vegeta:latest
       hostnetwork: false

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -13,6 +13,10 @@ spec:
         app: vegeta-benchmark-{{ trunc_uuid }}
         benchmark-uuid: {{ uuid }}
     spec:
+{% if workload_args.node_selector is defined %}
+      nodeSelector:
+        '{{ workload_args.node_selector.split("=")[0] }}': '{{ workload_args.node_selector.split("=")[1] }}'
+{% endif %}
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}


### PR DESCRIPTION
### Description

Currently vegeta pods can run on any node. This PR allows to specify a node selector in the vegeta benchmarks.

### Fixes
N/A, new feature