### PR TITLE
Add es_index parameter to log-generator workload template as it can be set on e2e-benchmarking as ES_BACKEND_INDEX

### DIFF
--- a/roles/log_generator/templates/log_generator.yml
+++ b/roles/log_generator/templates/log_generator.yml
@@ -109,6 +109,9 @@ spec:
 {% if workload_args.es_url is defined %}
             --es-url "{{ workload_args.es_url }}"
 {% endif %}
+{% if workload_args.es_index is defined %}
+            --es-index "{{ workload_args.es_index }}"
+{% endif %}
 {% if workload_args.es_token is defined %}
             --es-token "{{ workload_args.es_token }}"
 {% endif %}


### PR DESCRIPTION
e2e-benchmarking allow to select the index_name to use as ES_BACKEND_INDEX.

But this parameter is not managed on the template so it is never used.

Adding it to the template
