### PR TITLE
stress-ng: expose cpu method in cr

### DIFF
--- a/config/samples/stressng/cr.yaml
+++ b/config/samples/stressng/cr.yaml
@@ -25,6 +25,7 @@ spec:
       # cpu stressor options
       cpu_stressors: "1"
       cpu_percentage: "100"
+      cpu_method: "all"
       # vm stressor option
       vm_stressors: "1"
       vm_bytes: "128M"

--- a/roles/stressng/templates/jobfile.j2
+++ b/roles/stressng/templates/jobfile.j2
@@ -7,6 +7,7 @@ timeout {{ workload_args.timeout}}			# stop each stressor after 60 seconds
 {% if workload_args.cpu_stressors is defined %}
 cpu {{ workload_args.cpu_stressors }} 			# cpu stressor
 cpu-load {{ workload_args.cpu_percentage }}		# percentage to which the cpu gets loaded
+cpu-method {{ workload_args.cpu_method }}               # cpu test method
 {% endif %}
 
 # vm stressor


### PR DESCRIPTION
stress-ng has many [cpu methods](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/8/html/optimizing_rhel_8_for_real_time_for_low_latency_operation/assembly_stress-testing-real-time-systems-with-stress-ng_optimizing-rhel8-for-real-time-for-low-latency-operation) for testing. To expose this spec, this PR add cpu method in the CR and jobfile.