### PR TITLE
fixing configmap names

### DIFF
--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -90,7 +90,7 @@ spec:
           path: /dev/cpu_dma_latency
       - name: cyclictest-volume
         configMap:
-          name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
+          name: "cyclictest-{{ trunc_uuid }}"
           defaultMode: 0555
       restartPolicy: Never
       serviceAccountName: benchmark-operator

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -91,7 +91,7 @@ spec:
           path: /dev/cpu_dma_latency
       - name: oslat-volume
         configMap:
-          name: "{{ ansible_operator_meta.name }}-workload-{{ trunc_uuid }}"
+          name: "oslat-{{ trunc_uuid }}"
           defaultMode: 0555
       restartPolicy: Never
       serviceAccountName: benchmark-operator


### PR DESCRIPTION
### Description

Changing the names isn't enough, the corresponding configmaps need to be changed too.

### Fixes

configmap names for oslat and cyclictest
