### PR TITLE
Fix issues when running uperf and uperf-scale modules with multus networks

### DIFF
--- a/roles/uperf-scale/templates/workload.yml.j2
+++ b/roles/uperf-scale/templates/workload.yml.j2
@@ -16,6 +16,8 @@ items:
 {% else %}
       name: 'uperf-scale-client-{{item.spec.clusterIP}}-{{ trunc_uuid }}'
 {% endif %}
+{% elif workload_args.multus.enabled is sameas true %}
+      name: 'uperf-client-{{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/network-status'] | from_json)[1]['ips'][0] }}-{{ trunc_uuid }}'
 {% else %}
       name: 'uperf-scale-client-{{item.status.podIP}}-{{ trunc_uuid }}'
 {% endif %}
@@ -120,7 +122,7 @@ items:
 {% else %}
 {% if workload_args.multus.client is defined %}
               - "export multus_client={{workload_args.multus.client}};
-                 export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
+                 export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/network-status'] | from_json)[1]['ips'][0] }};
 {% else %}
               - "export h={{item.status.podIP}};
 {% endif %}

--- a/roles/uperf/templates/workload.yml.j2
+++ b/roles/uperf/templates/workload.yml.j2
@@ -11,6 +11,8 @@ metadata:
 {% else %}
   name: 'uperf-client-{{item.spec.clusterIP}}-{{ trunc_uuid }}'
 {% endif %}
+{% elif workload_args.multus.enabled is sameas true %}
+  name: 'uperf-client-{{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/network-status'] | from_json)[1]['ips'][0] }}-{{ trunc_uuid }}'
 {% else %}
   name: 'uperf-client-{{item.status.podIP}}-{{ trunc_uuid }}'
 {% endif %}
@@ -134,7 +136,7 @@ spec:
 {% else %}
 {% if workload_args.multus.client is defined %}
           - "export multus_client={{workload_args.multus.client}};
-             export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/networks-status'] | from_json)[1]['ips'][0] }};
+             export h={{ (item['metadata']['annotations']['k8s.v1.cni.cncf.io/network-status'] | from_json)[1]['ips'][0] }};
 {% else %}
           - "export h={{item.status.podIP}};
 {% endif %}


### PR DESCRIPTION
…works

## Type of change

- [ ] Refactor
- [ ] New feature
- [ X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There is a typo in the code when selecting the IP address of the pods while working with Multus networks. The filter used is `k8s.v1.cni.cncf.io/networks-status`, which is invalid. The correct filter should be `k8s.v1.cni.cncf.io/network-status`.

Additionally, the correct naming for the uperf clients has been implemented, ensuring the IP address of the uperf server in the Multus network is properly selected.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
