### PR TITLE
add proxy to k8s client if it exists in env

### DIFF
--- a/image_resources/centos8-appstream.repo
+++ b/image_resources/centos8-appstream.repo
@@ -1,17 +1,17 @@
 [centos8-appstream-x86_64]
 name=CentOS-8-Appstream-x86_64
-baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
+baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
 enabled=0
 gpgcheck=0
 
 [centos8-appstream-aarch64]
 name=CentOS-8-Appstream-aarch64
-baseurl=http://mirror.centos.org/centos/8/AppStream/aarch64/os/
+baseurl=http://mirror.centos.org/centos/8-stream/AppStream/aarch64/os/
 enabled=0
 gpgcheck=0
 
 [centos8-appstream-ppc64le]
 name=CentOS-8-Appstream-ppc64le
-baseurl=http://mirror.centos.org/centos/8/AppStream/ppc64le//os/
+baseurl=http://mirror.centos.org/centos/8-stream/AppStream/ppc64le/os/
 enabled=0
 gpgcheck=0


### PR DESCRIPTION
### Description
If http_proxy is in ENV, add proxy and proxy_headers to kubernetes.client.
example of the ENV variable:
http_proxy=http://<user>:<password>@<proxy_host>:<port>

### Fixes
https://github.com/cloud-bulldozer/benchmark-operator/issues/726
