### PR TITLE
fixing port conflict for uperf bidrec test

### DIFF
--- a/roles/uperf-scale/templates/configmap.yml.j2
+++ b/roles/uperf-scale/templates/configmap.yml.j2
@@ -49,7 +49,7 @@ data:
     {% if ( 'maerts' == test or 'bidirec' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + (0 if (workload_args.serviceip is defined and workload_args.serviceip and ( workload_args.servicetype | default("clusterip") == "clusterip" )) else (item|int * 100)) + 1 }}"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + (0 if (workload_args.serviceip is defined and workload_args.serviceip and ( workload_args.servicetype | default("clusterip") == "clusterip" )) else (item|int * 100)) + 2 }}"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=read options="count=16 size={{rsize}}"/>

--- a/roles/uperf/templates/configmap.yml.j2
+++ b/roles/uperf/templates/configmap.yml.j2
@@ -49,7 +49,7 @@ data:
     {% if ( 'maerts' == test or 'bidirec' == test ) %}
       <group nthreads="{{nthr}}">
           <transaction iterations="1">
-            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + (0 if (workload_args.serviceip is defined and workload_args.serviceip and ( workload_args.servicetype | default("clusterip") == "clusterip" )) else (item|int * 100)) + 1 }}"/>
+            <flowop type="connect" options="remotehost=$h protocol={{proto}} port={{ control_port|int + (0 if (workload_args.serviceip is defined and workload_args.serviceip and ( workload_args.servicetype | default("clusterip") == "clusterip" )) else (item|int * 100)) + 2 }}"/>
           </transaction>
           <transaction duration="{{workload_args.runtime}}">
             <flowop type=read options="count=16 size={{rsize}}"/>


### PR DESCRIPTION
### Description
Context: https://github.com/cloud-bulldozer/benchmark-operator/issues/780
### Fixes
Assigning a different port for the reverse test so that it doesn't conflict with the forward test port.
#### Testing screenshot
![Screenshot from 2022-07-11 21-42-15](https://user-images.githubusercontent.com/28471457/178391173-19c9e53b-83a3-462d-83c0-45890e97a209.png)
