### PR TITLE
Support for dualstack loadbalancer type services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 
 COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs redis openssl --enablerepo=centos8-appstream-* && dnf clean all
+RUN dnf install -y --nodocs redis openssl python3-netaddr --enablerepo=centos8-appstream-* && dnf clean all
 
 COPY resources/kernel-cache-drop-daemonset.yaml /opt/kernel_cache_dropper/
 COPY watches.yaml ${HOME}/watches.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 
 COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
-RUN dnf install -y --nodocs redis openssl python3-netaddr --enablerepo=centos8-appstream-* && dnf clean all
+RUN dnf install -y --nodocs redis openssl --enablerepo=centos8-appstream-* && dnf clean all
 RUN pip install netaddr
 
 COPY resources/kernel-cache-drop-daemonset.yaml /opt/kernel_cache_dropper/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
 
 COPY image_resources/centos8-appstream.repo /etc/yum.repos.d/centos8-appstream.repo
 RUN dnf install -y --nodocs redis openssl python3-netaddr --enablerepo=centos8-appstream-* && dnf clean all
+RUN pip install netaddr
 
 COPY resources/kernel-cache-drop-daemonset.yaml /opt/kernel_cache_dropper/
 COPY watches.yaml ${HOME}/watches.yaml

--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -65,7 +65,7 @@ spec:
 
 `serviceip` will place the uperf server behind a K8s [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
 
-`dualstack` will use IPv6 for establishing the connectivity between uperf client(s) and server(s). The environment has to be properly configured with dualstack previous to running the test.
+`dualstack` will use IPv6 for establishing the connectivity between uperf client(s) and server(s). The environment has to be properly configured with dualstack previous to running the test. For now, it is only supported with LoadBalancer type services.
 
 `runtime_class` If this is set, the benchmark-operator will apply the runtime_class to the podSpec runtimeClassName.
 

--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -34,6 +34,7 @@ spec:
           cpu: 500m
           memory: 500Mi
       serviceip: false
+      dualstack: false
       runtime_class: class_name
       hostnetwork: false
       networkpolicy: false
@@ -63,6 +64,8 @@ spec:
 `client_resources` and `server_resources` will create uperf client's and server's containers with the given k8s compute resources respectively [k8s resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
 
 `serviceip` will place the uperf server behind a K8s [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
+
+`dualstack` will use IPv6 for establishing the connectivity between uperf client(s) and server(s). The environment has to be properly configured with dualstack previous to running the test.
 
 `runtime_class` If this is set, the benchmark-operator will apply the runtime_class to the podSpec runtimeClassName.
 

--- a/roles/uperf/templates/service_metallb.yml.j2
+++ b/roles/uperf/templates/service_metallb.yml.j2
@@ -77,6 +77,12 @@ items:
 {% endif %}
       externalTrafficPolicy: '{{ workload_args.metallb.service_etp | default("Cluster") }}'
       type: LoadBalancer
+{% if dualstack | default("false") %}
+      ipFamilyPolicy: RequireDualStack
+      ipFamilies:
+      - IPv6
+      - IPv4
+{% endif %}
       ports:
       - name: uperf
         port: 30000

--- a/roles/uperf/templates/service_metallb.yml.j2
+++ b/roles/uperf/templates/service_metallb.yml.j2
@@ -32,6 +32,12 @@ items:
 {% endif %}
       externalTrafficPolicy: '{{ workload_args.metallb.service_etp | default("Cluster") }}'
       type: LoadBalancer
+{% if dualstack | default("false") %}
+      ipFamilyPolicy: RequireDualStack
+      ipFamilies:
+      - IPv6
+      - IPv4
+{% endif %}
       ports:
       - name: uperf
         port: 30000

--- a/roles/uperf/templates/service_metallb.yml.j2
+++ b/roles/uperf/templates/service_metallb.yml.j2
@@ -32,7 +32,7 @@ items:
 {% endif %}
       externalTrafficPolicy: '{{ workload_args.metallb.service_etp | default("Cluster") }}'
       type: LoadBalancer
-{% if dualstack | default("false") %}
+{% if workload_args.dualstack | default(false) %}
       ipFamilyPolicy: RequireDualStack
       ipFamilies:
       - IPv6
@@ -77,7 +77,7 @@ items:
 {% endif %}
       externalTrafficPolicy: '{{ workload_args.metallb.service_etp | default("Cluster") }}'
       type: LoadBalancer
-{% if dualstack | default("false") %}
+{% if workload_args.dualstack | default(false) %}
       ipFamilyPolicy: RequireDualStack
       ipFamilies:
       - IPv6

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -110,11 +110,11 @@ items:
                  export h={{item.status.hostIP}};
                  export servicetype={{workload_args.servicetype}};
 {% elif workload_args.servicetype | default("clusterip") == "metallb" or workload_args.servicetype | default("clusterip") == "loadbalancer" %}
-    {% if not workload_args.dualstack | default(false) %}
+{% if not workload_args.dualstack | default(false) %}
                  export h={{item.status.loadBalancer.ingress[0].ip}};
-    {% else %}
-                 export h={{item.status.loadBalancer | json_query('ingress[*].ip') | ipv6 | join}};
-    {% endif %}
+{% else %}
+                 export h={{item.status.loadBalancer | json_query('ingress[*].ip') | ipv6 | join }};
+{% endif %}
                  export servicetype={{workload_args.servicetype}};
 {% else %}
                  export h={{item.spec.clusterIP}};

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -113,7 +113,7 @@ items:
 {% if not workload_args.dualstack | default(false) %}
                  export h={{item.status.loadBalancer.ingress[0].ip}};
 {% else %}
-                 export h={{item.status.loadBalancer | json_query('ingress[*].ip') | ansible.netcommon.ipv6 | join }};
+                 export h={{item.status.loadBalancer | json_query('ingress[*].ip') | ipv6 | join }};
 {% endif %}
                  export servicetype={{workload_args.servicetype}};
 {% else %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -110,7 +110,7 @@ items:
                  export h={{item.status.hostIP}};
                  export servicetype={{workload_args.servicetype}};
 {% elif workload_args.servicetype | default("clusterip") == "metallb" or workload_args.servicetype | default("clusterip") == "loadbalancer" %}
-    {% if not dualstack | default("false") %}
+    {% if not workload_args.dualstack | default("false") %}
                  export h={{item.status.loadBalancer.ingress[0].ip}};
     {% else %}
                  export h={{item.status.loadBalancer | json_query('ingress[*].ip') | ipv6 | join}};

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -110,7 +110,7 @@ items:
                  export h={{item.status.hostIP}};
                  export servicetype={{workload_args.servicetype}};
 {% elif workload_args.servicetype | default("clusterip") == "metallb" or workload_args.servicetype | default("clusterip") == "loadbalancer" %}
-    {% if not workload_args.dualstack | default("false") %}
+    {% if not workload_args.dualstack | default(false) %}
                  export h={{item.status.loadBalancer.ingress[0].ip}};
     {% else %}
                  export h={{item.status.loadBalancer | json_query('ingress[*].ip') | ipv6 | join}};

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -113,7 +113,7 @@ items:
     {% if not dualstack | default("false") %}
                  export h={{item.status.loadBalancer.ingress[0].ip}};
     {% else %}
-                 export h={{item.status.loadBalancer.ingress.ip | ansible.netcommon.ipv6 }};
+                 export h={{item.status.loadBalancer | json_query('ingress[*].ip') | ipv6 | join}};
     {% endif %}
                  export servicetype={{workload_args.servicetype}};
 {% else %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -110,7 +110,11 @@ items:
                  export h={{item.status.hostIP}};
                  export servicetype={{workload_args.servicetype}};
 {% elif workload_args.servicetype | default("clusterip") == "metallb" or workload_args.servicetype | default("clusterip") == "loadbalancer" %}
+    {% if not dualstack | default("false") %}
                  export h={{item.status.loadBalancer.ingress[0].ip}};
+    {% else %}
+                 export h={{item.status.loadBalancer.ingress.ip | ansible.netcommon.ipv6 }};
+    {% endif %}
                  export servicetype={{workload_args.servicetype}};
 {% else %}
                  export h={{item.spec.clusterIP}};

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -113,7 +113,7 @@ items:
 {% if not workload_args.dualstack | default(false) %}
                  export h={{item.status.loadBalancer.ingress[0].ip}};
 {% else %}
-                 export h={{item.status.loadBalancer | json_query('ingress[*].ip') | ipv6 | join }};
+                 export h={{item.status.loadBalancer | json_query('ingress[*].ip') | ansible.netcommon.ipv6 | join }};
 {% endif %}
                  export servicetype={{workload_args.servicetype}};
 {% else %}


### PR DESCRIPTION
### Description
`dualstack` option will use IPv6 for establishing the connectivity between uperf client(s) and server(s). The environment has to be properly configured with dualstack previous to running the test. For now, it is only supported with LoadBalancer type services.

The same logic can be easily extended to support other scenarios, like pod2pod or pod2clusterIPsvc.

Did not include a test because the loadbalancer type service is platform specific.

### Fixes
