### PR TITLE
Benchmark-operator's affinity preference to workload node

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,14 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                - key: node-role.kubernetes.io/workload
+                  operator: Exists
       containers:
       - name: manager
         args:


### PR DESCRIPTION
### Description

Let's try to take more advantage of the workload node by setting benchmark-operator's affinity to preferably be scheduled on workload nodes.

I think we should hardcore it, as it doesn't affect the default behavior

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>


