### PR TITLE
shortening job names for cyclictest and oslat

### DIFF
--- a/roles/cyclictest/tasks/main.yml
+++ b/roles/cyclictest/tasks/main.yml
@@ -7,7 +7,7 @@
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
+          name: 'cyclictest-{{ trunc_uuid }}'
           namespace: '{{ operator_namespace }}'
         data:
           cyclictest.sh: "{{ lookup('file', 'cyclictest.sh') }}"

--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
+  name: "cyclictest-{{ trunc_uuid }}"
   namespace: "{{ operator_namespace }}"
 spec:
   template:

--- a/roles/oslat/tasks/main.yml
+++ b/roles/oslat/tasks/main.yml
@@ -5,7 +5,7 @@
       apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: '{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}'
+        name: 'oslat-{{ trunc_uuid }}'
         namespace: '{{ operator_namespace }}'
       data:
         oslat.sh: "{{ lookup('file', 'oslat.sh') }}"

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
+  name: "oslat-{{ trunc_uuid }}"
   namespace: "{{ operator_namespace }}"
 spec:
   backoffLimit: 0


### PR DESCRIPTION
### Description

If the benchmarks get launched via airflow, the UUID the combination of {{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }} gets too long (> 63 chars)

### Fixes

Shortened the names to <benchmark_name>-{{ trunc_uuid }}
