### PR TITLE
add storageClassName in "spec" section for PVC

### DIFF
--- a/roles/fio_distributed/tasks/main.yml
+++ b/roles/fio_distributed/tasks/main.yml
@@ -26,12 +26,11 @@
         metadata:
           name: "claim-{{ item }}-{{ trunc_uuid }}"
           namespace: '{{ operator_namespace }}'
-          annotations:
-             volume.beta.kubernetes.io/storage-class: "{{ workload_args.storageclass }}"
         spec:
           accessModes:
             - "{{ workload_args.pvcaccessmode | default('ReadWriteOnce') }}"
           volumeMode: "{{ workload_args.pvcvolumemode | default('Filesystem') }}"
+          storageClassName: "{{ workload_args.storageclass }}"
           resources:
             requests:
               storage: "{{ workload_args.storagesize }}"


### PR DESCRIPTION
1. add storageClassName in "spec" section for PVC
2. remove volume.beta.kubernetes.io/storage-class from annotations section

## Type of change

- [ ] Refactor
- [ ] New feature
- [x ] Bug fix
- [x ] Optimization
- [ ] Documentation Update

## Description

PVC created via benchmark-operator miss `storageClassName` in `spec` section what causes issues for some of tests which expect `storageClassName` to be present there. 

