### PR TITLE
Changing activeDeadlineSeconds default for api_load

### DIFF
--- a/roles/api_load/templates/api_load.yml
+++ b/roles/api_load/templates/api_load.yml
@@ -6,7 +6,7 @@ metadata:
   namespace: '{{ operator_namespace }}'
 spec:
   backoffLimit: 0
-  activeDeadlineSeconds: {{ workload_args.job_timeout|default(3600) }}
+  activeDeadlineSeconds: {{ workload_args.job_timeout | default(28800) }}
   parallelism: {{ workload_args.pod_count | default(1) | int }}
   template:
     metadata:


### PR DESCRIPTION
### Description

When running a full load test this made the
process undergo a forced termination.

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

