### PR TITLE
Change the uuid for the testpmd pod

### DIFF
--- a/roles/testpmd/templates/testpmd.yml.j2
+++ b/roles/testpmd/templates/testpmd.yml.j2
@@ -10,7 +10,9 @@ spec:
     metadata:
       labels:
         app: "testpmd-application-pod-{{ trunc_uuid }}"
-        benchmark-uuid: {{ uuid }}
+	# changing the uuid so that the check for complete pods ignores the server pod and only checks the 
+	# trex client pod (similar to uperf)
+        benchmark-uuid: testpmd-{{ uuid }}
       annotations:
         k8s.v1.cni.cncf.io/networks: '[
 {% set i = namespace(value=0) %}


### PR DESCRIPTION
### Description
Changed the uuid for the testpmd pod to be different from the uuid for the benchmark. We don't really need it there and it prevents the benchmark from ever finishing as the testpmd pod acts as a server pod and will never stop, unlike the client trex pod. 

