### PR TITLE
Allow the user to override the label to find nodes

### DIFF
--- a/config/samples/uperf/cr.yaml
+++ b/config/samples/uperf/cr.yaml
@@ -39,6 +39,9 @@ spec:
         - 16384
       nthrs:
         - 1
+      # By default, benchmark-operator will use the label - node-role.kubernetes.io/worker=
+      # However, some platforms do no ship with this.
+      #node_search_label: cloud.google.com/gke-nodepool=default-pool
       runtime: 30
 
       # The following variables are for 'Scale' mode.

--- a/roles/uperf/tasks/setup.yml
+++ b/roles/uperf/tasks/setup.yml
@@ -9,7 +9,7 @@
       api_version: v1
       kind: Node
       label_selectors:
-        - "node-role.kubernetes.io/worker="
+        - "{{ workload_args.node_search_label | default('node-role.kubernetes.io/worker=') }}"
     register: node_list
     no_log: True
   


### PR DESCRIPTION
Currently benchmark-operator only looks for a specific node label which
I have only seen with OpenShift.

This patch allows the user to provide other labels.

Signed-off-by: Joe Talerico <rook@isovalent.com>

### Description

### Fixes
