### PR TITLE
update hammerdb vm samples to centos stream8

### DIFF
--- a/config/samples/hammerdb/mariadb/vm-cr.yaml
+++ b/config/samples/hammerdb/mariadb/vm-cr.yaml
@@ -78,7 +78,7 @@ spec:
         sockets: 1
         cores: 2
         threads: 1
-        image: quay.io/cloud-bulldozer/centos8-mariadb103-container-disk:latest
+        image: quay.io/cloud-bulldozer/centos-stream8-mariadb103-container-disk:latest
         requests:
           memory: 100Mi
         limits:

--- a/config/samples/hammerdb/mssql/vm-cr.yaml
+++ b/config/samples/hammerdb/mssql/vm-cr.yaml
@@ -77,7 +77,7 @@ spec:
         sockets: 1
         cores: 2
         threads: 1
-        image: quay.io/cloud-bulldozer/centos8-mssql2019-container-disk:latest
+        image: quay.io/cloud-bulldozer/centos-stream8-mssql2019-container-disk:latest
         requests:
           memory: 100Mi
         limits:

--- a/config/samples/hammerdb/postgres/vm-cr.yaml
+++ b/config/samples/hammerdb/postgres/vm-cr.yaml
@@ -77,7 +77,7 @@ spec:
         sockets: 1
         cores: 2
         threads: 1
-        image: quay.io/cloud-bulldozer/centos8-postgres10-container-disk:latest
+        image: quay.io/cloud-bulldozer/centos-stream8-postgres10-container-disk:latest
         requests:
           memory: 100Mi
         limits:

--- a/config/samples/hammerdb/vm-cr.yaml
+++ b/config/samples/hammerdb/vm-cr.yaml
@@ -78,7 +78,7 @@ spec:
         sockets: 1
         cores: 2
         threads: 1
-        image: quay.io/cloud-bulldozer/centos8-mssql2019-container-disk:latest
+        image: quay.io/cloud-bulldozer/centos-stream8-mssql2019-container-disk:latest
         limits:
           memory: 16Gi # at least 16Gi for VM
         requests:


### PR DESCRIPTION
### Description
Update hammerdb samples from centos8 to centos-stream8
### Fixes
Update the following hammerdb container disks in the following databases:
1. Mssql
2. Postgresql
3. Mariadb