### PR TITLE
Added StorageClass support to Sysbench

### DIFF
--- a/config/samples/sysbench/cr.yaml
+++ b/config/samples/sysbench/cr.yaml
@@ -11,6 +11,8 @@ spec:
       #kind: vm
       # If you want to run this as a VM uncomment the above
       #pin_node: "worker-0.mylab.example.com"
+      #storageclass: ocs-storagecluster-ceph-rbd
+      #storagesize: 200Gi
       tests:
       - name: cpu
         parameters:

--- a/docs/sysbench.md
+++ b/docs/sysbench.md
@@ -17,6 +17,15 @@ annotations to the pod metadata.
 The `pin_node` parameter allows to place the sysbench pod 
 on a specific node, using the `hostname` label.
 
+The `storageclass` and `storagesize` options can be set to have sysbench run on a particular StorageClass volume.
+If `storageclass` is not provided, sysbench runs on an `emptyDir` volume by default.
+
+With the `fileio` test, you can define parameters for the `prepare`, `run` and `cleanup` steps
+independently, using `prepare_parameters`, `run_parameters`, and `cleanup_parameters` respectively.
+The `parameters` option is a global set of parameters each step inherits, but can be overriden.  To
+disable a value from `parameters` within `<prepare/run/cleanup>_parameters`, simply set the value to
+`null`.
+
 Note: please ensure you set 0 for other workloads if editing the
 [cr.yaml](../config/samples/sysbench/cr.yaml) file otherwise
 
@@ -36,6 +45,8 @@ spec:
       #kind: vm
       # If you want to run this as a VM uncomment the above
       #pin_node: "worker-0.mylab.example.com"
+      #storageclass: ocs-storagecluster-ceph-rbd
+      #storagesize: 200Gi
       tests:
       - name: cpu
         parameters:
@@ -43,6 +54,10 @@ spec:
       - name: fileio
         parameters:
           file-test-mode: rndrw
+        # This removes the file-test-mode parameter during the cleanup step
+        # Since run_parameters and prepare_parameters are not defined, they use file-test-mode: rndrw
+        #cleanup_parameters:
+          #file-test-mode: null
 ```
 
 Name here refers to testname and can be cpu or fileio or memory etc and the parameters are the parametes for the particular test.

--- a/roles/sysbench/tasks/main.yml
+++ b/roles/sysbench/tasks/main.yml
@@ -10,6 +10,24 @@
           namespace: '{{ operator_namespace }}'
         data:
           sysbenchScript: "{{ lookup('template', 'sysbench.sh.j2') }}"
+  - name: Create PVC
+    k8s:
+      definition:
+        kind: PersistentVolumeClaim
+        apiVersion: v1
+        metadata:
+          name: "claim-sysbench-{{ trunc_uuid }}"
+          namespace: '{{ operator_namespace }}'
+          annotations:
+             volume.beta.kubernetes.io/storage-class: "{{ workload_args.storageclass }}"
+        spec:
+          accessModes:
+            - "{{ workload_args.pvcaccessmode | default('ReadWriteOnce') }}"
+          volumeMode: "{{ workload_args.pvcvolumemode | default('Filesystem') }}"
+          resources:
+            requests:
+              storage: "{{ workload_args.storagesize }}"
+    when: workload_args.storageclass is defined
 
   - name: Start sysbench job
     k8s:

--- a/roles/sysbench/templates/sysbench.sh.j2
+++ b/roles/sysbench/templates/sysbench.sh.j2
@@ -1,4 +1,12 @@
 #!/bin/bash
+{% macro merge_params(global, local) -%}
+{% for key, val in global.items() %}
+    {% if key not in local %}
+        {% set dummy = local.__setitem__(key, val) %}
+    {% endif %}
+{% endfor %}
+{%- endmacro -%}
+
 {% for test in workload_args.tests %}
 {% if test.name == "cpu" or test.name == "memory" %}
 sysbench --test={{test.name}} {% for opt,value in test.parameters.items() %} --{{opt}}={{value}} {% endfor %} run
@@ -6,11 +14,34 @@ sysbench --test={{test.name}} {% for opt,value in test.parameters.items() %} --{
 {% if 'file-total-size' not in test.parameters %}
 {% set dummy = test['parameters'].__setitem__("file-total-size", "1G") %}
 {% endif %}
-sysbench --test=fileio {% for opt,value in test.parameters.items() %} --{{opt}}={{value}} {% endfor %} prepare
+
+{% if 'prepare_parameters' in test %}
+{% set dummy = merge_params(test.parameters, test.prepare_parameters) %}
+{% set prep_params = test.prepare_parameters %}
+{% else %}
+{% set prep_params = test.parameters %}
+{% endif %}
+sysbench --test=fileio {% for opt,value in prep_params.items() %} {% if value is not none %} --{{opt}}={{value}} {% endif %} {% endfor %} prepare
+
 {% if 'file-test-mode' not in test.parameters %}
 {% set dummy = test['parameters'].__setitem__("file-test-mode", "rndrw") %}
 {% endif %}
-sysbench --test=fileio {% for opt,value in test.parameters.items() %} --{{opt}}={{value}} {% endfor %} run
-sysbench --test=fileio --file-total-size={{test['parameters']['file-total-size']}} cleanup
+
+{% if 'run_parameters' in test %}
+{% set dummy = merge_params(test.parameters, test.run_parameters) %}
+{% set run_params = test.run_parameters %}
+{% else %}
+{% set run_params = test.parameters %}
+{% endif %}
+sysbench --test=fileio {% for opt,value in run_params.items() %} {% if value is not none %} --{{opt}}={{value}} {% endif %}{% endfor %} run
+
+{% if 'cleanup_parameters' in test %}
+{% set dummy = merge_params(test.parameters, test.cleanup_parameters) %}
+{% set clean_params = test.cleanup_parameters %}
+{% else %}
+{% set clean_params = test.parameters %}
+{% endif %}
+sysbench --test=fileio {% for opt, value in clean_params.items() %} {% if value is not none %} --{{opt}}={{value}} {% endif %}{% endfor %} cleanup
+
 {% endif %}
 {% endfor %}

--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -40,7 +40,12 @@ spec:
           mountPath: "/opt/sysbench"
       volumes:
       - name: sysbench-runtime
+{% if workload_args.storageclass is defined %}
+        persistentVolumeClaim:
+          claimName: claim-sysbench-{{ trunc_uuid }}
+{% else %}
         emptyDir: {}
+{% endif %}
       - name: sysbench-volume
         configMap:
           name: "sysbench-config-{{ trunc_uuid }}"


### PR DESCRIPTION
### Description
This PR adds the ability to run sysbench in a CR defined SC.  If a SC is not provided, the volume defaults to `emptyDir` type, as it was doing previously.

It also adds the ability to define options for each phase of `fileio` test.  The current `parameters` act as global parameters, and then it breaks out into `<prepare/run/cleanup>_parameters` that override the global parameters, if you want to remove a global parameter from a phase of the test, providing `null` for the option in the YAML file achieves this.

### Fixes
Adds CR defend SC selection for sysbench.
Creates PVC for the selected SC with CR defined size for sysbench.