### PR TITLE
update sleep execution after scale tu capture run_snafu exit code correctly

### DIFF
--- a/docs/e2e-ci.md
+++ b/docs/e2e-ci.md
@@ -68,3 +68,4 @@ Running tests in local has several requirements:
 - make
 - kubectl
 - oc
+- yq

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -72,7 +72,7 @@ spec:
           - name: AWS_DEFAULT_REGION
             value: "{{ workload_args.aws.default_region | default() }}"
 {% endif %}
-        command: ["/bin/sh", "-c"]
+        command: ["/bin/sh", "-e", "-c"]
         args:
           - "run_snafu --tool scale --scale {{workload_args.scale}} -u {{uuid}} --user {{test_user|default("ripsaw")}} --incluster true --poll_interval {{workload_args.poll_interval|default(5)}} \
 {% if workload_args.debug is defined and workload_args.debug %}


### PR DESCRIPTION
Current execution always ends with exit 0 after sleep runs.

Executing sh with -e will exit if run_snafu fails capturing its exit code

```
[morenod@morenod-laptop ~]$ sh -e -c "echo 1 ; echo 0"
1
0
[morenod@morenod-laptop ~]$ sh -e -c "false ; echo 0"
[morenod@morenod-laptop ~]$ sh -e -c "true ; echo 0"
0
[morenod@morenod-laptop ~]$ 
```

Fixes #692