### PR TITLE
Fix tests race condition

### DIFF
--- a/cli/tests/clients/test_k8s.py
+++ b/cli/tests/clients/test_k8s.py
@@ -33,6 +33,7 @@ class TestCluster:
     def test_get_jobs(self, cluster, test_job):
         label_selector = "app=test-job"
         jobs = cluster.get_jobs(label_selector=label_selector, namespace="default")
+        cluster.wait_for_pods("job-name=busybox", "default")
         assert len(jobs.items) == 1
         assert jobs.items[0].metadata.name == "busybox"
 

--- a/cli/tests/resources/job.yaml
+++ b/cli/tests/resources/job.yaml
@@ -16,3 +16,4 @@ spec:
         imagePullPolicy: IfNotPresent
         name: busybox
       restartPolicy: Never
+      terminationGracePeriodSeconds: 0


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

There was a race condition in the tests. We where counting the number of pods while an old pod was still in Deleting stage.



Fixes: https://github.com/cloud-bulldozer/benchmark-operator/issues/749 
