### PR TITLE
Support for dualstack loadbalancer type services

### DIFF
--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -34,6 +34,7 @@ spec:
           cpu: 500m
           memory: 500Mi
       serviceip: false
+      dualstack: false
       runtime_class: class_name
       hostnetwork: false
       networkpolicy: false
@@ -63,6 +64,8 @@ spec:
 `client_resources` and `server_resources` will create uperf client's and server's containers with the given k8s compute resources respectively [k8s resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
 
 `serviceip` will place the uperf server behind a K8s [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
+
+`dualstack` will use IPv6 for establishing the connectivity between uperf client(s) and server(s). The environment has to be properly configured with dualstack previous to running the test.
 
 `runtime_class` If this is set, the benchmark-operator will apply the runtime_class to the podSpec runtimeClassName.
 

--- a/roles/uperf/templates/service_metallb.yml.j2
+++ b/roles/uperf/templates/service_metallb.yml.j2
@@ -32,6 +32,12 @@ items:
 {% endif %}
       externalTrafficPolicy: '{{ workload_args.metallb.service_etp | default("Cluster") }}'
       type: LoadBalancer
+{% if dualstack | default("false") %}
+      ipFamilyPolicy: RequireDualStack
+      ipFamilies:
+      - IPv6
+      - IPv4
+{% endif %}
       ports:
       - name: uperf
         port: 30000

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -110,7 +110,11 @@ items:
                  export h={{item.status.hostIP}};
                  export servicetype={{workload_args.servicetype}};
 {% elif workload_args.servicetype | default("clusterip") == "metallb" or workload_args.servicetype | default("clusterip") == "loadbalancer" %}
+    {% if not dualstack | default("false") %}
                  export h={{item.status.loadBalancer.ingress[0].ip}};
+    {% else %}
+                 export h={{item.status.loadBalancer.ingress.ip | ansible.netcommon.ipv6 }};
+    {% endif %}
                  export servicetype={{workload_args.servicetype}};
 {% else %}
                  export h={{item.spec.clusterIP}};


### PR DESCRIPTION
### Description
`dualstack` option will use IPv6 for establishing the connectivity between uperf client(s) and server(s). The environment has to be properly configured with dualstack previous to running the test. For now, it is only supported with LoadBalancer type services.

The same logic can be easily extended to support other scenarios, like pod2pod or pod2clusterIPsvc.

Did not include a test because the loadbalancer type service is platform specific.

### Fixes
