### PR TITLE
Use uperf pod antiAffinity rules

### DIFF
--- a/docs/uperf.md
+++ b/docs/uperf.md
@@ -54,11 +54,9 @@ spec:
       nthrs:
         - 1
       runtime: 30
-      colocate: false
-      density_range: [low, high]
-      node_range: [low, high]
-      step_size: addN, log2
 ```
+
+ By default, the uperf server and client pods will be preferably scheduled on different nodes, thanks to a `podAntiAffinity` rule. In scenarios with more than 1 pair, all clients and servers will be scheduled to the same node. 
 
 `client_resources` and `server_resources` will create uperf client's and server's containers with the given k8s compute resources respectively [k8s resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
 
@@ -85,9 +83,6 @@ spec:
 `pin_client` what node to pin the client pod to.
 
 `pair` how many instances of uperf client-server pairs. `pair` is applicable for `pin: true` only.
-If `pair` is not specified, the operator will use the value in `density_range` to detemine the number of pairs.
-See **Scale** section for more info. `density_range` can do more than `pair` can, but `pair` support is retained 
-for backward compatibility.
 
 `multus[1]` Configure our pods to use multus.
 
@@ -203,62 +198,6 @@ To enable Multus in Ripsaw, here is the relevant config.
       pin_client: "openshift-master-1.dev4.kni.lab.eng.bos.redhat.com"
       ...
 
-```
-### Scale
-Scale in this context refers to the ability to enumerate UPERF 
-client-server pairs during test in a control fashion using the following knobs.
-
-`colocate: true` will place each client and server pod pair on the same node.
-
-`density_range` to specify the range of client-server pairs that the test will iterate.
-
-`node_range` to specify the range of nodes that the test will iterate.
-
-`step_size` to specify the incrementing method.
-
-Here is one scale example:
-
-```
-      ...
-      pin: false
-      colocate: false
-      density_range: [1,10]
-      node_range: [1,128]
-      step_size: log2
-      ...
-```
-Note, the `scale` mode is mutually exlusive to `pin` mode with the `pin` mode having higher precedence.
-In other words, if `pin:true` the test will deploy pods on `pin_server` and `pin_client` nodes
-and ignore `colocate`, `node_range`, and the number of pairs to deploy is specified by the
- `density_range.high` value.
-
-In the above sample, the `scale` mode will be activated since `pin: false`. In the first phase, the 
-pod instantion phase, the system gathers node inventory and may reduce the `node_range.high` value 
-to match the number of worker node available in the cluster.
-
-According to `node_range: [1,128]`, and `density_range:[1,10]`, the system will instantiate 10 pairs on 
-each of 128 nodes. Each pair has a node_idx and a pod_idx that are used later to control
-which one and when they should run the UPERF workload, After all pairs are up and ready,
-next comes the test execution phase.
-
-The scale mode iterates the test as a double nested loop as follows:
-```
-   for node with node_idx less-or-equal node_range(low, high. step_size):
-      for pod with pod_idx less-or-equal density_range(low, high, step_size):
-          run uperf 
-```
-Hence, with the above params, the first iteration runs the pair with node_idx/pod_idx of {1,1}. After the first
-run has completed, the second interation runs 2 pairs of {1,1} and {1,2} and so on.
-
-The valid `step_size` methods are: addN and log2. `N` can be any integer and `log2` will double the value at each iteration i.e. 1,2,4,8,16 ...
-By choosing the appropriate values for `density_range` and `node_range`, the user can generate most if not all
-combinations of UPERF data points to exercise datapath performance from many angles.
-
-Once done creating/editing the resource file, you can run it by:
-
-```bash
-# kubectl apply -f config/samples/uperf/cr.yaml # if edited the original one
-# kubectl apply -f <path_to_file> # if created a new cr file
 ```
 ### Advanced Service types
 

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -1,31 +1,5 @@
 ---
 
-- name: Get current state
-  k8s_facts:
-    api_version: ripsaw.cloudbulldozer.io/v1alpha1
-    kind: Benchmark
-    name: '{{ ansible_operator_meta.name }}'
-    namespace: '{{ operator_namespace }}'
-  register: resource_state
-
-- operator_sdk.util.k8s_status:
-    api_version: ripsaw.cloudbulldozer.io/v1alpha1
-    kind: Benchmark
-    name: "{{ ansible_operator_meta.name }}"
-    namespace: "{{ operator_namespace }}"
-    status:
-      state: Building
-      complete: false
-  when: resource_state.resources[0].status.state is not defined
-
-- name: Get current state - If it has changed
-  k8s_facts:
-    api_version: ripsaw.cloudbulldozer.io/v1alpha1
-    kind: Benchmark
-    name: '{{ ansible_operator_meta.name }}'
-    namespace: '{{ operator_namespace }}'
-  register: resource_state
-
 - name: Capture ServiceIP
   k8s_facts:
     kind: Service
