### PR TITLE
Reduce test scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ endif
 # E2E testing
 E2E_DIR = e2e
 E2E_RESULTS = test-results.xml
-BATS_FLAGS = -j 5 -F pretty --report-formatter junit -T
+BATS_FLAGS = -j 6 -F pretty --report-formatter junit -T
 ifdef BATS_TESTS
   FILTERED_TESTS := -f "$(BATS_TESTS)"
 endif

--- a/e2e/001-scale_openshift.bats
+++ b/e2e/001-scale_openshift.bats
@@ -13,7 +13,7 @@ ES_INDEX=openshift-cluster-timings
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   # Make node no schedulable as soon as benchmark finishes
   kubectl cordon $(kubectl get node --sort-by='{.metadata.creationTimestamp}' -o name | tail -1)
   # Annotate machine to ensure it's the one deleted in the scale-down test
@@ -27,7 +27,7 @@ ES_INDEX=openshift-cluster-timings
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900 || die "Timeout waiting for benchmark/${CR_NAME} to complete"
+  check_benchmark 1200 || die "Timeout waiting for benchmark/${CR_NAME} to complete"
   check_es
 }
 

--- a/e2e/002-sysbench.bats
+++ b/e2e/002-sysbench.bats
@@ -12,7 +12,7 @@ ES_INDEX=ripsaw-sysbench-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 setup_file() {

--- a/e2e/003-byowl.bats
+++ b/e2e/003-byowl.bats
@@ -12,7 +12,7 @@ load helpers.bash
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 @test "byowl-not-targeted" {
@@ -20,7 +20,7 @@ load helpers.bash
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 setup_file() {

--- a/e2e/004-backpack.bats
+++ b/e2e/004-backpack.bats
@@ -12,7 +12,7 @@ indexes=(cpu_vulnerabilities-metadata cpuinfo-metadata dmidecode-metadata k8s_no
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -21,7 +21,7 @@ indexes=(cpu_vulnerabilities-metadata cpuinfo-metadata dmidecode-metadata k8s_no
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/005-stressng.bats
+++ b/e2e/005-stressng.bats
@@ -12,7 +12,7 @@ ES_INDEX=ripsaw-stressng-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/006-vegeta.bats
+++ b/e2e/006-vegeta.bats
@@ -12,7 +12,7 @@ ES_INDEX=ripsaw-vegeta-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -21,7 +21,7 @@ ES_INDEX=ripsaw-vegeta-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/007-smallfile.bats
+++ b/e2e/007-smallfile.bats
@@ -12,7 +12,7 @@ indexes=(ripsaw-smallfile-results ripsaw-smallfile-rsptimes)
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -21,7 +21,7 @@ indexes=(ripsaw-smallfile-results ripsaw-smallfile-rsptimes)
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/008-kube-burner.bats
+++ b/e2e/008-kube-burner.bats
@@ -12,7 +12,7 @@ ES_INDEX=ripsaw-kube-burner
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -21,7 +21,7 @@ ES_INDEX=ripsaw-kube-burner
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 @test "kube-burner-node-density-heavy" {
@@ -29,7 +29,7 @@ ES_INDEX=ripsaw-kube-burner
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 @test "kube-burner-node-density-cni" {
@@ -37,7 +37,7 @@ ES_INDEX=ripsaw-kube-burner
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 @test "kube-burner-node-density-cni-networkpolicy" {
@@ -45,7 +45,7 @@ ES_INDEX=ripsaw-kube-burner
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 @test "kube-burner-max-services" {
@@ -53,7 +53,7 @@ ES_INDEX=ripsaw-kube-burner
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 @test "kube-burner-max-namespaces" {
@@ -61,7 +61,7 @@ ES_INDEX=ripsaw-kube-burner
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 @test "kube-burner-concurrent-builds" {
@@ -69,7 +69,7 @@ ES_INDEX=ripsaw-kube-burner
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 @test "kube-burner-configmap" {
@@ -77,7 +77,7 @@ ES_INDEX=ripsaw-kube-burner
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/008-kube-burner.bats
+++ b/e2e/008-kube-burner.bats
@@ -22,7 +22,6 @@ ES_INDEX=ripsaw-kube-burner
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
   check_benchmark 900
-  check_es
 }
 
 @test "kube-burner-node-density-heavy" {
@@ -31,7 +30,6 @@ ES_INDEX=ripsaw-kube-burner
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
   check_benchmark 900
-  check_es
 }
 
 @test "kube-burner-node-density-cni" {
@@ -40,7 +38,6 @@ ES_INDEX=ripsaw-kube-burner
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
   check_benchmark 900
-  check_es
 }
 
 @test "kube-burner-node-density-cni-networkpolicy" {
@@ -49,7 +46,6 @@ ES_INDEX=ripsaw-kube-burner
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
   check_benchmark 900
-  check_es
 }
 
 @test "kube-burner-max-services" {
@@ -58,7 +54,6 @@ ES_INDEX=ripsaw-kube-burner
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
   check_benchmark 900
-  check_es
 }
 
 @test "kube-burner-max-namespaces" {
@@ -67,7 +62,6 @@ ES_INDEX=ripsaw-kube-burner
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
   check_benchmark 900
-  check_es
 }
 
 @test "kube-burner-concurrent-builds" {
@@ -76,7 +70,6 @@ ES_INDEX=ripsaw-kube-burner
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
   check_benchmark 900
-  check_es
 }
 
 @test "kube-burner-configmap" {

--- a/e2e/009-iperf3.bats
+++ b/e2e/009-iperf3.bats
@@ -11,7 +11,7 @@ load helpers.bash
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
 }
 
 setup_file() {

--- a/e2e/010-fio.bats
+++ b/e2e/010-fio.bats
@@ -12,7 +12,7 @@ indexes=(ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result)
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -21,7 +21,7 @@ indexes=(ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result)
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -30,7 +30,7 @@ indexes=(ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result)
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f - 
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -50,7 +50,7 @@ indexes=(ripsaw-fio-results ripsaw-fio-log ripsaw-fio-analyzed-result)
     sleep 5
     envsubst < ${CR} | kubectl apply -f - 
     get_uuid "${CR_NAME}"
-    check_benchmark 900
+    check_benchmark 1200
     check_es
   fi
 }

--- a/e2e/011-ycsb.bats
+++ b/e2e/011-ycsb.bats
@@ -12,7 +12,7 @@ indexes=(ripsaw-ycsb-summary ripsaw-ycsb-results)
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/012-flent.bats
+++ b/e2e/012-flent.bats
@@ -12,7 +12,7 @@ ES_INDEX=ripsaw-flent-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -22,7 +22,7 @@ ES_INDEX=ripsaw-flent-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/013-uperf.bats
+++ b/e2e/013-uperf.bats
@@ -12,7 +12,7 @@ ES_INDEX=ripsaw-uperf-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -21,7 +21,7 @@ ES_INDEX=ripsaw-uperf-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -30,7 +30,7 @@ ES_INDEX=ripsaw-uperf-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -39,7 +39,7 @@ ES_INDEX=ripsaw-uperf-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -48,7 +48,7 @@ ES_INDEX=ripsaw-uperf-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -57,7 +57,7 @@ ES_INDEX=ripsaw-uperf-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/014-pgbench.bats
+++ b/e2e/014-pgbench.bats
@@ -12,7 +12,7 @@ indexes=(ripsaw-pgbench-summary ripsaw-pgbench-raw)
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/015-image_pull.bats
+++ b/e2e/015-image_pull.bats
@@ -12,7 +12,7 @@ ES_INDEX=image-pull-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/016-hammerdb.bats
+++ b/e2e/016-hammerdb.bats
@@ -12,7 +12,7 @@ ES_INDEX=ripsaw-hammerdb-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/017-fs_drift.bats
+++ b/e2e/017-fs_drift.bats
@@ -12,7 +12,7 @@ indexes=(ripsaw-fs-drift-results ripsaw-fs-drift-rsptimes ripsaw-fs-drift-rates-
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 
@@ -22,7 +22,7 @@ indexes=(ripsaw-fs-drift-results ripsaw-fs-drift-rsptimes ripsaw-fs-drift-rates-
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/018-log-generator.bats
+++ b/e2e/018-log-generator.bats
@@ -12,7 +12,7 @@ ES_INDEX=log-generator-results
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"
-  check_benchmark 900
+  check_benchmark 1200
   check_es
 }
 

--- a/e2e/byowl/byowl-targeted.yaml
+++ b/e2e/byowl/byowl-targeted.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/fio/fio_bsrange.yaml
+++ b/e2e/fio/fio_bsrange.yaml
@@ -14,7 +14,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-fio
   metadata:
-    collection: true
+    collection: false
   cleanup: false
   workload:
     name: "fio_distributed"
@@ -23,10 +23,6 @@ spec:
       servers: 2
       jobs:
         - write
-        - read
-        - randwrite
-        - randread
-        - randrw
       bsrange:
         - 4KiB-16KiB
       numjobs:
@@ -50,37 +46,5 @@ spec:
         - time_based=1
         - fsync_on_close=1
         - create_on_open=1
-        - runtime={{ workload_args.write_runtime }}
-        - ramp_time={{ workload_args.write_ramp_time }}
-    - jobname_match: read
-      params:
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: rw
-      params:
-        - rwmixread=50
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: readwrite
-      params:
-        - rwmixread=50
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: randread
-      params:
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: randwrite
-      params:
-        - time_based=1
-        - runtime={{ workload_args.write_runtime }}
-        - ramp_time={{ workload_args.write_ramp_time }}
-    - jobname_match: randrw
-      params:
-        - time_based=1
         - runtime={{ workload_args.write_runtime }}
         - ramp_time={{ workload_args.write_ramp_time }}

--- a/e2e/fio/fio_bsrange.yaml
+++ b/e2e/fio/fio_bsrange.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/fio/fio_hostpath.yaml
+++ b/e2e/fio/fio_hostpath.yaml
@@ -14,7 +14,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-fio
   metadata:
-    collection: true
+    collection: false
   cleanup: false
   hostpath: /mnt/vda1/workload_args/
   workload:
@@ -25,8 +25,6 @@ spec:
       prefill: true
       jobs:
         - write
-        - randread
-        - randrw
       bs:
         - 4KiB
       numjobs:
@@ -49,36 +47,3 @@ spec:
         - create_on_open=1
         - runtime={{ workload_args.write_runtime }}
         - ramp_time={{ workload_args.write_ramp_time }}
-    - jobname_match: read
-      params:
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: rw
-      params:
-        - rwmixread=50
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: readwrite
-      params:
-        - rwmixread=50
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: randread
-      params:
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: randwrite
-      params:
-        - time_based=1
-        - runtime={{ workload_args.write_runtime }}
-        - ramp_time={{ workload_args.write_ramp_time }}
-    - jobname_match: randrw
-      params:
-        - time_based=1
-        - runtime={{ workload_args.write_runtime }}
-        - ramp_time={{ workload_args.write_ramp_time }}
-

--- a/e2e/fio/fio_hostpath.yaml
+++ b/e2e/fio/fio_hostpath.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/fio/fio_ocs_cache_drop.yaml
+++ b/e2e/fio/fio_ocs_cache_drop.yaml
@@ -14,7 +14,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-fio
   metadata:
-    collection: true
+    collection: false
   cleanup: false
   workload:
     name: "fio_distributed"
@@ -24,9 +24,7 @@ spec:
       samples: 1
       servers: 2
       jobs:
-        - randwrite
-        - randread
-        - randrw
+        - write
       bs:
         - 4KiB
       numjobs:
@@ -49,37 +47,5 @@ spec:
         - time_based=1
         - fsync_on_close=1
         - create_on_open=1
-        - runtime={{ workload_args.write_runtime }}
-        - ramp_time={{ workload_args.write_ramp_time }}
-    - jobname_match: read
-      params:
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: rw
-      params:
-        - rwmixread=50
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: readwrite
-      params:
-        - rwmixread=50
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: randread
-      params:
-        - time_based=1
-        - runtime={{ workload_args.read_runtime }}
-        - ramp_time={{ workload_args.read_ramp_time }}
-    - jobname_match: randwrite
-      params:
-        - time_based=1
-        - runtime={{ workload_args.write_runtime }}
-        - ramp_time={{ workload_args.write_ramp_time }}
-    - jobname_match: randrw
-      params:
-        - time_based=1
         - runtime={{ workload_args.write_runtime }}
         - ramp_time={{ workload_args.write_ramp_time }}

--- a/e2e/fio/fio_ocs_cache_drop.yaml
+++ b/e2e/fio/fio_ocs_cache_drop.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/flent/flent_resources.yaml
+++ b/e2e/flent/flent_resources.yaml
@@ -13,6 +13,8 @@ spec:
   elasticsearch:
     url: ${ES_SERVER}
     index_name: ripsaw-flent
+  metadata:
+    collection: false
   workload:
     # cleanup: true
     name: flent

--- a/e2e/flent/flent_resources.yaml
+++ b/e2e/flent/flent_resources.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/fs_drift/fs_drift_hostpath.yaml
+++ b/e2e/fs_drift/fs_drift_hostpath.yaml
@@ -18,7 +18,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-fs-drift
   metadata:
-    collection: true
+    collection: false
   hostpath: /mnt/vda1/fs_drift
   workload:
     name: fs-drift

--- a/e2e/fs_drift/fs_drift_hostpath.yaml
+++ b/e2e/fs_drift/fs_drift_hostpath.yaml
@@ -8,7 +8,7 @@ spec:
   # to separate this test run from everyone else's
   clustername: test_ci
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/kube-burner/concurrent-builds.yaml
+++ b/e2e/kube-burner/concurrent-builds.yaml
@@ -9,10 +9,6 @@ spec:
     url: ${ES_SERVER}
   metadata:
     collection: false
-  prometheus:
-    es_url: ${ES_SERVER}
-    prom_token: ${PROMETHEUS_TOKEN}
-    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:
     name: kube-burner
     args:

--- a/e2e/kube-burner/configmap.yaml
+++ b/e2e/kube-burner/configmap.yaml
@@ -8,7 +8,7 @@ spec:
   elasticsearch:
     url: ${ES_SERVER}
   metadata:
-    collection: true
+    collection: false
   prometheus:
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/kube-burner/configmap.yaml
+++ b/e2e/kube-burner/configmap.yaml
@@ -9,10 +9,6 @@ spec:
     url: ${ES_SERVER}
   metadata:
     collection: false
-  prometheus:
-    es_url: ${ES_SERVER}
-    prom_token: ${PROMETHEUS_TOKEN}
-    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:
     name: kube-burner
     args:

--- a/e2e/kube-burner/max-namespaces.yaml
+++ b/e2e/kube-burner/max-namespaces.yaml
@@ -9,10 +9,6 @@ spec:
     url: ${ES_SERVER}
   metadata:
     collection: false
-  prometheus:
-    es_url: ${ES_SERVER}
-    prom_token: ${PROMETHEUS_TOKEN}
-    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:
     name: kube-burner
     args:

--- a/e2e/kube-burner/max-services.yaml
+++ b/e2e/kube-burner/max-services.yaml
@@ -9,10 +9,6 @@ spec:
     url: ${ES_SERVER}
   metadata:
     collection: false
-  prometheus:
-    es_url: ${ES_SERVER}
-    prom_token: ${PROMETHEUS_TOKEN}
-    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:
     name: kube-burner
     args:

--- a/e2e/kube-burner/node-density-cni-networkpolicy.yaml
+++ b/e2e/kube-burner/node-density-cni-networkpolicy.yaml
@@ -9,10 +9,6 @@ spec:
     url: ${ES_SERVER}
   metadata:
     collection: false
-  prometheus:
-    es_url: ${ES_SERVER}
-    prom_token: ${PROMETHEUS_TOKEN}
-    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:
     name: kube-burner
     args:

--- a/e2e/kube-burner/node-density-cni.yaml
+++ b/e2e/kube-burner/node-density-cni.yaml
@@ -9,10 +9,6 @@ spec:
     url: ${ES_SERVER}
   metadata:
     collection: false
-  prometheus:
-    es_url: ${ES_SERVER}
-    prom_token: ${PROMETHEUS_TOKEN}
-    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:
     name: kube-burner
     args:

--- a/e2e/kube-burner/node-density-heavy.yaml
+++ b/e2e/kube-burner/node-density-heavy.yaml
@@ -9,10 +9,6 @@ spec:
     url: ${ES_SERVER}
   metadata:
     collection: false
-  prometheus:
-    es_url: ${ES_SERVER}
-    prom_token: ${PROMETHEUS_TOKEN}
-    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:
     name: kube-burner
     args:

--- a/e2e/kube-burner/node-density.yaml
+++ b/e2e/kube-burner/node-density.yaml
@@ -9,10 +9,6 @@ spec:
     url: ${ES_SERVER}
   metadata:
     collection: false
-  prometheus:
-    es_url: ${ES_SERVER}
-    prom_token: ${PROMETHEUS_TOKEN}
-    prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
   workload:
     name: kube-burner
     args:

--- a/e2e/scale-openshift/scale_down.yaml
+++ b/e2e/scale-openshift/scale_down.yaml
@@ -7,7 +7,7 @@ spec:
   metadata:
     collection: true
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/smallfile/smallfile_hostpath.yaml
+++ b/e2e/smallfile/smallfile_hostpath.yaml
@@ -18,7 +18,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-smallfile
   metadata:
-    collection: true
+    collection: false
   hostpath: /mnt/vda1/smallfile
   workload:
     name: smallfile

--- a/e2e/smallfile/smallfile_hostpath.yaml
+++ b/e2e/smallfile/smallfile_hostpath.yaml
@@ -9,7 +9,7 @@ spec:
   # to separate this test run from everyone else's
   clustername: test_ci
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/uperf/uperf.yaml
+++ b/e2e/uperf/uperf.yaml
@@ -15,7 +15,6 @@ spec:
     index_name: ripsaw-uperf
   metadata:
     collection: true
-    collection: false
   cleanup: false
   workload:
     name: uperf

--- a/e2e/uperf/uperf.yaml
+++ b/e2e/uperf/uperf.yaml
@@ -15,6 +15,7 @@ spec:
     index_name: ripsaw-uperf
   metadata:
     collection: true
+    collection: false
   cleanup: false
   workload:
     name: uperf

--- a/e2e/uperf/uperf_hostnetwork.yaml
+++ b/e2e/uperf/uperf_hostnetwork.yaml
@@ -14,7 +14,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-uperf
   metadata:
-    collection: true
+    collection: false
   cleanup: false
   workload:
     name: uperf

--- a/e2e/uperf/uperf_hostnetwork.yaml
+++ b/e2e/uperf/uperf_hostnetwork.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/uperf/uperf_networkpolicy.yaml
+++ b/e2e/uperf/uperf_networkpolicy.yaml
@@ -14,7 +14,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-uperf
   metadata:
-    collection: true
+    collection: false
   cleanup: false
   workload:
     name: uperf

--- a/e2e/uperf/uperf_networkpolicy.yaml
+++ b/e2e/uperf/uperf_networkpolicy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/uperf/uperf_resources.yaml
+++ b/e2e/uperf/uperf_resources.yaml
@@ -14,7 +14,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-uperf
   metadata:
-    collection: true
+    collection: false
   cleanup: false
   workload:
     name: uperf

--- a/e2e/uperf/uperf_resources.yaml
+++ b/e2e/uperf/uperf_resources.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/uperf/uperf_serviceip.yaml
+++ b/e2e/uperf/uperf_serviceip.yaml
@@ -14,7 +14,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-uperf
   metadata:
-    collection: true
+    collection: false
   cleanup: false
   workload:
     name: uperf

--- a/e2e/uperf/uperf_serviceip.yaml
+++ b/e2e/uperf/uperf_serviceip.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/uperf/uperf_serviceip_nodeport.yaml
+++ b/e2e/uperf/uperf_serviceip_nodeport.yaml
@@ -14,7 +14,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-uperf
   metadata:
-    collection: true
+    collection: false
   cleanup: false
   workload:
     name: uperf

--- a/e2e/uperf/uperf_serviceip_nodeport.yaml
+++ b/e2e/uperf/uperf_serviceip_nodeport.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/vegeta/vegeta_hostnetwork.yaml
+++ b/e2e/vegeta/vegeta_hostnetwork.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: benchmark-operator
 spec:
   system_metrics:
-    collection: true
+    collection: false
     prom_url: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
     es_url: ${ES_SERVER}
     prom_token: ${PROMETHEUS_TOKEN}

--- a/e2e/vegeta/vegeta_hostnetwork.yaml
+++ b/e2e/vegeta/vegeta_hostnetwork.yaml
@@ -15,7 +15,7 @@ spec:
     url: ${ES_SERVER}
     index_name: ripsaw-vegeta
   metadata:
-    collection: true
+    collection: false
   workload:
     name: vegeta
     args:


### PR DESCRIPTION
### Description

Should improve CI reliability and reduce test duration. 
- Only perform all FIO I/O operations in one of the tests 
- Disable metadata collection in benchmarks with more than one test case.
- Enable prometheus metric collection in only one kube-burner test

