### PR TITLE
zone affinity for uperf clients

### DIFF
--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -56,6 +56,13 @@ spec:
                 values:
                 - {{ ansible_operator_meta.name }}-bench-client-{{ trunc_uuid }}
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: type
+                operator: In
+                values:
+                - {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
+            topologyKey: topology.kubernetes.io/zone            
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -56,6 +56,7 @@ spec:
                 values:
                 - {{ ansible_operator_meta.name }}-bench-client-{{ trunc_uuid }}
             topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
               - key: type
@@ -109,7 +110,7 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
           - name: server_node
-            value: "{{ workload_args.pin_server|default("unknown") }}"
+            value: "{{ item.spec.nodeName | default("unknown") }}"
 {% if workload_args.client_resources is defined %}
         resources: {{ workload_args.client_resources | to_json }}
 {% endif %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -57,13 +57,15 @@ spec:
                 - {{ ansible_operator_meta.name }}-bench-client-{{ trunc_uuid }}
             topologyKey: kubernetes.io/hostname
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: type
-                operator: In
-                values:
-                - {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
-            topologyKey: topology.kubernetes.io/zone            
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: type
+                  operator: In
+                  values:
+                  - {{ ansible_operator_meta.name }}-bench-server-{{ trunc_uuid }}
+              topologyKey: topology.kubernetes.io/zone       
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100


### PR DESCRIPTION
### Description
Pod affinity to keep server and client within same zone to avoid external variability.

### Fixes
