### PR TITLE
corrected indentation with `filter`

### DIFF
--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -75,8 +75,9 @@ items:
             - name: net.ipv4.ip_local_port_range
               value: 30000 30011
 {% endif %}
-{% macro metadata() %}{% include "metadata.yml.j2" %}{% endmacro %}
-    {{ metadata()|indent }}
+{% filter indent(width=4, first=True) %}
+{% include "metadata.yml.j2" %}
+{% endfilter %}
 {% endmacro %}
 {% for node_idx_item in range(node_sequence|int)  %}
 {% for item in range(pod_sequence|int)  %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -238,6 +238,7 @@ items:
    
 {% endif %}
 
-{% macro metadata() %}{% include "metadata.yml.j2" %}{% endmacro %}
-    {{ metadata()|indent }}
+{% filter indent(width=4, first=True) %}
+{% include "metadata.yml.j2" %}
+{% endfilter %}
 {% endfor %}


### PR DESCRIPTION
### Description
`macro` is not passing all current variables to the `include`'d template, so `metadata` dict was always undefined and job definition was missing `initContainers` section. Replaced that with regular `include` with `filter` to indent properly

I could see it includes `metadata.yml` on both server and client pod definition now,
```
...
  initContainers:
  - args:
    - |
      python3 stockpile-wrapper.py -s=https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443 -u=13a31b07-4c90-535f-90cd-37c8bda42c8b -n=${my_node_name} -N=${my_pod_name} --redisip=10.129.40.107 --redisport=6379 --tags=common,k8s,openshift
    command:
    - /bin/sh
    - -c
...
```

### Fixes
#725 