### PR TITLE
Fio server_vm image updates

### DIFF
--- a/config/samples/fio/vm-cr.yaml
+++ b/config/samples/fio/vm-cr.yaml
@@ -33,7 +33,10 @@ spec:
       # vm_cores: 2
       # Memory that will be available inside the VM
       # Default: 5G
-      # vm_cores: 10G
+      # vm_memory: 10G
+      # VM bus type: virtio, sata, or scsi
+      # Default: virtio
+      # vm_bus: virtio
       # test types, see fio documentation
       jobs:
         - write

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -108,12 +108,13 @@ The workload loops are nested as such from the CR options:
   > the specified annotations on the client pods' metadata.
 - **kind**: Can either be `pod` or `vm` to determine if the fio workload is run in a Pod or in a VM
   > Note: For VM workloads, you need to install Openshift Virtualization first
-- **vm_image**: Whether to use a pre-defined VM image with pre-installed requirements. Necessary for disconnected installs.
-  > Note: You can use my fedora image here: quay.io/mulbc/fed-fio \
-  > Note: Only applies when kind is set to `vm`
+- **vm_image**: VM image to use for the test, benchmark dependencies are provided by a pod container image (Default pod image: quay.io/cloud-bulldozer/fio:latest). Container images should be pre-loaded for disconnected installs. Default: quay.io/kubevirt/fedora-container-disk-images:latest
+  > Note: Only applies when kind is set to `vm`, current assumption is the firewall is disabled in the VM (default for most cloud images)
 - **vm_cores**: The number of CPU cores that will be available inside the VM. Default=1
   > Note: Only applies when kind is set to `vm`
-- **vm_cores**: The amount of Memory that will be available inside the VM in Kubernetes format. Default=5G
+- **vm_memory**: The amount of Memory that will be available inside the VM in Kubernetes format. Default=5G
+  > Note: Only applies when kind is set to `vm`
+- **vm_bus**: The VM bus type (virtio, scsi, or sata). Default=virtio
   > Note: Only applies when kind is set to `vm`
 - **bs**: (list) blocksize values to use for I/O transactions
   > Note: We set the `direct=1` fio option in the jobfile configmap. In order to avoid errors, the `bs` values
@@ -141,6 +142,9 @@ The workload loops are nested as such from the CR options:
 - **log_sample_rate**: (optional) Applied to fio options `log_avg_msec` (milliseconds) in the jobfile configmap; see `fio(1)`
 - **log_hist_msec** (optional) if set, enables histogram logging at this specified interval in milliseconds
 - **storageclass**: (optional) The K8S StorageClass to use for persistent volume claims (PVC) per server pod
+  > Note: Currently when the type is set to `vm` only Block-device storageclasses are supported
+- **hostpath**: (optional) The local storage path to be used for hostPath (pods) or hostDisk (VMs)
+  > Note: When the type is set to `vm` make sure the hostDisk feature-gate is enabled and proper permission settings are applied to the path if applicable (i.e. chcon -Rt container_file_t <path>)
 - **pvcaccessmode**: (optional) The AccessMode to request with the persistent volume claim (PVC) for the fio server. Can be one of ReadWriteOnce,ReadOnlyMany,ReadWriteMany Default: ReadWriteOnce
 - **pvcvolumemode**: (optional) The volmeMode to request with the persistent volume claim (PVC) for the fio server. Can be one of Filesystem,Block Default: Filesystem
   > Note: It is recommended to change this to `Block` for VM tests

--- a/roles/fio_distributed/templates/server_vm.yml.j2
+++ b/roles/fio_distributed/templates/server_vm.yml.j2
@@ -22,13 +22,22 @@ spec:
       cores: {{ workload_args.vm_cores | default(1) }}
     devices:
       disks:
-        - name: registrydisk
-        - name: cloudinitdisk
+        - disk:
+            bus: {{ workload_args.vm_bus | default('virtio') }}
+          name: registrydisk
+        - disk:
+            bus: {{ workload_args.vm_bus | default('virtio') }}
+          name: cloudinitdisk
 {% if workload_args.storageclass is defined
     or workload_args.hostpath is defined %}
         - disk:
-            bus: virtio
+            bus: {{ workload_args.vm_bus | default('virtio') }}
           name: data-volume
+          serial: data
+{% else %}
+        - disk:
+            bus: {{ workload_args.vm_bus | default('virtio') }}
+          name: emptydisk
           serial: data
 {% endif %}
     resources:
@@ -37,37 +46,23 @@ spec:
   volumes:
     - name: registrydisk
       containerDisk:
-        image: {{ workload_args.vm_image | default('kubevirt/fedora-cloud-container-disk-demo:latest') }}
+        image: {{ workload_args.vm_image | default('quay.io/kubevirt/fedora-container-disk-images:latest') }}
     - name: cloudinitdisk
       cloudInitNoCloud:
         userData: |-
           #cloud-config
-          password: fedora
+          password: ripsaw
           chpasswd: { expire: False }
           bootcmd:
-{% if workload_args.storageclass is defined
-    or workload_args.hostpath is defined %}
             - "mkdir -p {{ fio_path }} || true"
-            - mkfs.ext4 /dev/disk/by-id/virtio-data
-            - "mount /dev/disk/by-id/virtio-data {{ fio_path }}"
-{% endif %}
+            - "[ -e /dev/disk/by-id/*data ] && disk=$(shopt -s nullglob; basename /dev/disk/by-id/*data) && mkfs.ext4 /dev/disk/by-id/$disk && mount /dev/disk/by-id/$disk {{ fio_path }}"
           runcmd:
-{% if workload_args.vm_image is undefined %}
-            - dnf install -y fio wget curl python3 python3-pip
-{% endif %}
-            - cd /tmp
-{% if workload_args.metadata is defined
-    and (workload_args.metadata.collection|default(false))
-    and (workload_args.metadata.targeted|default(true)) %}
-            - export ES_SERVER={{ elasticsearch.url }}
-{% if workload_args.vm_image is undefined %}
-            - wget https://raw.githubusercontent.com/cloud-bulldozer/bohica/master/stockpile-wrapper/stockpile-wrapper.py
-            - pip3 install elasticsearch-dsl openshift kubernetes redis
-{% endif %}
-            # TODO: start stockpile-wrapper script
-            python3 stockpile-wrapper.py -s {{ elasticsearch.url }} -u {{ uuid }} -n "$my_node_name" -N "$my_pod_name" --redisip {{ bo.resources[0].status.podIP }} --redisport 6379 --force
-{% endif %}
-            - fio --server
+            - dnf install -y podman
+            - "img=`podman create {{ workload_args.image | default('quay.io/cloud-bulldozer/fio:latest') }}`"
+            - fs=`podman mount $img`
+            - "mkdir -p $fs/{{ fio_path }} || true"
+            - "mount -o bind /{{ fio_path }} $fs/{{ fio_path }}"
+            - "chroot $fs bash -c 'cd /{{ fio_path }}; fio --server'"
 {% if workload_args.storageclass is defined %}
     - name: data-volume
       persistentVolumeClaim:
@@ -75,7 +70,17 @@ spec:
 {% elif workload_args.hostpath is defined %}
     - name: data-volume
       hostDisk:
-        path: {{ workload_args.hostpath }}
+        path: "{{ workload_args.hostpath }}/fio-server-{{item | string}}-{{ trunc_uuid }}"
         capacity: {{ workload_args.storagesize | default("5Gi") }}
         type: DiskOrCreate
+{% else %}
+    - name: emptydisk
+      emptyDisk:
+        capacity: {{ workload_args.storagesize | default("5Gi") }}
 {% endif %}
+{% if workload_args.nodeselector is defined %}
+  nodeSelector:
+{% for label, value in  workload_args.nodeselector.items() %}
+    {{ label | replace ("_", "-" )}}: {{ value }}
+{% endfor %}
+{% endif  %}


### PR DESCRIPTION
### Description
Adjusting server_vm config so that any VM containerDisk image can be used since the workload is run from chroot into a fio container image (i.e. no custom VM images need to be maintained).

Also adding a fallback VM option if no PVC/HostDisk is specified, use an emptyDisk (ephemeral storage).
Adding nodeSelector support for VMs.



### Fixes
#527 