@@ -61,25 +35,13 @@
     register: servers
     with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
 
-  - name: Wait for pods to be running....
-    k8s_facts:
-      kind: Pod
-      api_version: v1
-      namespace: '{{ operator_namespace }}'
-      label_selectors:
-        - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
-    register: server_pods
+  - include_role:
+      name: benchmark_state
+      tasks_from: set_state
+    vars:
+      state: Starting Servers
 
-  - name: Update resource state
-    operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ ansible_operator_meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: "Starting Servers"
-
-  when: resource_state.resources[0].status.state == "Building" and resource_kind == "pod"
+  when: benchmark_state.resources[0].status.state == "Building" and resource_kind == "pod"
 
 - block:
 
@@ -89,25 +51,13 @@
     register: servers
     with_sequence: start=0 count={{ workload_args.pair | default('1')|int }}
 
-  - name: Wait for vms to be running....
-    k8s_facts:
-      kind: VirtualMachineInstance
-      api_version: kubevirt.io/v1alpha3
-      namespace: '{{ operator_namespace }}'
-      label_selectors:
-        - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
-    register: server_vms
+  - include_role:
+      name: benchmark_state
+      tasks_from: set_state
+    vars:
+      state: Starting Servers
 
-  - name: Update resource state
-    operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ ansible_operator_meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: "Starting Servers"
-
-  when: resource_state.resources[0].status.state == "Building" and resource_kind == "vm"
+  when: benchmark_state.resources[0].status.state == "Building" and resource_kind == "vm"
 
 - block:
 
@@ -120,18 +70,15 @@
         - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_pods
 
-  - name: Update resource state
-    operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ ansible_operator_meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: "Starting Clients"
+  - include_role:
+      name: benchmark_state
+      tasks_from: set_state
+    vars:
+      state: "Starting Clients"
     when: "workload_args.pair|default('1')|int == server_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length"
 
 
-  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "pod"
+  when: benchmark_state.resources[0].status.state == "Starting Servers" and resource_kind == "pod"
 
 - block:
 
