### PR TITLE
Concurrency for e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,8 @@ on:
       img:
         description: Benchmark-operator image location
         default: quay.io/rht_perf_ci/benchmark-operator:e2e
+concurrency:
+  group: e2e-ci
 jobs:
   e2e:
     name: E2E testing


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Limits concurrency to one in e2e workflow to prevent conflicts.

### Fixes
