### PR TITLE
Using tag latest, since master tag is out of sync

### DIFF
--- a/roles/smallfile/tasks/main.yml
+++ b/roles/smallfile/tasks/main.yml
@@ -58,7 +58,7 @@
             spec:
               containers:
                 - name: publisher-container
-                  image: "{{ workload_args.image | default('quay.io/cloud-bulldozer/smallfile:master') }}"
+                  image: "{{ workload_args.image | default('quay.io/cloud-bulldozer/smallfile:latest') }}"
                   tty: true
                   command: ["/bin/sh", "-c"]
                   workingDir: /root/smallfile-master/

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -41,7 +41,7 @@ spec:
           securityContext:
             privileged: true
 {% endif %}
-          image: {{ workload_args.image | default('quay.io/cloud-bulldozer/smallfile:master') }}
+          image: {{ workload_args.image | default('quay.io/cloud-bulldozer/smallfile:latest') }}
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           workingDir: /opt/snafu
@@ -103,11 +103,11 @@ spec:
 {% if workload_args.samples is defined %}
               --samples {{ workload_args.samples }}
 {% endif %}
-              --tool smallfile 
-              --operations $arr 
-              --top {{ smallfile_path }}/smallfile_test_data 
-              --dir /var/tmp/RESULTS 
-              --yaml-input-file /tmp/smallfile/smallfilejob 
+              --tool smallfile
+              --operations $arr
+              --top {{ smallfile_path }}/smallfile_test_data
+              --dir /var/tmp/RESULTS
+              --yaml-input-file /tmp/smallfile/smallfilejob
 {% if workload_args.debug is defined and workload_args.debug %}
               -v
 {% endif %}


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

### Description

`smallfile` image tag is pointing to `master` as default. But `master` tag is not being built when a new version is deployed, changing it to `latest`.

### Fixes
