### PR TITLE
disable hammerdb postgreSQL autovacuum

### DIFF
--- a/roles/hammerdb/templates/db_postgres_workload_vm.sh.j2
+++ b/roles/hammerdb/templates/db_postgres_workload_vm.sh.j2
@@ -58,7 +58,7 @@ echo host    all             all             all            trust >> /var/lib/pg
 echo max_connections = 100 > /var/lib/pgsql/data/postgresql.conf
 echo max_prepared_transactions = 0 >> /var/lib/pgsql/data/postgresql.conf
 echo shared_buffers = 4096MB >> /var/lib/pgsql/data/postgresql.conf
-echo effective_cache_size = 8192MB >> /var/lib/pgsql/data/postgresql.conf
+echo autovacuum = off >> /var/lib/pgsql/data/postgresql.conf
 sudo systemctl start postgresql;
 echo "alter role postgres password 'postgres'" > input
 psql -U postgres -d postgres < input


### PR DESCRIPTION
### Description
Disable autovacuum for improving PostgreSQL performance

## Fixes
1. Adding autovacuum = off:
The hammerdb framework has a setting for PostgreSQL where we can specify that manual vacuuming should be done after every sample … we currently have it disabled, I’m seeing if enabling it (and disabling auto vacuuming which can kick in at random times) will give us consistent performance while also keeping dead tuples under control (too many dead tuples slow down query performance)

** Already tested and Fixed in benchmark-runner [Pod](https://github.com/redhat-performance/benchmark-runner/blob/bc1b7fffb0f8e4d5c19c7d981c9d958538cc2527/benchmark_runner/common/template_operations/templates/hammerdb/internal_data/postgres_template.yaml#L77), case to huge improvement, need to fix it also in VM

2. Removing effective_cache_size = 8192MB
The default parameter is effective_cache_size = 4096MB, configure as Pod.
