### PR TITLE
hammerdb samples: fix broken volumeMounts in deployments

### DIFF
--- a/config/samples/hammerdb/mariadb/hostpath-cr.yaml
+++ b/config/samples/hammerdb/mariadb/hostpath-cr.yaml
@@ -63,8 +63,6 @@ spec:
              value: "test"
            - name: MYSQL_ROOT_PASSWORD
              value: "mysql"
-      securityContext:
-        privileged: true
         volumeMounts:
           - name: mariadb-custom-config
             mountPath: /etc/my.cnf

--- a/config/samples/hammerdb/mariadb/local-cr.yaml
+++ b/config/samples/hammerdb/mariadb/local-cr.yaml
@@ -63,8 +63,6 @@ spec:
              value: "test"
            - name: MYSQL_ROOT_PASSWORD
              value: "mysql"
-      securityContext:
-        privileged: true
         volumeMounts:
           - name: mariadb-custom-config
             mountPath: /etc/my.cnf

--- a/config/samples/hammerdb/mssql/hostpath-cr.yaml
+++ b/config/samples/hammerdb/mssql/hostpath-cr.yaml
@@ -42,8 +42,6 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
-      securityContext:
-        privileged: true
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql

--- a/config/samples/hammerdb/mssql/local-cr.yaml
+++ b/config/samples/hammerdb/mssql/local-cr.yaml
@@ -42,8 +42,6 @@ spec:
             value: "Y"
           - name: MSSQL_SA_PASSWORD
             value: "s3curePasswordString"
-      securityContext:
-        privileged: true
         volumeMounts:
           - name: mssql-persistent-storage
             mountPath: /var/opt/mssql

--- a/config/samples/hammerdb/postgres/hostpath-cr.yaml
+++ b/config/samples/hammerdb/postgres/hostpath-cr.yaml
@@ -57,8 +57,6 @@ spec:
               value: "test"
             - name: POSTGRESQL_ADMIN_PASSWORD
               value: "postgres"
-      securityContext:
-          privileged: true
           volumeMounts:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf

--- a/config/samples/hammerdb/postgres/local-cr.yaml
+++ b/config/samples/hammerdb/postgres/local-cr.yaml
@@ -57,8 +57,6 @@ spec:
               value: "test"
             - name: POSTGRESQL_ADMIN_PASSWORD
               value: "postgres"
-      securityContext:
-          privileged: true
           volumeMounts:
             - name: postgres-custom-config
               mountPath: /var/lib/pgsql/data/pg_hba.conf


### PR DESCRIPTION
### Description
The samples for deploying mariadb, mssql, and postgres contain the `privileged: true` `securityContext`, however because of bad formatting in the YAML, these are not applied. The bad formatting also prevents the volumes from being mounted in the Pod. AFAICT, privileged is not needed for these pods anyway, so it can be removed.

### Fixes
Fix the hammerdb database examples.