### PR TITLE
oslat runtime parameter fix

### DIFF
--- a/roles/oslat/files/oslat.sh
+++ b/roles/oslat/files/oslat.sh
@@ -78,9 +78,9 @@ if [ "${USE_TASKSET}" == "true" ]; then
 	prefix_cmd="taskset --cpu-list ${cyccore}"
 fi
  
-echo "cmd to run: oslat --runtime ${RUNTIME} --rtprio ${RTPRIO} --cpu-list ${cyccore} --cpu-main-thread ${cpus[0]}"
+echo "cmd to run: oslat --duration ${RUNTIME} --rtprio ${RTPRIO} --cpu-list ${cyccore} --cpu-main-thread ${cpus[0]}"
 
-oslat --runtime ${RUNTIME} --rtprio ${RTPRIO} --cpu-list ${cyccore} --cpu-main-thread ${cpus[0]}
+oslat --duration ${RUNTIME} --rtprio ${RTPRIO} --cpu-list ${cyccore} --cpu-main-thread ${cpus[0]}
 
 if [ "${DISABLE_CPU_BALANCE}" == "true" ]; then
 	enable_balance


### PR DESCRIPTION
### Description
oslat doesn't have a --runtime parameter (anymore?), but a --duration instead:

```
This is an OS latency detector by running busy loops on specified cores.
Please run this tool using root.

Available options:

-b, --bucket-size      Specify the number of the buckets (4-1024)
-B, --bias             Add a bias to all the buckets using the estimated mininum
-c, --cpu-list         Specify CPUs to run on, e.g. '1,3,5,7-15'
-C, --cpu-main-thread  Specify which CPU the main thread runs on.  Default is cpu0.
-D, --duration         Specify test duration, e.g., 60, 20m, 2H
                       (m/M: minutes, h/H: hours, d/D: days)
-f, --rtprio           Using SCHED_FIFO priority (1-99)
-m, --workload-mem     Size of the memory to use for the workload (e.g., 4K, 1M).
                       Total memory usage will be this value multiplies 2*N,
                       because there will be src/dst buffers for each thread, and
                       N is the number of processors for testing.
-s, --single-preheat   Use a single thread when measuring latency at preheat stage
                       NOTE: please make sure the CPU frequency on all testing cores
                       are locked before using this parmater.  If you don't know how
                       to lock the freq then please don't use this parameter.
-T, --trace-threshold  Stop the test when threshold triggered (in us),
                       print a marker in ftrace and stop ftrace too.
-v, --version          Display the version of the software.
-w, --workload         Specify a kind of workload, default is no workload
                       (options: no, memmove)
-z, --zero-omit        Don't display buckets in the output histogram if all zeros.
```

### Fixes

- Fixes the call in oslat.sh
- also fixes a misspelled node_selector
