### PR TITLE
Improve cli exeption handling

### DIFF
--- a/cli/ripsaw/models/benchmark.py
+++ b/cli/ripsaw/models/benchmark.py
@@ -62,9 +62,13 @@ class Benchmark:
         """Wait for benchmark to enter desired state with specified timeout in seconds (default: 600)"""
         if self.metadata == {}:
             raise BenchmarkNotStartedError(self.name)
-        self.cluster.wait_for_benchmark(
-            self.name, self.namespace, desired_state=desired_state, timeout=timeout
-        )
+        try:
+            self.cluster.wait_for_benchmark(
+                self.name, self.namespace, desired_state=desired_state, timeout=timeout
+            )
+        except Exception as err:
+            logger.error(f"Benchmark exception: {err}")
+            exit(1)
         self.metadata = self.cluster.get_benchmark_metadata(self.name, self.namespace)
         return self.metadata
 


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

This will prevent ugly and useless traceback messages like:

```
2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO - Traceback (most recent call last):
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/bin/ripsaw", line 33, in <module>
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     sys.exit(load_entry_point('ripsaw-cli==0.0.1', 'console_scripts', 'ripsaw')())
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/lib/python3.8/site-packages/click/core.py", line 1137, in __call__
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     return self.main(*args, **kwargs)
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/lib/python3.8/site-packages/click/core.py", line 1062, in main
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     rv = self.invoke(ctx)
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/lib/python3.8/site-packages/click/core.py", line 1668, in invoke
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     return _process_result(sub_ctx.command.invoke(sub_ctx))
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/lib/python3.8/site-packages/click/core.py", line 1668, in invoke
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     return _process_result(sub_ctx.command.invoke(sub_ctx))
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     return ctx.invoke(self.callback, **ctx.params)
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/lib/python3.8/site-packages/click/core.py", line 763, in invoke
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     return __callback(*args, **kwargs)
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/lib/python3.8/site-packages/ripsaw/commands/benchmark.py", line 42, in run_benchmark
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     benchmark.run(timeout=timeout)
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/lib/python3.8/site-packages/ripsaw/models/benchmark.py", line 58, in run
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     self.wait(timeout=timeout)
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/lib/python3.8/site-packages/ripsaw/models/benchmark.py", line 65, in wait
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     self.cluster.wait_for_benchmark(
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -   File "/tmp/ripsaw-cli/lib/python3.8/site-packages/ripsaw/clients/k8s.py", line 153, in wait_for_benchmark
[2022-04-01, 13:11:52 EDT] {subprocess.py:89} INFO -     raise BenchmarkFailedError(benchmark["metadata"]["name"], benchmark["status"]["uuid"])
```


### Fixes
