### PR TITLE
Template serviceAccountName

### DIFF
--- a/e2e/013-uperf.bats
+++ b/e2e/013-uperf.bats
@@ -7,6 +7,15 @@ load helpers.bash
 ES_INDEX=ripsaw-uperf-results
 
 
+@test "uperf-hostnetwork" {
+  CR=uperf/uperf_hostnetwork.yaml
+  CR_NAME=$(get_benchmark_name ${CR})
+  envsubst < ${CR} | kubectl apply -f -
+  get_uuid "${CR_NAME}"
+  check_benchmark 1200
+  check_es
+}
+
 @test "uperf-standard" {
   CR=uperf/uperf.yaml
   CR_NAME=$(get_benchmark_name ${CR})
@@ -45,15 +54,6 @@ ES_INDEX=ripsaw-uperf-results
 
 @test "uperf-serviceip-nodeport" {
   CR=uperf/uperf_serviceip_nodeport.yaml
-  CR_NAME=$(get_benchmark_name ${CR})
-  envsubst < ${CR} | kubectl apply -f -
-  get_uuid "${CR_NAME}"
-  check_benchmark 1200
-  check_es
-}
-
-@test "uperf-hostnetwork" {
-  CR=uperf/uperf_hostnetwork.yaml
   CR_NAME=$(get_benchmark_name ${CR})
   envsubst < ${CR} | kubectl apply -f -
   get_uuid "${CR_NAME}"

--- a/playbooks/templates/metadata.yml.j2
+++ b/playbooks/templates/metadata.yml.j2
@@ -1,3 +1,4 @@
+      serviceAccountName: benchmark-operator
 {% if metadata.collection is sameas true and metadata.targeted is sameas true %}
       initContainers:
       - name: backpack

--- a/playbooks/templates/metadata_pod.yml.j2
+++ b/playbooks/templates/metadata_pod.yml.j2
@@ -1,3 +1,4 @@
+  serviceAccountName: benchmark-operator
 {% if metadata.collection is sameas true and metadata.targeted is sameas true %}
   initContainers:
   - name: backpack

--- a/roles/byowl/templates/workload.yml
+++ b/roles/byowl/templates/workload.yml
@@ -19,7 +19,6 @@ spec:
 {% endfor %}
 {% endif %}
     spec:
-      serviceAccountName: benchmark-operator
 {% if workload_args.runtime_class is defined %}
       runtimeClassName: "{{ workload_args.runtime_class }}"
 {% endif %}

--- a/roles/cyclictest/templates/cyclictestjob.yaml
+++ b/roles/cyclictest/templates/cyclictestjob.yaml
@@ -93,5 +93,4 @@ spec:
           name: "cyclictest-{{ trunc_uuid }}"
           defaultMode: 0555
       restartPolicy: Never
-      serviceAccountName: benchmark-operator
 {% include "metadata.yml.j2" %}

--- a/roles/fio_distributed/templates/servers.yaml
+++ b/roles/fio_distributed/templates/servers.yaml
@@ -51,7 +51,6 @@ spec:
       mountPath: "{{ fio_path }}"
 {% endif %}
   restartPolicy: Never
-  serviceAccountName: benchmark-operator
 {% if workload_args.nodeselector is defined %}
   nodeSelector: 
 {% for label, value in  workload_args.nodeselector.items() %}

--- a/roles/flent/templates/server.yml.j2
+++ b/roles/flent/templates/server.yml.j2
@@ -26,7 +26,6 @@ spec:
 {% endif %}
 {% if workload_args.hostnetwork is sameas true %}
   hostNetwork: true
-  serviceAccountName: benchmark-operator
 {% endif %}
   containers:
   - name: benchmark

--- a/roles/flent/templates/workload.yml.j2
+++ b/roles/flent/templates/workload.yml.j2
@@ -26,7 +26,6 @@ spec:
     spec:
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork : true
-      serviceAccountName: benchmark-operator
 {% endif %}
       affinity:
         podAntiAffinity:

--- a/roles/fs-drift/templates/workload_job.yml.j2
+++ b/roles/fs-drift/templates/workload_job.yml.j2
@@ -118,5 +118,4 @@ spec:
             type: DirectoryOrCreate
 {% endif %}
       restartPolicy: Never
-      serviceAccountName: benchmark-operator
 {% include "metadata.yml.j2" %}

--- a/roles/iperf3/templates/client.yml.j2
+++ b/roles/iperf3/templates/client.yml.j2
@@ -39,7 +39,6 @@ spec:
 {% endif %}
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
-      serviceAccountName: benchmark-operator
 {% endif %}
       containers:
       - name: benchmark

--- a/roles/iperf3/templates/server.yml.j2
+++ b/roles/iperf3/templates/server.yml.j2
@@ -34,7 +34,6 @@ spec:
 {% endif %}
 {% if workload_args.hostnetwork is sameas true %}
   hostNetwork: true
-  serviceAccountName: benchmark-operator
 {% endif %}
   containers:
   - name: benchmark

--- a/roles/kube-burner/templates/kube-burner.yml.j2
+++ b/roles/kube-burner/templates/kube-burner.yml.j2
@@ -24,7 +24,6 @@ spec:
 {% endif %}
       tolerations: {{ workload_args.tolerations|default([]) }}
       restartPolicy: Never
-      serviceAccountName: benchmark-operator
       nodeSelector:
 {% if workload_args.pin_server is defined and workload_args.pin_server is mapping %}
 {% for label, value in  workload_args.pin_server.items() %}

--- a/roles/oslat/templates/oslatjob.yaml
+++ b/roles/oslat/templates/oslatjob.yaml
@@ -94,5 +94,4 @@ spec:
           name: "oslat-{{ trunc_uuid }}"
           defaultMode: 0555
       restartPolicy: Never
-      serviceAccountName: benchmark-operator
 {% include "metadata.yml.j2" %}

--- a/roles/scale_openshift/templates/scale.yml
+++ b/roles/scale_openshift/templates/scale.yml
@@ -89,6 +89,5 @@ spec:
 {% endif %}
             ;
             sleep {{post_sleep|default(0)}}"
-      serviceAccountName: benchmark-operator
       restartPolicy: Never
 {% include "metadata.yml.j2" %}

--- a/roles/smallfile/templates/workload_job.yml.j2
+++ b/roles/smallfile/templates/workload_job.yml.j2
@@ -140,5 +140,4 @@ spec:
             type: DirectoryOrCreate
 {% endif %}
       restartPolicy: Never
-      serviceAccountName: benchmark-operator
 {% include "metadata.yml.j2" %}

--- a/roles/testpmd/templates/testpmd.yml.j2
+++ b/roles/testpmd/templates/testpmd.yml.j2
@@ -78,6 +78,5 @@ spec:
     emptyDir:
       medium: HugePages
   restartPolicy: Never
-  serviceAccountName: benchmark-operator
 {% include "metadata_pod.yml.j2" %}
 

--- a/roles/testpmd/templates/trex.yml.j2
+++ b/roles/testpmd/templates/trex.yml.j2
@@ -139,6 +139,5 @@ spec:
         hostPath:
           path: /lib/modules
       restartPolicy: Never
-      serviceAccountName: benchmark-operator
 {% include "metadata.yml.j2" %}
 

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -51,7 +51,6 @@ items:
 {% endif %}
 {% if workload_args.hostnetwork is sameas true %}
           hostNetwork: true
-          serviceAccountName: benchmark-operator
 {% endif %}
           containers:
           - name: benchmark

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -49,7 +49,6 @@ items:
 {% endif %}
 {% if workload_args.hostnetwork is sameas true %}
           hostNetwork: true
-          serviceAccountName: benchmark-operator
 {% endif %}
           affinity:
             podAntiAffinity:

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -49,6 +49,7 @@ items:
 {% endif %}
 {% if workload_args.hostnetwork is sameas true %}
           hostNetwork: true
+          serviceAccountName: benchmark-operator
 {% endif %}
           affinity:
             podAntiAffinity:

--- a/roles/vegeta/templates/vegeta.yml.j2
+++ b/roles/vegeta/templates/vegeta.yml.j2
@@ -28,7 +28,6 @@ spec:
 {% endif %}
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork : true
-      serviceAccountName: benchmark-operator
 {% endif %}
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Rather than setting serviceAccountName: benchmark-operator in every YAML, let's use the metadata template to set it.

