### PR TITLE
Cleanup delay pass to smf

### DIFF
--- a/roles/smallfile/templates/smallfilejob.other_parameters.yaml.j2
+++ b/roles/smallfile/templates/smallfilejob.other_parameters.yaml.j2
@@ -99,3 +99,8 @@ verify-read: {{ workload_args.verify_read }}
 {% if workload_args.incompressible is defined %}
 incompressible: {{ workload_args.incompressible }}
 {% endif %}
+
+{% if workload_args.cleanup_delay_usec_per_file is defined %}
+cleanup-delay-usec-per-file: {{ workload_args.cleanup_delay_usec_per_file }}
+{% endif %}
+

--- a/tests/test_crs/valid_smallfile.yaml
+++ b/tests/test_crs/valid_smallfile.yaml
@@ -23,7 +23,7 @@ spec:
     name: smallfile
     args:
       clients: 2
-      operation: ["create", "read", "append", "delete"]
+      operation: ["create", "read", "delete", "cleanup"]
       threads: 1
       file_size: 2
       record_size: 1
@@ -42,5 +42,5 @@ spec:
       files_per_dir: 2000
       dirs_per_dir: 4
       files: 100000
-      cleanup_delay_usec_per_file: 200
+      cleanup_delay_usec_per_file: 20
       debug: true


### PR DESCRIPTION
add support for cleanup_delay_usec_per_file CR parameter 
should have been in last PR but I missed
change the CI to actually test it