### PR TITLE
Add dateutil and requests as deps for CLI setup.cfg

### DIFF
--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -29,6 +29,8 @@ install_requires =
     PyYAML==5.4.1
     elasticsearch==7.13.4
     GitPython==3.1.18
+    python-dateutil
+    requests
 python_requires = >=3.8
 
 [options.extras_require]


### PR DESCRIPTION
### Description
Missing Python package for the Ripsaw CLI in a fresh 3.10 venv.

### Fixes
Fixes #716




