### PR TITLE
iPerf: work-around for ipv6 traffic type on dual-stack cluster

### DIFF
--- a/roles/iperf3/templates/client.yml.j2
+++ b/roles/iperf3/templates/client.yml.j2
@@ -46,7 +46,9 @@ spec:
         imagePullPolicy: Always
         command: ["/bin/sh", "-c"]
         args:
-          - "iperf3 -c {{ item.status.podIP }}
+          - "iperf3 -c
+            {% if workload_args.extra_options_client is defined and '-6' in workload_args.extra_options_client %} {{ item.status.podIPs[-1].ip }}
+            {% else %} {{ item.status.podIP }} {% endif %}
             {% if workload_args.port is defined %} -p {{ workload_args.port }} {% endif %}
             {% if workload_args.transmit_type is defined and workload_args.transmit_value is defined %} --{{ workload_args.transmit_type }} {{ workload_args.transmit_value }} {% endif %}
             {% if workload_args.length_buffer is defined %} -l {{ workload_args.length_buffer }} {% endif %}


### PR DESCRIPTION
### Description
In the case of a dual-stack cluster, when ipv6 traffic is required, and even the '-6' option is provided, the 'iperf3 -c ' command will always use an ipv4 address.
The openshift preference in the case of dual-stack is always ipv4. And this is a reason the server pod will always have ipv4 as a main pod address (podIP value).

As a result, when '-6' option is used in this case and 'iperf3 -c ' will run to the ipv4 address, the pod execution fails.

### Fixes
switch to the item.status.podIPs list handling instead of item.status.podIP when ipv6 is required
