### PR TITLE
Uperf workload with nodeport and loadbalancer type svc

### DIFF
--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -279,7 +279,7 @@ For `metallb` type, there are certain pre-requisites,
 3.  Configuration of [AddressPool](https://github.com/metallb/metallb-operator#create-an-address-pool-object) for lb service
 4.  Configuration of extenal router for BGP
 
-`metallb` type creates 2 services per benchmark CRD (for each protocol, tcp and udp) and they will share the external IP like below
+`metallb` type creates 2 services per benchmark CR (for each protocol, `tcp` and `udp`) and they will share the external IP like below
 
 ```
 NAME                TYPE           CLUSTER-IP      EXTERNAL-IP       PORT(S) 
@@ -307,7 +307,7 @@ uperf-service-lb2   LoadBalancer   172.30.126.71   192.168.216.102   30001:31312
       servicetype: "metallb"
       metallb:
         addresspool: "addresspool-l3"
-        service_etp: "Cluster"
+        service_etp: "Cluster" # Either `Cluster` or `Local`
       ...
 ```
 

--- a/e2e/013-uperf.bats
+++ b/e2e/013-uperf.bats
@@ -43,6 +43,15 @@ ES_INDEX=ripsaw-uperf-results
   check_es
 }
 
+@test "uperf-serviceip-nodeport" {
+  CR=uperf/uperf_serviceip_nodeport.yaml
+  CR_NAME=$(get_benchmark_name ${CR})
+  envsubst < ${CR} | kubectl apply -f -
+  get_uuid "${CR_NAME}"
+  check_benchmark 900
+  check_es
+}
+
 @test "uperf-hostnetwork" {
   CR=uperf/uperf_hostnetwork.yaml
   CR_NAME=$(get_benchmark_name ${CR})

--- a/e2e/uperf/uperf_serviceip_nodeport.yaml
+++ b/e2e/uperf/uperf_serviceip_nodeport.yaml
@@ -1,0 +1,39 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: uperf-serviceip-nodeport
+  namespace: benchmark-operator
+spec:
+  system_metrics:
+    collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    es_url: ${ES_SERVER}
+    prom_token: ${PROMETHEUS_TOKEN}
+    metrics_profile: node-metrics.yml
+  elasticsearch:
+    url: ${ES_SERVER}
+    index_name: ripsaw-uperf
+  metadata:
+    collection: true
+  cleanup: false
+  workload:
+    name: uperf
+    args:
+      hostnetwork: false
+      serviceip: true
+      servicetype: "nodeport"
+      multus:
+        enabled: false
+      samples: 1
+      pair: 1
+      test_types:
+        - stream
+      protos:
+        - tcp
+        - udp
+      sizes:
+        - 512
+      nthrs:
+        - 1
+      runtime: 2
+      debug: true

--- a/roles/uperf/tasks/start_client.yml
+++ b/roles/uperf/tasks/start_client.yml
@@ -20,7 +20,10 @@
       definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
     vars: 
       resource_item: "{{ server_pods.resources }}"
-    when: workload_args.serviceip|default(False) == False and server_pods.resources|length > 0
+    when: 
+      - ( workload_args.serviceip|default(False) == False and server_pods.resources|length > 0 ) or 
+        ( workload_args.serviceip|default(False) == True and server_pods.resources|length > 0 and 
+          workload_args.servicetype | default("clusterip") == "nodeport" )
 
    #
    # Each server annotates a "node_idx". Each peer client will
@@ -32,8 +35,9 @@
       definition: "{{ lookup('template', 'workload.yml.j2') | from_yaml }}"
     vars: 
       resource_item: "{{ serviceip.resources }}"
-    when: workload_args.serviceip|default(False) == True and serviceip.resources|length > 0
-
+    when: 
+      - workload_args.serviceip|default(False) == True and serviceip.resources|length > 0
+      - workload_args.servicetype | default("clusterip") != "nodeport"
   when: resource_kind == "pod"
  
 - block:

--- a/roles/uperf/tasks/start_server.yml
+++ b/roles/uperf/tasks/start_server.yml
@@ -11,7 +11,21 @@
       pod_sequence: "{{ pod_hi_idx|int +1 }}"
       node_sequence: "{{ node_hi_idx|int +1 }}"
 
-    when: workload_args.serviceip is defined and workload_args.serviceip
+    when: 
+      - workload_args.serviceip is defined and workload_args.serviceip
+      - ( workload_args.servicetype | default("clusterip") == "clusterip" ) or 
+        ( workload_args.servicetype | default("clusterip") == "nodeport" )
+
+  - name: Create metal LB service for server pods
+    k8s:
+      definition: "{{ lookup('template', 'service_metallb.yml.j2') | from_yaml }}"
+    vars:
+      pod_sequence: "{{ pod_hi_idx|int +1 }}"
+      node_sequence: "{{ node_hi_idx|int +1 }}"
+
+    when: 
+      - workload_args.serviceip is defined and workload_args.serviceip
+      - workload_args.servicetype | default("clusterip") == "metallb"
 
   - name: Start Server(s) - total = eligible nodes * density
     k8s:

--- a/roles/uperf/templates/configmap.yml.j2
+++ b/roles/uperf/templates/configmap.yml.j2
@@ -22,7 +22,7 @@ data:
     {% if ( 'rr' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}}"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port=30001"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=write options="size={{wsize}}"/>
@@ -35,7 +35,7 @@ data:
     {% if ( 'stream' == test or 'bidirec' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}}"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port=30001"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=write options="count=16 size={{wsize}}"/>
@@ -48,7 +48,7 @@ data:
     {% if ( 'maerts' == test or 'bidirec' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}}"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port=30001"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=read options="count=16 size={{rsize}}"/>

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -60,7 +60,7 @@ items:
 {% endif %}
             imagePullPolicy: Always
             command: ["/bin/sh","-c"]
-            args: ["uperf -s -v -P 20000"]
+            args: ["uperf -s -v -P 30000"]
           restartPolicy: OnFailure
 {% if workload_args.pin is sameas true %}
           nodeSelector:
@@ -73,7 +73,7 @@ items:
           securityContext:
             sysctls:
             - name: net.ipv4.ip_local_port_range
-              value: 20000 20011
+              value: 30000 30011
 {% endif %}
 {% macro metadata() %}{% include "metadata.yml.j2" %}{% endmacro %}
     {{ metadata()|indent }}

--- a/roles/uperf/templates/server_vm.yml.j2
+++ b/roles/uperf/templates/server_vm.yml.j2
@@ -73,6 +73,6 @@ spec:
           - dnf install -y uperf redis git
           - redis-cli -h {{ bo.resources[0].status.podIP }} setnx {{ trunc_uuid }} 0
           - redis-cli -h {{ bo.resources[0].status.podIP }} incr {{ trunc_uuid }}
-          - uperf -s -v -P 20000
+          - uperf -s -v -P 30000
     name: cloudinitdisk
 status: {}

--- a/roles/uperf/templates/service_metallb.yml.j2
+++ b/roles/uperf/templates/service_metallb.yml.j2
@@ -21,6 +21,8 @@ items:
       annotations:
         node_idx: '{{ node_idx_item }}'
         pod_idx: '{{ item }}'
+        metallb.universe.tf/address-pool: '{{ workload_args.metallb.addresspool | default("addresspool-l2") }}'
+        metallb.universe.tf/allow-shared-ip: uperf-service-{{ item }}-{{ trunc_uuid }}
     spec:
       selector:
 {% if (worker_node_list[node_idx_item]|length>27) and (worker_node_list[node_idx_item][26] == '.') %}
@@ -28,44 +30,58 @@ items:
 {% else %}
         app: uperf-bench-server-{{worker_node_list[node_idx_item] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
 {% endif %}
-{% if workload_args.servicetype | default("clusterip") == "nodeport" %}
-      type: NodePort
+      externalTrafficPolicy: '{{ workload_args.metallb.service_etp | default("Cluster") }}'
+      type: LoadBalancer
       ports:
       - name: uperf
         port: 30000
         targetPort: 30000
-        nodePort: 30000
         protocol: TCP
 {% for num in range(30001,30012,1) %}
       - name: uperf-control-tcp-{{num}}
         port: {{num}}
         targetPort: {{num}}
-        nodePort: {{num}}
         protocol: TCP
-      - name: uperf-control-udp-{{num}}
-        port: {{num}}
-        targetPort: {{num}}
-        nodePort: {{num}}
-        protocol: UDP
 {% endfor %}
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name:  uperf-service-{{ item }}-{{ trunc_uuid }}-udp
+      namespace: '{{ operator_namespace }}'
+      labels:
+        benchmark-uuid: {{ uuid }}
+        benchmark-operator-workload: uperf
+{% if (worker_node_list[node_idx_item]|length>27) and (worker_node_list[node_idx_item][26] == '.') %}
+        app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}
 {% else %}
-      type: ClusterIP
+        app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
+{% endif %}
+        type: {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}-udp
+      annotations:
+        node_idx: '{{ node_idx_item }}'
+        pod_idx: '{{ item }}'
+        metallb.universe.tf/address-pool: '{{ workload_args.metallb.addresspool | default("addresspool-l2") }}'
+        metallb.universe.tf/allow-shared-ip: uperf-service-{{ item }}-{{ trunc_uuid }}
+    spec:
+      selector:
+{% if (worker_node_list[node_idx_item]|length>27) and (worker_node_list[node_idx_item][26] == '.') %}
+        app: uperf-bench-server-{{worker_node_list[node_idx_item] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}
+{% else %}
+        app: uperf-bench-server-{{worker_node_list[node_idx_item] | truncate(27,true,'')}}-{{ item }}-{{ trunc_uuid }}
+{% endif %}
+      externalTrafficPolicy: '{{ workload_args.metallb.service_etp | default("Cluster") }}'
+      type: LoadBalancer
       ports:
       - name: uperf
         port: 30000
         targetPort: 30000
-        protocol: TCP
+        protocol: UDP
 {% for num in range(30001,30012,1) %}
       - name: uperf-control-tcp-{{num}}
         port: {{num}}
         targetPort: {{num}}
-        protocol: TCP
-      - name: uperf-control-udp-{{num}}
-        port: {{num}}
-        targetPort: {{num}}
         protocol: UDP
 {% endfor %}
-{% endif %}
 {% endmacro %}
 {% for node_idx_item in range(node_sequence|int)  %}
 {% for item in range(pod_sequence|int)  %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -8,7 +8,13 @@ items:
     apiVersion: batch/v1
     metadata:
 {% if workload_args.serviceip is sameas true %}
+{% if workload_args.servicetype | default("clusterip") == "nodeport" %}
+      name: 'uperf-client-{{item.status.hostIP}}-{{ trunc_uuid }}'
+{% elif workload_args.servicetype | default("clusterip") == "metallb" or workload_args.servicetype | default("clusterip") == "loadbalancer" %}
+      name: 'uperf-client-{{item.status.loadBalancer.ingress[0].ip}}-{{ trunc_uuid }}'
+{% else %}
       name: 'uperf-client-{{item.spec.clusterIP}}-{{ trunc_uuid }}'
+{% endif %}
 {% else %}
       name: 'uperf-client-{{item.status.podIP}}-{{ trunc_uuid }}'
 {% endif %}
@@ -100,7 +106,16 @@ items:
             args:
 {% if workload_args.serviceip is sameas true %}
               - "export serviceip=true;
+{% if workload_args.servicetype | default("clusterip") == "nodeport" %}
+                 export h={{item.status.hostIP}};
+                 export servicetype={{workload_args.servicetype}};
+{% elif workload_args.servicetype | default("clusterip") == "metallb" or workload_args.servicetype | default("clusterip") == "loadbalancer" %}
+                 export h={{item.status.loadBalancer.ingress[0].ip}};
+                 export servicetype={{workload_args.servicetype}};
+{% else %}
                  export h={{item.spec.clusterIP}};
+                 export servicetype={{workload_args.servicetype | default("clusterip")}};
+{% endif %}             
 {% else %}
 {% if workload_args.multus.client is defined %}
               - "export multus_client={{workload_args.multus.client}};

--- a/tests/test_crs/valid_uperf_serviceip_nodeport.yaml
+++ b/tests/test_crs/valid_uperf_serviceip_nodeport.yaml
@@ -1,0 +1,45 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: uperf-serviceip-nodeport
+  namespace: benchmark-operator
+spec:
+  system_metrics:
+    collection: true
+    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+    es_url: ES_SERVER
+    prom_token: PROMETHEUS_TOKEN
+    metrics_profile: node-metrics.yml
+  elasticsearch:
+    url: ES_SERVER
+    index_name: ripsaw-uperf
+  metadata:
+    collection: true
+  cleanup: false
+  workload:
+    name: uperf
+    args:
+      hostnetwork: false
+      serviceip: true
+      servicetype: "nodeport"
+      pin: false
+      pin_server: "node-0"
+      pin_client: "node-1"
+      multus:
+        enabled: false
+      samples: 2
+      pair: 1
+      test_types:
+        - stream
+        - rr
+      protos:
+        - tcp
+        - udp
+      sizes:
+        - 1024
+        - 512
+      nthrs:
+        - 1
+        - 2
+      runtime: 2
+      debug: true

--- a/tests/test_uperf.sh
+++ b/tests/test_uperf.sh
@@ -44,5 +44,6 @@ function functional_test_uperf {
 figlet $(basename $0)
 functional_test_uperf "Uperf without resources definition" tests/test_crs/valid_uperf.yaml
 functional_test_uperf "Uperf with ServiceIP" tests/test_crs/valid_uperf_serviceip.yaml
+functional_test_uperf "Uperf with NodePort ServiceIP" tests/test_crs/valid_uperf_serviceip_nodeport.yaml
 functional_test_uperf "Uperf with resources definition and hostNetwork" tests/test_crs/valid_uperf_resources.yaml
 functional_test_uperf "Uperf with networkpolicy" tests/test_crs/valid_uperf_networkpolicy.yaml


### PR DESCRIPTION
### Description
To support different service types for uperf workload
NodePort: 
```
      serviceip: true
      servicetype: "nodeport"
```

Loadbalancer: only tested for `metallb` loadbalancers on baremetal.
```
      serviceip: true
      servicetype: "metallb"
      metallb:
        addresspool: "addresspool-l3"
        service_etp: "Cluster"
```

@rsevilla87 and @josecastillolema  I've updated the uperf server to listen on port `30000` for all service types as advised, that avoids complexity in the code.  
### Fixes
