### PR TITLE
Add a feature to enable workload loops with varying iodepth values

### DIFF
--- a/config/samples/fio/cr.yaml
+++ b/config/samples/fio/cr.yaml
@@ -38,7 +38,8 @@ spec:
       numjobs:
         - 1
       # with libaio ioengine, number of in-flight requests per process
-      iodepth: 4
+      iodepth:
+        - 4
       # how long to run read tests, this is TOO SHORT DURATION
       read_runtime: 15
       # how long to run write tests, this is TOO SHORT DURATION

--- a/config/samples/fio/vm-cr.yaml
+++ b/config/samples/fio/vm-cr.yaml
@@ -51,7 +51,8 @@ spec:
       numjobs:
         - 1
       # with libaio ioengine, number of in-flight requests per process
-      iodepth: 4
+      iodepth:
+        - 4
       # how long to run write tests, this is TOO SHORT DURATION
       read_runtime: 15
       # how long to run read tests, this is TOO SHORT DURATION

--- a/docs/fio_distributed.md
+++ b/docs/fio_distributed.md
@@ -48,19 +48,22 @@ or even days to complete, and the jobs will continue through the nested loops un
 The workload loops are nested as such from the CR options:
 
 ```
-+-------->numjobs---------+
-|                         |
-| +------>bs|bsrange----+ |
-| |                     | |
-| | +---->job---------+ | |
-| | |                 | | |
-| | | +-->samples---+ | | |
-| | | |             | | | |
-| | | |             | | | |
-| | | +-------------+ | | |
-| | +-----------------+ | |
-| +---------------------+ |
-+-------------------------+
++---------->iodepth-----------+
+|                             |
+| +-------->numjobs---------+ |
+| |                         | |
+| | +------>bs|bsrange----+ | |
+| | |                     | | |
+| | | +---->job---------+ | | |
+| | | |                 | | | |
+| | | | +-->samples---+ | | | |
+| | | | |             | | | | |
+| | | | |             | | | | |
+| | | | +-------------+ | | | |
+| | | +-----------------+ | | |
+| | +---------------------+ | |
++---------------------------+ |
++-----------------------------+
 ```
 
 ### Understanding the CR options
@@ -131,7 +134,7 @@ The workload loops are nested as such from the CR options:
     - 256KiB-4096KiB
   ```
 - **numjobs**: (list) Number of clones of the job to run on each server -- Total jobs will be `numjobs * servers`
-- **iodepth**: Number of I/O units to keep in flight against a file; see `fio(1)`
+- **iodepth**: (list) Number of I/O units to keep in flight against a file; see `fio(1)`
 - **read_runtime**: Amount of time in seconds to run `read` workloads (including `readwrite` workloads)
 - **read_ramp_time**: Amount of time in seconds to ramp up `read` workloads (i.e., executing the workload without recording the data)
   > Note: We intentionally run `write` workloads to completion of the file size specified in order to ensure

--- a/roles/fio_distributed/templates/client.yaml
+++ b/roles/fio_distributed/templates/client.yaml
@@ -79,8 +79,9 @@ spec:
 {% for numjobs in workload_args.numjobs %}
 {% for i in loopvar %}
 {% for job in workload_args.jobs %}
-             cat /tmp/fio/fiojob-{{job}}-{{i}}-{{numjobs}}; mkdir -p /tmp/fiod-{{uuid}}/fiojob-{{job}}-{{i}}-{{numjobs}};
-             run_snafu -t fio -H /tmp/host/hosts -j /tmp/fio/fiojob-{{job}}-{{i}}-{{numjobs}} -s {{workload_args.samples}} -d /tmp/fiod-{{ uuid }}/fiojob-{{job}}-{{i}}-{{numjobs}} \
+{% for iodepth in workload_args.iodepth %}
+             cat /tmp/fio/fiojob-{{job}}-{{i}}-{{numjobs}}-{{iodepth}}; mkdir -p /tmp/fiod-{{uuid}}/fiojob-{{job}}-{{i}}-{{numjobs}}-{{iodepth}};
+             run_snafu -t fio -H /tmp/host/hosts -j /tmp/fio/fiojob-{{job}}-{{i}}-{{numjobs}}-{{iodepth}} -s {{workload_args.samples}} -d /tmp/fiod-{{ uuid }}/fiojob-{{job}}-{{i}}-{{numjobs}}-{{iodepth}} \
 {% if workload_args.debug is defined and workload_args.debug %}
              -v \
 {% endif %}
@@ -91,6 +92,7 @@ spec:
              test -f /tmp/fiod-{{uuid}}/fiojob-{{job}}-{{i}}-{{numjobs}}/$fio_sample/{{job}}/fio-result.json && cat /tmp/fiod-{{uuid}}/fiojob-{{job}}-{{i}}-{{numjobs}}/$fio_sample/{{job}}/fio-result.json || echo ERROR_FIO_JSON_FILE_NOT_AVAILABLE;
              echo END_FIO_JSON_OUTPUT_fiod-{{uuid}}_fiojob-{{job}}-{{i}}-{{numjobs}}_SAMPLE_$fio_sample;done;
 {% endif %}
+{% endfor %}
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/roles/fio_distributed/templates/configmap.yml.j2
+++ b/roles/fio_distributed/templates/configmap.yml.j2
@@ -48,7 +48,8 @@ data:
 {% endif %}
 {% for i in loopvar %}
 {% for job in workload_args.jobs %}
-  fiojob-{{job}}-{{i}}-{{numjobs}}: |
+{% for iodepth in workload_args.iodepth %}
+  fiojob-{{job}}-{{i}}-{{numjobs}}-{{iodepth}}: |
     [global]
 {% if workload_args.pvcvolumemode is defined and workload_args.pvcvolumemode == "Block" %}
     filename={{fio_path}}
@@ -72,7 +73,7 @@ data:
     ioengine=libaio
     size={{workload_args.filesize}}
     {{loopvar_str}}={{i}}
-    iodepth={{workload_args.iodepth}}
+    iodepth={{iodepth}}
     direct=1
     numjobs={{numjobs}}
 
@@ -92,6 +93,7 @@ data:
 {% endif %}
 {% endfor %}
 {% endif %}
+{% endfor %}
 {% endfor %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

**Add support for workload loops with varying iodepth values**

This commit introduces a feature that allows running workload loops using a list of `iodepth` values. By enabling this functionality, users can configure and execute multiple iterations of a workload, each with a different `iodepth`, providing greater flexibility and detailed insights into performance behavior under varying queue depths.

**Key Changes:**

- Modified the workload configuration to accept a list of `iodepth` values.
- Updated logic to iterate through each `iodepth` value and execute workloads accordingly.
- Ensured compatibility with existing configurations to avoid breaking changes.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
