### PR TITLE
Standardizes using latest tag for images

### DIFF
--- a/roles/fs-drift/tasks/main.yml
+++ b/roles/fs-drift/tasks/main.yml
@@ -59,7 +59,7 @@
             spec:
               containers:
                 - name: publisher-container
-                  image: quay.io/cloud-bulldozer/fs-drift:latest
+                  image: "{{ workload_args.image | default('quay.io/cloud-bulldozer/fs-drift:latest') }}"
                   tty: true
                   command: ["/bin/sh", "-c"]
                   workingDir: /root/fs-drift-master/

--- a/roles/fs-drift/tasks/main.yml
+++ b/roles/fs-drift/tasks/main.yml
@@ -59,7 +59,7 @@
             spec:
               containers:
                 - name: publisher-container
-                  image: quay.io/cloud-bulldozer/fs-drift:master
+                  image: quay.io/cloud-bulldozer/fs-drift:latest
                   tty: true
                   command: ["/bin/sh", "-c"]
                   workingDir: /root/fs-drift-master/

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -41,7 +41,7 @@ spec:
           securityContext:
             privileged: true
 {% endif %}
-          image: {{ workload_args.image | default('quay.io/cloud-bulldozer/fs-drift:master') }}
+          image: {{ workload_args.image | default('quay.io/cloud-bulldozer/fs-drift:latest') }}
           # example of what to do when debugging image
           # image: quay.io/bengland2/fs-drift:latest
           imagePullPolicy: Always

--- a/roles/hammerdb/templates/db_mariadb_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mariadb_workload.yml.j2
@@ -41,7 +41,7 @@ spec:
             cpu: {{ workload_args.limits_cpu }}
             memory: {{ workload_args.limits_memory }}
 {% endif %}
-        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/hammerdb:master') }}
+        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/hammerdb:latest') }}
         imagePullPolicy: Always
         env:
           - name: uuid

--- a/roles/hammerdb/templates/db_mssql_workload.yml.j2
+++ b/roles/hammerdb/templates/db_mssql_workload.yml.j2
@@ -41,7 +41,7 @@ spec:
             cpu: {{ workload_args.limits_cpu }}
             memory: {{ workload_args.limits_memory }}
 {% endif %}
-        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/hammerdb:master') }}
+        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/hammerdb:latest') }}
         imagePullPolicy: Always
         env:
           - name: uuid

--- a/roles/hammerdb/templates/db_postgres_workload.yml.j2
+++ b/roles/hammerdb/templates/db_postgres_workload.yml.j2
@@ -41,7 +41,7 @@ spec:
             cpu: {{ workload_args.limits_cpu }}
             memory: {{ workload_args.limits_memory }}
 {% endif %}
-        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/hammerdb:master') }}
+        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/hammerdb:latest') }}
         imagePullPolicy: Always
         env:
           - name: uuid

--- a/roles/iperf3/templates/client_store.yml.j2
+++ b/roles/iperf3/templates/client_store.yml.j2
@@ -42,7 +42,7 @@ spec:
 {% endif %}
       containers:
       - name: benchmark
-        image: "quay.io/cloud-bulldozer/iperf3:latest"
+        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/iperf3:latest') }}
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args:

--- a/roles/pgbench/defaults/main.yml
+++ b/roles/pgbench/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 db_port: 5432
-pgb_base_image: "quay.io/cloud-bulldozer/pgbench:latest"
+pgb_base_image: "{{ workload_args.image | default('quay.io/cloud-bulldozer/pgbench:latest') }}"
 timeout_min: 300
 num_databases_pattern: "{{ workload_args.num_databases_pattern|default('all') }}"
 run_time: "{{ workload_args.run_time|default('') }}"

--- a/roles/smallfile/tasks/main.yml
+++ b/roles/smallfile/tasks/main.yml
@@ -58,7 +58,7 @@
             spec:
               containers:
                 - name: publisher-container
-                  image: "{{ workload_args.image | default('quay.io/cloud-bulldozer/smallfile:master') }}"
+                  image: "{{ workload_args.image | default('quay.io/cloud-bulldozer/smallfile:latest') }}"
                   tty: true
                   command: ["/bin/sh", "-c"]
                   workingDir: /root/smallfile-master/

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -41,7 +41,7 @@ spec:
           securityContext:
             privileged: true
 {% endif %}
-          image: {{ workload_args.image | default('quay.io/cloud-bulldozer/smallfile:master') }}
+          image: {{ workload_args.image | default('quay.io/cloud-bulldozer/smallfile:latest') }}
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
           workingDir: /opt/snafu
@@ -103,11 +103,11 @@ spec:
 {% if workload_args.samples is defined %}
               --samples {{ workload_args.samples }}
 {% endif %}
-              --tool smallfile 
-              --operations $arr 
-              --top {{ smallfile_path }}/smallfile_test_data 
-              --dir /var/tmp/RESULTS 
-              --yaml-input-file /tmp/smallfile/smallfilejob 
+              --tool smallfile
+              --operations $arr
+              --top {{ smallfile_path }}/smallfile_test_data
+              --dir /var/tmp/RESULTS
+              --yaml-input-file /tmp/smallfile/smallfilejob
 {% if workload_args.debug is defined and workload_args.debug %}
               -v
 {% endif %}


### PR DESCRIPTION
Depends-On: https://github.com/cloud-bulldozer/benchmark-wrapper/pull/396

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

### Description

image tags are pointing to master as default. But master tag is not being built when a new version is deployed, changing it to latest.

### Fixes
