### PR TITLE
bug fix for ports mismatch between client and server pairs in without…

### DIFF
--- a/roles/uperf/templates/configmap.yml.j2
+++ b/roles/uperf/templates/configmap.yml.j2
@@ -23,7 +23,7 @@ data:
     {% if ( 'rr' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + item|int * 100 + 1 }}"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + (0 if (workload_args.serviceip is defined and workload_args.serviceip and ( workload_args.servicetype | default("clusterip") == "clusterip" )) else (item|int * 100)) + 1 }}"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=write options="size={{wsize}}"/>
@@ -36,7 +36,7 @@ data:
     {% if ( 'stream' == test or 'bidirec' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + item|int * 100 + 1 }}"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + (0 if (workload_args.serviceip is defined and workload_args.serviceip and ( workload_args.servicetype | default("clusterip") == "clusterip" )) else (item|int * 100)) + 1 }}"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=write options="count=16 size={{wsize}}"/>
@@ -49,7 +49,7 @@ data:
     {% if ( 'maerts' == test or 'bidirec' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + item|int * 100 + 1 }}"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + (0 if (workload_args.serviceip is defined and workload_args.serviceip and ( workload_args.servicetype | default("clusterip") == "clusterip" )) else (item|int * 100)) + 1 }}"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=read options="count=16 size={{rsize}}"/>

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -32,6 +32,7 @@ items:
             benchmark-uuid: {{ uuid }}
             benchmark-operator-workload: uperf
             benchmark-operator-role: server
+            index: "{{item}}"
 {% if (worker_node_list[node_idx_item]|length>27) and (worker_node_list[node_idx_item][26] == '.') %}
             app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(26,true,'')}}-{{ item  }}-{{ trunc_uuid }}
 {% else %}
@@ -60,7 +61,7 @@ items:
 {% endif %}
             imagePullPolicy: Always
             command: ["/bin/sh","-c"]
-            args: ["uperf -s -v -P {{ control_port|int + item|int * 100 }}"]
+            args: ["uperf -s -v -P {{ control_port|int + (0 if (workload_args.serviceip is defined and workload_args.serviceip and ( workload_args.servicetype | default("clusterip") == "clusterip" )) else (item|int * 100)) }}"]
           restartPolicy: Never
 {% if workload_args.pin is sameas true %}
           nodeSelector:

--- a/roles/uperf/templates/service.yml.j2
+++ b/roles/uperf/templates/service.yml.j2
@@ -13,6 +13,7 @@ items:
       labels:
         benchmark-uuid: {{ uuid }}
         benchmark-operator-workload: uperf
+        index: "{{item}}"
 {% if (worker_node_list[node_idx_item]|length>27) and (worker_node_list[node_idx_item][26] == '.') %}
         app: uperf-bench-server-{{ worker_node_list[node_idx_item] | truncate(26,true,'')}}-{{ item }}-{{ trunc_uuid }}
 {% else %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -10,7 +10,7 @@ items:
     metadata:
 {% if workload_args.serviceip is sameas true %}
 {% if workload_args.servicetype | default("clusterip") == "nodeport" %}
-      name: 'uperf-client-{{item.status.hostIP}}-{{ loop.index - 1 }}-{{ trunc_uuid }}'
+      name: 'uperf-client-{{item.status.hostIP}}-{{ item.metadata.labels.index|int }}-{{ trunc_uuid }}'
 {% elif workload_args.servicetype | default("clusterip") == "metallb" or workload_args.servicetype | default("clusterip") == "loadbalancer" %}
       name: 'uperf-client-{{item.status.loadBalancer.ingress[0].ip}}-{{ trunc_uuid }}'
 {% else %}
@@ -125,7 +125,8 @@ items:
               - "export h={{item.status.podIP}};
 {% endif %}
 {% endif %}
-                 export port={{ control_port + (loop.index - 1) * 100 }}
+                 export port={{ control_port + (0 if (workload_args.serviceip is defined and workload_args.serviceip and ( workload_args.servicetype | default("clusterip") == "clusterip" )) else (item.metadata.labels.index|int * 100))}}
+
 {% if (workload_args.colocate is defined) %}
                  export colocate={{ workload_args.colocate}};
 {% endif %}
@@ -219,7 +220,7 @@ items:
           volumes:
             - name: config-volume
               configMap:
-                name: uperf-test-{{ loop.index - 1 }}-{{ trunc_uuid }}
+                name: uperf-test-{{ item.metadata.labels.index|int }}-{{ trunc_uuid }}
           restartPolicy: Never
 {% if workload_args.pin is sameas false %}
 {% if workload_args.colocate is sameas true %}


### PR DESCRIPTION
### Description
Context : https://github.com/cloud-bulldozer/benchmark-operator/issues/773
### Fixes
Made code changes to assign correct ports to client-server pairs.
### Testing
Tested for multiple cases. Below are the uuids to check in ES cluster [here](https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com/_plugin/kibana/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(_source),filters:!(),index:c842dec0-50f4-11eb-ab97-59afc90e99be,interval:auto,query:(language:lucene,query:''),sort:!())).
- afb84c72-5878-5431-8427-7de4ca844e80 - without service case
- 90ec5ad1-bc6c-5e2c-863e-fc90e0caaf4b - clusterip case
- ed7b52e6-6dfb-5f98-93d3-43ac34831a0d - nodeport case

