### PR TITLE
patching client pod indentation

### DIFF
--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -241,4 +241,5 @@ items:
 {% filter indent(width=4, first=True) %}
 {% include "metadata.yml.j2" %}
 {% endfilter %}
+
 {% endfor %}


### PR DESCRIPTION
### Description
Recent PR #735 had an issue in formatting the client_pod.yml when creating multi pair + pin uperf pods.

### Fixes
#737 