### PR TITLE
Add proxy support for FIO in VMs

### DIFF
--- a/config/samples/fio/vm-cr.yaml
+++ b/config/samples/fio/vm-cr.yaml
@@ -28,6 +28,9 @@ spec:
       # This is helpful in disconnected environments and we assume
       # this VM image has all requirements already present
       vm_image: quay.io/mulbc/fed-fio
+      # Specify proxy for the VM to be able to connect to the Internet.
+      # This is helpful for proxy environments
+      vm_proxy: http://my.proxy.server:8080
       # CPU cores that will be available inside the VM
       # Default: 1
       # vm_cores: 2

--- a/roles/fio_distributed/templates/server_vm.yml.j2
+++ b/roles/fio_distributed/templates/server_vm.yml.j2
@@ -69,9 +69,17 @@ spec:
             - "mkdir -p {{ fio_path }} || true"
             - "[ -e /dev/disk/by-id/*data ] && disk=$(shopt -s nullglob; basename /dev/disk/by-id/*data) && mkfs.ext4 /dev/disk/by-id/$disk && mount /dev/disk/by-id/$disk {{ fio_path }}"
           runcmd:
+{% if workload_args.vm_proxy is defined %}
+            - export http_proxy="{{ workload_args.vm_proxy }}"
+            - export https_proxy="{{ workload_args.vm_proxy }}"
+{% endif %}
             - dnf install -y podman
             - "img=`podman create {{ workload_args.image | default('quay.io/cloud-bulldozer/fio:latest') }}`"
             - fs=`podman mount $img`
+{% if workload_args.vm_proxy is defined %}
+            - unset http_proxy
+            - unset https_proxy
+{% endif %}
             - "mkdir -p $fs/{{ fio_path }} || true"
             - "mount -o bind /{{ fio_path }} $fs/{{ fio_path }}"
             - "chroot $fs bash -c 'cd /{{ fio_path }}; fio --server'"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently, when running FIO in VMs, we install software like Podman. In restricted environments, internet access may require a proxy. This update introduces a new parameter that allows setting a proxy environment variable, ensuring compatibility with such environments

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
