### PR TITLE
Updating api-load to match latest release

### DIFF
--- a/e2e/api_load/api_load.yaml
+++ b/e2e/api_load/api_load.yaml
@@ -24,6 +24,7 @@ spec:
       aws_access_key: empty
       aws_access_secret: empty
       aws_account_id: empty
+      aws_region: empty
       cooldown: 10
       sleep: 5
       test_list:

--- a/roles/api_load/templates/api_load.yml
+++ b/roles/api_load/templates/api_load.yml
@@ -65,19 +65,30 @@ spec:
 {% for key, value in workload_args.test_list.items() %}
             ocm-load-test
             --test-id={{ uuid }}
-            --gateway-url {{ workload_args.gateway_url }}
+            --gateway-url={{ workload_args.gateway_url }}
             --ocm-token={{ workload_args.ocm_token }}
             --duration={{ value.duration | default(workload_args.duration) }}
             --rate={{ value.rate | default(workload_args.rate) }}
             --output-path={{ workload_args.output_path | default('/tmp/results') }}
-            --test-names {{ key }}
-            --aws-access-key {{ workload_args.aws_access_key }}
-            --aws-access-secret {{ workload_args.aws_access_secret }}
-            --aws-account-id {{ workload_args.aws_account_id }};
+            --test-names={{ key }}
+            --aws-access-key={{ workload_args.aws_access_key }}
+            --aws-access-secret={{ workload_args.aws_access_secret }}
+            --aws-account-id={{ workload_args.aws_account_id }}
+            --aws-region={{ workload_args.aws_region | default('us-west-2') }}
+{% if value.ramp_type is defined %}
+            --ramp-type={{ value.ramp_type }}
+            --ramp-duration={{ value.ramp_duration | default(value.duration) }}
+            --ramp-steps={{ value.ramp_steps }}
+            --start-rate={{ value.ramp_start_rate }}
+            --end-rate={{ value.ramp_end_rate }}
+{% endif %}
+            --elastic-server={{ elasticsearch.url }}
+            --elastic-index={{ elasticsearch.index_name }};
             echo "Cooldown for {{ workload_args.cooldown | default(60) }}";
             sleep {{ workload_args.cooldown | default(60) }};
 {% endfor %}
 {% endif %}
+            echo "Updating redis status";
             redis-cli -h {{ bo.resources[0].status.podIP }} SET "{{ uuid }}-status" "ready";
         volumeMounts:
           - mountPath: /tmp/results
@@ -96,14 +107,12 @@ spec:
                 fieldPath: metadata.name
           - name: uuid
             value: "{{ uuid }}"
-          - name: ES
-            value: "{{ elasticsearch.url }}"
         command: ["/bin/sh", "-c"]
         args:
           - >
             echo "Getting redis status";
             status=`redis-cli -h {{ bo.resources[0].status.podIP }} GET "{{ uuid }}-status"`;
-            while [ $status != "ready" ]; do
+            while [ "$status" != "ready" ]; do
               sleep {{ workload_args.sleep | default(360) }};
               echo "Testing readiness";
               status=`redis-cli -h {{ bo.resources[0].status.podIP }} GET "{{ uuid }}-status"`;
@@ -111,8 +120,6 @@ spec:
 {% if workload_args.override is defined %}
             echo "succeeded"
 {% else %}
-            echo "Uploading to ES...";
-            python automation.py esbulk --dir {{ workload_args.output_path | default('/tmp/results') }} --index {{ elasticsearch.index_name }};
 {% if snappy.url %}
             echo "Uploading RAW files...";
             python automation.py upload --dir {{ workload_args.output_path | default('/tmp/results') }} --server {{ snappy.url }} --user {{ snappy.user }} --password {{ snappy.password }};


### PR DESCRIPTION

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>

### Description

Updating api-load to match latest [release](https://github.com/cloud-bulldozer/ocm-api-load/releases/tag/v0.3.2)
- Removes extra step to upload to elastic since now it's done within
  ocm-api-load
- Adds flags to use elastic search indexing within ocm-api-load

### Fixes
