### PR TITLE
Swap the label selector for the operator

### DIFF
--- a/cli/ripsaw/commands/operator.py
+++ b/cli/ripsaw/commands/operator.py
@@ -70,7 +70,7 @@ def delete(
 def wait_for_operator(namespace="benchmark-operator", kubeconfig=None):
     """wait for operator pods to be ready"""
     cluster = Cluster(kubeconfig_path=kubeconfig)
-    label_selector = "control-plane=controller-manager"
+    label_selector = "name=benchmark-operator"
     cluster.wait_for_pods(label_selector, namespace, timeout=120)
 
 

--- a/cli/tests/commands/test_operator_commands.py
+++ b/cli/tests/commands/test_operator_commands.py
@@ -21,12 +21,12 @@ class TestOperatorCommands:
     def test_operator_commands(self, kind_kubeconfig, cluster, benchmark_namespace):
         operator.install(kubeconfig=kind_kubeconfig)
         pods = cluster.get_pods(
-            label_selector="control-plane=controller-manager", namespace="benchmark-operator"
+            label_selector="name=benchmark-operator", namespace="benchmark-operator"
         )
         assert len(pods.items) == 1
         assert pods.items[0].status.phase == "Running"
         operator.delete(kubeconfig=kind_kubeconfig)
         pods = cluster.get_pods(
-            label_selector="control-plane=controller-manager", namespace="benchmark-operator"
+            label_selector="name=benchmark-operator", namespace="benchmark-operator"
         )
         assert len(pods.items) == 0

--- a/playbooks/benchmark.yml
+++ b/playbooks/benchmark.yml
@@ -27,7 +27,7 @@
       api_version: v1
       namespace: "{{ operator_namespace }}"
       label_selectors:
-        - control-plane = controller-manager
+        - name = benchmark-operator
     register: bo
 
 


### PR DESCRIPTION
### Description
Using the label "name=benchmark-operator". The other label wasn't being
applied in non-openshift deployments?


### Fixes
