### PR TITLE
Update benchmark-operator to enable testing on ARM systems

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,7 +63,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
       - name: redis-master
-        image: bitnami/redis:latest
+        image: quay.io/cloud-bulldozer/redis:latest
         env:
           - name: MASTER
             value: "true"


### PR DESCRIPTION
### Description
This is one of the several related PRs in e2e and benchmark-operator repos to follow, where we have been identifying issues and updating images and code as necessary to allow us to execute scale-ci tests on ARM clusters along with x86.

### Fixes
Point to new redis multi-arch image on quay.io
This fix allows us to successfully execute [network-perf test](https://github.com/cloud-bulldozer/e2e-benchmarking/tree/master/workloads/network-perf).