### PR TITLE
Helm Chart missing label

### DIFF
--- a/charts/benchmark-operator/templates/operator.yaml
+++ b/charts/benchmark-operator/templates/operator.yaml
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       labels:
+        control-plane: controller-manager
         name: {{ include "benchmark-operator.fullname" . }}
     spec:
       serviceAccountName: {{ include "benchmark-operator.fullname" . }}


### PR DESCRIPTION
The helm chart was missing a label, which was causing issues with deploy
UPerf. Fixing the template.

Signed-off-by: Joe Talerico <rook@isovalent.com>