### PR TITLE
iPerf: resolve ipv6 client pod deployment issue with a name format

### DIFF
--- a/roles/iperf3/templates/client.yml.j2
+++ b/roles/iperf3/templates/client.yml.j2
@@ -2,7 +2,7 @@
 kind: Job
 apiVersion: batch/v1
 metadata:
-  name: 'iperf3-client-{{ item.status.podIP }}-{{ trunc_uuid }}'
+  name: 'iperf3-client-{{ trunc_uuid }}'
   namespace: '{{ operator_namespace }}'
 spec:
   backoffLimit: 0


### PR DESCRIPTION
### Description
When the ipv6 address is used for traffic generation, and this is the only ip version defined for the server:
 item.status.podIP getting ipv6 ip format value, "podIP": "fd01:0:0:6::bd" as an example
As a result, the client pod failed to start because of the name format failure; only '.' and '_' are acceptable in a name string (not ':').

### Fixes
remove item.status.podIP variable from the name definition
