### PR TITLE
Include anti-affinity rules when executing fio-distributed with VM wo…

### DIFF
--- a/roles/fio_distributed/templates/server_vm.yml.j2
+++ b/roles/fio_distributed/templates/server_vm.yml.j2
@@ -43,6 +43,18 @@ spec:
     resources:
       requests:
         memory: {{ workload_args.vm_memory | default('5G') }}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - fio-benchmark-{{ trunc_uuid }}
+          topologyKey: "kubernetes.io/hostname"
   volumes:
     - name: registrydisk
       containerDisk:


### PR DESCRIPTION
…rkloads

## Type of change

- [ ] Refactor
- [ ] New feature
- [ X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently, anti-affinity rules are applied only to pods when executing performance tests with fio-distributed. With this update, anti-affinity rules are now also applied when running performance tests with VM workloads.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
