### PR TITLE
Add somaxconn parameter to vegeta tests

### DIFF
--- a/config/samples/vegeta/cr.yaml
+++ b/config/samples/vegeta/cr.yaml
@@ -13,6 +13,7 @@ spec:
     name: vegeta
     args:
       # node_selector: "vegeta=true"
+      # net_core_somaxconn: 4096
       hostnetwork: false
       clients: 2
       targets:

--- a/docs/vegeta.md
+++ b/docs/vegeta.md
@@ -14,6 +14,8 @@ intended for Kata containers.
 The **node_selector** option can be used to limit the nodes where
 the vegeta pods are deployed.
 
+Use **net_core_somaxconn** to tweak the maximum number of "backlogged sockets" (`net.core.somaxconn`).  Default is 128.
+
 ```yaml
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
@@ -28,6 +30,7 @@ spec:
     name: vegeta
     args:
       # node_selector: "vegeta=true"
+      # net_core_somaxconn: 4096
       clients: 2
       image: quay.io/cloud-bulldozer/vegeta:latest
       hostnetwork: false

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -13,6 +13,12 @@ spec:
         app: vegeta-benchmark-{{ trunc_uuid }}
         benchmark-uuid: {{ uuid }}
     spec:
+{% if workload_args.net_core_somaxconn is defined %}
+      securityContext:
+        sysctls:
+        - name: net.core.somaxconn
+          value: "{{ workload_args.net_core_somaxconn }}"
+{% endif %}
 {% if workload_args.node_selector is defined %}
       nodeSelector:
         '{{ workload_args.node_selector.split("=")[0] }}': '{{ workload_args.node_selector.split("=")[1] }}'


### PR DESCRIPTION
### Description

The net.core.somaxconn sysctl is 128 by default (4096 in newer kernels https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=19f92a030ca6d772ab44b22ee6a01378a8cb32d4)

You can specify sysctls at pod level as https://docs.openshift.com/container-platform/4.7/nodes/containers/nodes-containers-sysctls.html#nodes-containers-sysctls-setting_nodes-containers-using 

### Fixes
N/A, new feature