### PR TITLE
Option to specify resources for sysbench workload

### DIFF
--- a/roles/sysbench/templates/workload.yml
+++ b/roles/sysbench/templates/workload.yml
@@ -38,6 +38,9 @@ spec:
           mountPath: "/tmp/"
         - name: sysbench-runtime
           mountPath: "/opt/sysbench"
+{% if workload_args.resources is defined %}
+        resources: {{ workload_args.resources|tojson }}
+{% endif %}
       volumes:
       - name: sysbench-runtime
 {% if workload_args.storageclass is defined %}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes # 817

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
The resources can be specified for the sysbench workload benchmark
```
spec:
  workload:
    name: sysbench
    args:
      resources:
        limits:
          memory: "10Gi"
          cpu: "10"
        requests:
          memory: "10Gi"
          cpu: "10"
```

