### PR TITLE
Fs drift test captures response time stats

### DIFF
--- a/e2e/fs_drift/fs_drift.yaml
+++ b/e2e/fs_drift/fs_drift.yaml
@@ -26,5 +26,6 @@ spec:
       threads: 5
       max_file_size_kb: 4
       max_files: 1000
-      duration: 10
+      duration: 240
       debug: true
+      response_times: true

--- a/e2e/fs_drift/fs_drift_hostpath.yaml
+++ b/e2e/fs_drift/fs_drift_hostpath.yaml
@@ -27,5 +27,6 @@ spec:
       threads: 5
       max_file_size_kb: 4
       max_files: 1000
-      duration: 10
+      duration: 240
       debug: true
+      response_times: true

--- a/roles/fs-drift/templates/other_parameters.yaml.j2
+++ b/roles/fs-drift/templates/other_parameters.yaml.j2
@@ -47,5 +47,8 @@ gaussian_stddev: {{workload_args.gaussian_stddev}}
 {% if workload_args.create_stddevs_ahead is defined %}
 create_stddevs_ahead: {{workload_args.create_stddevs_ahead}}
 {% endif %}
+{% if workload_args.response_times is defined %}
+response_times: {{workload_args.response_times}}
+{% endif %}
 
 

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -4,9 +4,6 @@ metadata:
   name: fs-drift-benchmark
   namespace: benchmark-operator
 spec:
-  test_user: homer_simpson
-  # to separate this test run from everyone else's
-  clustername: test_ci
   system_metrics:
     collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
@@ -26,5 +23,6 @@ spec:
       threads: 5
       max_file_size_kb: 4
       max_files: 1000
-      duration: 15
+      duration: 120
+      response_times: Y
       debug: true

--- a/tests/test_crs/valid_fs_drift.yaml
+++ b/tests/test_crs/valid_fs_drift.yaml
@@ -7,12 +7,12 @@ spec:
   system_metrics:
     collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
-    es_url: ES_SERVER
+    es_url: https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml
   # where elastic search is running
   elasticsearch:
-    url: ES_SERVER
+    url: https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com
     index_name: ripsaw-fs-drift
   metadata:
     collection: true
@@ -23,6 +23,6 @@ spec:
       threads: 5
       max_file_size_kb: 4
       max_files: 1000
-      duration: 120
+      duration: 240
       response_times: Y
       debug: true

--- a/tests/test_crs/valid_fs_drift_hostpath.yaml
+++ b/tests/test_crs/valid_fs_drift_hostpath.yaml
@@ -23,6 +23,6 @@ spec:
       threads: 5
       max_file_size_kb: 4
       max_files: 1000
-      duration: 120
+      duration: 240
       response_times: true
       debug: true

--- a/tests/test_crs/valid_fs_drift_hostpath.yaml
+++ b/tests/test_crs/valid_fs_drift_hostpath.yaml
@@ -4,16 +4,12 @@ metadata:
   name: fs-drift-hostpath-benchmark
   namespace: benchmark-operator
 spec:
-  test_user: homer_simpson
-  # to separate this test run from everyone else's
-  clustername: test_ci
   system_metrics:
     collection: true
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ES_SERVER
     prom_token: PROMETHEUS_TOKEN
     metrics_profile: node-metrics.yml
-  # where elastic search is running
   elasticsearch:
     url: ES_SERVER
     index_name: ripsaw-fs-drift
@@ -27,5 +23,6 @@ spec:
       threads: 5
       max_file_size_kb: 4
       max_files: 1000
-      duration: 15
+      duration: 120
+      response_times: true
       debug: true

--- a/tests/test_fs_drift.sh
+++ b/tests/test_fs_drift.sh
@@ -43,4 +43,4 @@ function functional_test_fs_drift {
 
 figlet $(basename $0)
 functional_test_fs_drift "fs-drift" tests/test_crs/valid_fs_drift.yaml
-functional_test_fs_drift "fs-drift hostpath" tests/test_crs/valid_fs_drift_hostpath.yaml
+functional_test_fs_drift "fs-drift-hostpath" tests/test_crs/valid_fs_drift_hostpath.yaml


### PR DESCRIPTION
Do not merge yet...
change test parameters so that response time stats reach elastic search
addresses issue #741 