### PR TITLE
Add CPU resource request to kutomize manifest

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,6 +72,8 @@ spec:
         ports:
           - containerPort: 6379
         resources:
+          requests: 
+            cpu: "100m"
           limits:
             cpu: "2.0"
         volumeMounts:


### PR DESCRIPTION
### Description

In smaller deployments (not number of nodes, but number of cores), I
have seen where the operator will not deploy.

Additionally, setting the limit to 2, kustomize will set requests to 2.