@@ -144,14 +91,11 @@
         - type = {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
     register: server_vms
 
-  - name: Update resource state
-    operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ ansible_operator_meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: "Starting Clients"
+  - include_role:
+      name: benchmark_state
+      tasks_from: set_state
+    vars:
+      state: "Starting Clients"
     when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
 
   - name: blocking client from running uperf
@@ -159,7 +103,7 @@
     with_items: "{{ server_vms.resources }}"
     when: "workload_args.pair|default('1')|int == server_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (server_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
 
-  when: resource_state.resources[0].status.state == "Starting Servers" and resource_kind == "vm" and workload_args.pair|default('1')|int|int == 1
+  when: benchmark_state.resources[0].status.state == "Starting Servers" and resource_kind == "vm" and workload_args.pair|default('1')|int|int == 1
 
 - block:
 
@@ -231,15 +175,13 @@
 
     when: resource_kind == "vm"
 
-  - operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ ansible_operator_meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: Waiting for Clients
+  - include_role:
+      name: benchmark_state
+      tasks_from: set_state
+    vars:
+      state: "Waiting for Clients"
 
-  when: resource_state.resources[0].status.state == "Starting Clients"
+  when: benchmark_state.resources[0].status.state == "Starting Clients"
 
 - block:
 
@@ -261,6 +203,11 @@
         namespace: "{{ operator_namespace }}"
         status:
           state: Clients Running
+    - include_role:
+        name: benchmark_state
+        tasks_from: set_state
+      vars:
+        state: Clients Running
       when: "workload_args.pair|default('1')|int == client_pods | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (client_pods | json_query('resources[].status.podIP')|length)"
 
     when: resource_kind == "pod"
@@ -279,35 +226,29 @@
           - app = uperf-bench-client-{{ trunc_uuid }}
       register: client_vms
 
-    - name: Update resource state
-      operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ ansible_operator_meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Clients Running
+    - include_role:
+        name: benchmark_state
+        tasks_from: set_state
+      vars:
+        state: Clients Running
       when: "workload_args.pair|default('1')|int == client_vms | json_query('resources[].status[]')|selectattr('phase','match','Running')|list|length and workload_args.pair|default('1')|int  == (client_vms | json_query('resources[].status.interfaces[0].ipAddress')|length)"
 
     when: resource_kind == "vm"
 
-  when: resource_state.resources[0].status.state == "Waiting for Clients"
+  when: benchmark_state.resources[0].status.state == "Waiting for Clients"
 
 - block:
 
   - name: Signal workload
     command: "redis-cli set start-{{ trunc_uuid }} true"
 
-  - name: Update resource state
-    operator_sdk.util.k8s_status:
-      api_version: ripsaw.cloudbulldozer.io/v1alpha1
-      kind: Benchmark
-      name: "{{ ansible_operator_meta.name }}"
-      namespace: "{{ operator_namespace }}"
-      status:
-        state: "Running"
+  - include_role:
+      name: benchmark_state
+      tasks_from: set_state
+    vars:
+      state: Running
 
-  when: resource_state.resources[0].status.state == "Clients Running"
+  when: benchmark_state.resources[0].status.state == "Clients Running"
 
 - block:
   - block:
@@ -326,14 +267,11 @@
         tasks_from: failure
       when: "(client_pods|json_query('resources[].status[]')|selectattr('phase','match','Failed')|list|length) > 0"
 
-    - operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ ansible_operator_meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Cleanup
-          complete: false
+    - include_role:
+        name: benchmark_state
+        tasks_from: set_state
+      vars:
+        state: Cleanup
       when: "workload_args.pair|default('1')|int == (client_pods|json_query('resources[].status[]')|selectattr('phase','match','Succeeded')|list|length)"
     when: resource_kind == "pod"
 
@@ -343,18 +281,15 @@
       command: "redis-cli get complete-{{ trunc_uuid }}"
       register: complete_status
 
-    - operator_sdk.util.k8s_status:
-        api_version: ripsaw.cloudbulldozer.io/v1alpha1
-        kind: Benchmark
-        name: "{{ ansible_operator_meta.name }}"
-        namespace: "{{ operator_namespace }}"
-        status:
-          state: Cleanup
-          complete: false
+    - include_role:
+        name: benchmark_state
+        tasks_from: set_state
+      vars:
+        state: Cleanup
       when: complete_status.stdout == "true"
     when: resource_kind == "vm"
 
-  when: resource_state.resources[0].status.state == "Running"
+  when: benchmark_state.resources[0].status.state == "Running"
 
 - block:
 
@@ -429,4 +364,8 @@
         state: Complete
         complete: true
 
+<<<<<<< HEAD
   when: resource_state.resources[0].status.state == "Cleanup"
+=======
+  when: benchmark_state.resources[0].status.state == "Cleanup"
+>>>>>>> 8dfe50a (Affinity rules)

--- a/roles/uperf/tasks/main.yml
+++ b/roles/uperf/tasks/main.yml
@@ -364,8 +364,4 @@
         state: Complete
         complete: true
 
-<<<<<<< HEAD
-  when: resource_state.resources[0].status.state == "Cleanup"
-=======
   when: benchmark_state.resources[0].status.state == "Cleanup"
->>>>>>> 8dfe50a (Affinity rules)

--- a/roles/uperf/templates/server.yml.j2
+++ b/roles/uperf/templates/server.yml.j2
@@ -37,6 +37,16 @@ spec:
 {% if workload_args.hostnetwork is sameas true %}
       hostNetwork: true
 {% endif %}
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: type
+                operator: In
+                values:
+                - {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
+            topologyKey: kubernetes.io/hostname
       containers:
       - name: benchmark
         image: {{ workload_args.image | default('quay.io/cloud-bulldozer/uperf:latest') }}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -47,6 +47,15 @@ spec:
       serviceAccountName: benchmark-operator
 {% endif %}
       affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: type
+                operator: In
+                values:
+                - {{ ansible_operator_meta.name }}-bench-client-{{ trunc_uuid }}
+            topologyKey: kubernetes.io/hostname
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100


### PR DESCRIPTION
Use podAntiaffinity rules to place uperf client pods in different worker
nodes where the servers are running on

Use podAffinity rules to place all client and server pods in the same node, useful when running more than one pair
All client pods will be scheduled in the same node and servers in another

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>