### PR TITLE
Fix mechanism to get current tag name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ ARCH ?= $(shell uname -m | sed 's/x86_64/amd64/')
 REGISTRY ?= quay.io
 ORG ?= cloud-bulldozer
 # Get the current branch name
-# In case this is the master branch, rename it to latest
-VERSION ?= $(shell git describe --tags 2>/dev/null || git rev-parse --abbrev-ref HEAD | sed 's/master/latest/g')
+# In case is the master branch, rename it to latest
+VERSION ?= $(shell hack/tag_name.sh)
 IMG ?= $(REGISTRY)/$(ORG)/benchmark-operator:$(VERSION)
 ifdef IMAGE_ARCH
 IMG := $(REGISTRY)/$(ORG)/benchmark-operator:$(VERSION)-$(IMAGE_ARCH)

--- a/hack/tag_name.sh
+++ b/hack/tag_name.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ -z $(git branch --show-current) ]]; then
+  git describe --tags --abbrev=0
+else
+  git branch --show-current | sed 's/master/latest/g'
+fi


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

The original implementation is problematic, i.e: https://github.com/cloud-bulldozer/benchmark-operator/issues/787
The current mechanism to get the tag name doesn't work well. When a new commit lands to the master branch, the master branch is not named correctly
    
 i.e:
```
rsevilla@wonderland /tmp/foo (master) $ git describe --tags 2>/dev/null || git rev-parse --abbrev-ref HEAD | sed 's/master/latest/g'
v1.0.0-1-g487fada
rsevilla@wonderland /tmp/foo (master) $ git log --oneline | head
487fada Foo
12701a6 Added exit status for uperf failures (#782)
94005cd missing env var num_pairs (#784)
```


Some tests I've done:

```shell
rsevilla@wonderland /tmp/foo (master) $ hack/tag_name.sh
latest
rsevilla@wonderland /tmp/foo (master) $ git checkout v1.0.0 
Note: switching to 'v1.0.0'.
HEAD is now at 12701a6 Added exit status for uperf failures (#782)    <- This tag is behind the current master branch
rsevilla@wonderland /tmp/foo ((v1.0.0)) $ hack/tag_name.sh
v1.0.0
rsevilla@wonderland /tmp/foo ((v1.0.0)) $ git checkout foo 
Previous HEAD position was 12701a6 Added exit status for uperf failures (#782)
Switched to branch 'foo'
rsevilla@wonderland /tmp/foo (foo) $ hack/tag_name.sh
foo
rsevilla@wonderland /tmp/foo ((v1.0.0)) $ git checkout -b kaka  <- Create a new branch from the v1.0.0 tag
Switched to a new branch 'kaka'
rsevilla@wonderland /tmp/foo (kaka) $ hack/tag_name.sh
kaka


