### PR TITLE
Remove redundant metadata section in client

### DIFF
--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -238,8 +238,4 @@ items:
    
 {% endif %}
 
-{% filter indent(width=4, first=True) %}
-{% include "metadata.yml.j2" %}
-{% endfilter %}
-
 {% endfor %}


### PR DESCRIPTION
### Description
Remove redundant metadata collection from uperf client. If metadata is set to true we will already gather it when server pods launch.

### Fixes
