### PR TITLE
FIO Prefill State

### DIFF
--- a/roles/fio_distributed/tasks/main.yml
+++ b/roles/fio_distributed/tasks/main.yml
@@ -13,6 +13,10 @@
   - name: Generate fio test
     k8s:
       definition: "{{ lookup('template', 'configmap.yml.j2') | from_yaml }}"
+  
+  - name: Generate fio prefill job
+    k8s:
+      definition: "{{ lookup('template', 'prefill-configmap.yml.j2') | from_yaml }}"
 
   - name: Create PVC(s)
     k8s:
@@ -132,7 +136,39 @@
       port: 8765
     when: (workload.args.kind | default('pod')) == "vm"
     with_items: "[{% for ip in pod_details.keys() %}'{{ ip }}', {% endfor %}]"
+  when: benchmark_state.resources[0].status.state == "StartingClient"
+  
+- block:
+  - name: Run Prefill Job
+    k8s:
+      definition: "{{ lookup('template', 'prefill-client.yaml.j2') | from_yaml }}"
+    register: fio_prefill_pod
+  
+  - include_role:
+      name: benchmark_state
+      tasks_from: set_state
+    vars:
+      state: Prefilling
+  when: workload.args.prefill and benchmark_state.resources[0].status.state == "StartingClient"
 
+- block:
+  - name: wait for db creation job to finish
+    k8s_facts:
+      kind: Job
+      api_version: batch/v1
+      name: 'fio-prefill-{{ trunc_uuid }}'
+      namespace: "{{ operator_namespace }}"
+    register: fio_prefill_pod
+
+  - include_role:
+      name: benchmark_state
+      tasks_from: set_state
+    vars:
+      state: StartBenchmark
+    when: fio_prefill_pod | json_query('resources[].status.succeeded')
+  when: workload.args.prefill and benchmark_state.resources[0].status.state == "Prefilling"
+
+- block:
   - name: Start FIO Client
     k8s:
       definition: "{{ lookup('template', 'client.yaml') | from_yaml }}"
@@ -142,8 +178,7 @@
       tasks_from: set_state
     vars:
       state: Running
-
-  when: benchmark_state.resources[0].status.state == "StartingClient"
+  when: (benchmark_state.resources[0].status.state == "StartBenchmark" and workload.args.prefill) or (benchmark_state.resources[0].status.state == "StartingClient" and not workload.args.prefill)
 
 - include_role:
     name: benchmark_state

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -71,16 +71,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - "cat /tmp/host/hosts;
-{% if workload_args.prefill is defined and workload_args.prefill is sameas true %}
-             echo ***************Prefill*****************;
-             cat /tmp/fio/fiojob-prefill;
-             mkdir -p /tmp/fiod-{{ uuid }}/fiojob-prefill;
-             fio --client=/tmp/host/hosts /tmp/fio/fiojob-prefill --output-format=json;
-{% if workload_args.post_prefill_sleep is defined %}
-             sleep {{ workload_args.post_prefill_sleep }};
-{% endif %}
-             echo ***********End of Prefill*************;
-{% endif %}
 {% if workload_args.bsrange is defined %}
 {% set loopvar = workload_args.bsrange %}
 {% elif workload_args.bs is defined %}

--- a/roles/fio_distributed/templates/prefill-client.yaml.j2
+++ b/roles/fio_distributed/templates/prefill-client.yaml.j2
@@ -1,0 +1,58 @@
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: 'fio-prefill-{{ trunc_uuid }}'
+  namespace: '{{ operator_namespace }}'
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ workload_args.job_timeout|default(3600) }}
+  template:
+    metadata:
+      labels:
+        benchmark-uuid: prefill-{{ uuid }}
+        app: fiod-prefill-{{ trunc_uuid }}
+{% if workload_args.annotations is defined or workload_args.client_annotations is defined %}
+      annotations:
+{% for annotation, value in workload_args.annotations.items() %}
+        "{{annotation}}": "{{value}}"
+{% endfor %}
+{% for annotation, value in workload_args.client_annotations.items() %}
+        "{{annotation}}": "{{value}}"
+{% endfor %}
+{% endif %}
+    spec:
+{% if workload_args.runtime_class is defined %}
+      runtimeClassName: "{{ workload_args.runtime_class }}"
+{% endif %}
+      containers:
+      - name: fio-client
+        image: {{ workload_args.image | default('quay.io/cloud-bulldozer/fio:latest') }}
+        imagePullPolicy: Always
+        command: ["/bin/sh", "-c"]
+        args:
+          - "cat /tmp/host/hosts;
+             echo ***************Prefill*****************;
+             cat /tmp/fio/fiojob-prefill;
+             mkdir -p /tmp/fiod-{{ uuid }}/fiojob-prefill;
+             fio --client=/tmp/host/hosts /tmp/fio/fiojob-prefill --output-format=json;
+{% if workload_args.post_prefill_sleep is defined %}
+             sleep {{ workload_args.post_prefill_sleep }};
+{% endif %}
+             echo ***********End of Prefill*************"
+        volumeMounts:
+        - name: fio-volume
+          mountPath: "/tmp/fio"
+        - name: host-volume
+          mountPath: "/tmp/host"
+      volumes:
+      - name: fio-volume
+        configMap:
+          name: "fio-prefill-{{ trunc_uuid }}"
+          defaultMode: 0777
+      - name: host-volume
+        configMap:
+          name: "fio-hosts-{{ trunc_uuid }}"
+          defaultMode: 0777
+      restartPolicy: Never
+{% include "metadata.yml.j2" %}

--- a/roles/fio_distributed/templates/prefill-configmap.yml.j2
+++ b/roles/fio_distributed/templates/prefill-configmap.yml.j2
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fio-prefill-{{ trunc_uuid }}
+  namespace: '{{ operator_namespace }}'
+data:
+# FIXME: I don't think prefill works correctly for a list of numjobs values, only for 1 of them
+{% for numjobs in workload_args.numjobs %}
+{% if workload_args.prefill is defined and workload_args.prefill is sameas true %}
+  fiojob-prefill: |
+    [global]
+{% if workload_args.pvcvolumemode is defined and workload_args.pvcvolumemode == "Block" %}
+    filename={{fio_path}}
+{% else %}
+    directory={{fio_path}}
+{% endif %}
+    filename_format=f.\$jobnum.\$filenum
+    clocksource=clock_gettime
+    kb_base=1000
+    unit_base=8
+    ioengine=libaio
+    size={{workload_args.filesize}}
+{% if workload_args.prefill_bs is defined %}
+    bs={{workload_args.prefill_bs}}
+{% else %}
+    bs=4096KiB
+{% endif %}
+    iodepth=1
+    direct=1
+    numjobs={{numjobs}}
+    
+    [write]
+    rw=write
+    create_on_open=1
+    fsync_on_close=1
+{% if workload_args.cmp_ratio is defined %}
+    buffer_compress_percentage={{ workload_args.cmp_ratio }}
+    buffer_pattern=0xdeadface
+{% endif %}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
### Description

This PR adds a `Prefilling` state to the FIO benchmark.  Previously prefilling and running the actual benchmark were both under the state of `Running`, with this PR the actual benchmark is running during the `Running` state, and prefilling during the `Prefilling` state.

This update has not been tested using `kind: vm`.

### Fixes
